### PR TITLE
Create FLC-Standalone-BasicWindowsEventsAndLogFileconfig

### DIFF
--- a/Config-Samples/Log-Shippers/Falcon-LogScale-Collector/FLC-Standalone-BasicWindowsEventsAndLogFileconfig
+++ b/Config-Samples/Log-Shippers/Falcon-LogScale-Collector/FLC-Standalone-BasicWindowsEventsAndLogFileconfig
@@ -1,0 +1,38 @@
+# This is a config yaml file for a Standalone-Windows Events 
+# collector with tailing a log file on disk.
+
+dataDirectory: C:\ProgramData\LogScale Collector
+ 
+sources:
+  windows_events:
+    type: wineventlog
+    channels:
+      - name: Application
+        excludeEventIDs: [11]
+      - name: Security
+      - name: System
+    sink: humio
+
+# This configuration file uses the custom windows event parser 
+# in from GitHub. If you use a parser in the yaml file then set the 
+# ingester parser to none.
+
+    parser: crowdstrike-lcc/microsoft-windows:windows 
+# This section identifies a log file on disk to be tailed and shipped.
+
+  sample_log:
+    type: file
+    include: C:\SAMPLELogPath\SAMPLELogFile.log
+    sink: humio
+
+# This configuration file sample sets a custom parser for the log file 
+# that you are shipping. If you use a parser in the yaml file then set 
+# the ingester parser to none.
+    parser: SAMPLECUSTOMPARSER
+
+sinks:
+  humio:
+    type: humio
+    token: YOUR_INGEST_TOKEN_HERE
+    url: https://cloud.us.humio.com
+    proxy: none


### PR DESCRIPTION
This is a sample config.yaml that will grab the windows events from the event logs and also will tail a log file on disk for shipping to LogScale. Two types of logs in one yaml.