### PR TITLE
updating FLC Batch size. Generic FLC config 

### DIFF
--- a/Config-Samples/Log-Shippers/Falcon-LogScale-Collector/FLC-SyslogOnly.yaml
+++ b/Config-Samples/Log-Shippers/Falcon-LogScale-Collector/FLC-SyslogOnly.yaml
@@ -10,16 +10,16 @@ sources:
     type: syslog
     mode: udp
     port: 1514
-    sink: next-gen-siem
+    sink: hec
  
   syslog_tcp_1514:
     type: syslog
     mode: tcp
     port: 1514
-    sink: next-gen-siem
+    sink: hec
      
 sinks:
-  next-gen-siem:
+  hec:
     type: hec
     token: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
     url: https://XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.ingest.YY-Y.crowdstrike.com

--- a/Config-Samples/Log-Shippers/Falcon-LogScale-Collector/NG-SIEM/NGS-FLC-BasicLinuxConfig.yaml
+++ b/Config-Samples/Log-Shippers/Falcon-LogScale-Collector/NG-SIEM/NGS-FLC-BasicLinuxConfig.yaml
@@ -39,7 +39,7 @@ sinks:
     ## NOTE: you MUST REMOVE the "services/collector" from the URL if it exists.  
     url: https://XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.ingest.YY-Y.crowdstrike.com
     maxEventSize: 910000
-    maxBatchSize: 5242880
+    maxBatchSize: 12000000
     workers: 4
    
    ## This sink receives data from "var_log" source above 
@@ -51,5 +51,5 @@ sinks:
     ## NOTE: you MUST REMOVE the "services/collector" from the URL if it exists.  
     url: https://XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.ingest.YY-Y.crowdstrike.com
     maxEventSize: 910000
-    maxBatchSize: 5242880
+    maxBatchSize: 12000000
     workers: 4

--- a/Config-Samples/Log-Shippers/Falcon-LogScale-Collector/NG-SIEM/NGS-FLC-BasicWindowsConfig.yaml
+++ b/Config-Samples/Log-Shippers/Falcon-LogScale-Collector/NG-SIEM/NGS-FLC-BasicWindowsConfig.yaml
@@ -41,7 +41,7 @@ sinks:
     ## NOTE: you MUST REMOVE the "services/collector" from the URL if it exists.  
     url: https://XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.ingest.YY-Y.crowdstrike.com
     maxEventSize: 910000
-    maxBatchSize: 5242880
+    maxBatchSize: 12000000
     workers: 4
   
   ## This sink receives data from "syslog_udp_1514" source above  
@@ -53,5 +53,5 @@ sinks:
     ## NOTE: you MUST REMOVE the "services/collector" from the URL if it exists.  
     url: https://XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.ingest.YY-Y.crowdstrike.com
     maxEventSize: 910000
-    maxBatchSize: 5242880
+    maxBatchSize: 12000000
     workers: 4

--- a/Config-Samples/Log-Shippers/Falcon-LogScale-Collector/NG-SIEM/NGS-FLC-MultiSourceWindowsConfig.yaml
+++ b/Config-Samples/Log-Shippers/Falcon-LogScale-Collector/NG-SIEM/NGS-FLC-MultiSourceWindowsConfig.yaml
@@ -89,8 +89,8 @@ sinks:
     proxy: none  
     ## This sets the maximum single event size to 900KB. You can change as needed.
     maxEventSize: 910000
-    ## This sets the maximum payload size (bytes) for a single batch of events. The max value is maxBatchSize: 16777216.
-    maxBatchSize: 5242880
+    ## This sets the maximum payload size (bytes) for a single batch of events. The max value is maxBatchSize: 12000000.
+    maxBatchSize: 12000000
     ## Uncomment if you would like to force a specific level of gzip compression. 9 is the highest.
     #compression: gzip
     #compressionLevel: 9
@@ -116,8 +116,8 @@ sinks:
     proxy: none  
     ## This sets the maximum single event size to 900KB. You can change as needed.
     maxEventSize: 910000
-    ## This sets the maximum payload size (bytes) for a single batch of events. The max value is maxBatchSize: 16777216.
-    maxBatchSize: 5242880
+    ## This sets the maximum payload size (bytes) for a single batch of events. The max value is maxBatchSize: 12000000.
+    maxBatchSize: 12000000
     ## Uncomment if you would like to force a specific level of gzip compression. 9 is the highest.
     #compression: gzip
     #compressionLevel: 9
@@ -141,8 +141,8 @@ sinks:
     proxy: none
     ## This sets the maximum single event size (bytes). The max value is maxEventSize: 950000.
     maxEventSize: 910000
-    ## This sets the maximum payload size (bytes) for a single batch of events. The max value is maxBatchSize: 16777216.
-    maxBatchSize: 5242880
+    ## This sets the maximum payload size (bytes) for a single batch of events. The max value is maxBatchSize: 12000000.
+    maxBatchSize: 12000000
     ## Uncomment if you would like to force a specific level of type and level compression. 9 is the highest.
     ## Default is "auto", which attempts "gzip" and its default compression but falls back to "none" if unsupported.
     #compression: gzip
@@ -171,8 +171,8 @@ sinks:
     proxy: none
     ## This sets the maximum single event size (bytes). The max value is maxEventSize: 950000.
     maxEventSize: 910000
-    ## This sets the maximum payload size (bytes) for a batch of events being uploaded together. The max value is maxBatchSize: 16777216.
-    maxBatchSize: 5242880
+    ## This sets the maximum payload size (bytes) for a batch of events being uploaded together. The max value is maxBatchSize: 12000000.
+    maxBatchSize: 12000000
     ## Uncomment if you would like to force a specific level of type and level compression. 9 is the highest.
     ## Default is "auto", which attempts "gzip" and its default compression but falls back to "none" if unsupported.
     #compression: gzip

--- a/Config-Samples/Log-Shippers/Falcon-LogScale-Collector/NG-SIEM/NGS-FLC-SyslogOnly.yaml
+++ b/Config-Samples/Log-Shippers/Falcon-LogScale-Collector/NG-SIEM/NGS-FLC-SyslogOnly.yaml
@@ -27,5 +27,5 @@ sinks:
     workers: 4
     ## This sets the maximum single event size to. You can change as needed. the maximum value is 950000.
     maxEventSize: 910000
-    ## This sets the maximum payload size for a single batch of events. The max value is maxBatchSize: 16777216.
-    maxBatchSize: 5242880
+    ## This sets the maximum payload size for a single batch of events. The max value is maxBatchSize: 12000000.
+    maxBatchSize: 12000000


### PR DESCRIPTION
Updating the FLC configs with a lower max batch size. 
renamed generic FLC syslog only config for use between logscale and ngsiem for wiki instructions. 