### PR TITLE
Updates to FLC to move maxEventSize and update maxBatchSize

### DIFF
--- a/Config-Samples/Log-Shippers/Falcon-LogScale-Collector/FLC-SyslogOnly.yaml
+++ b/Config-Samples/Log-Shippers/Falcon-LogScale-Collector/FLC-SyslogOnly.yaml
@@ -11,12 +11,22 @@ sources:
     mode: udp
     port: 1514
     sink: hec
+    ## Optional: Max allowed event size (default = 2048 bytes), messages larger than this will be truncated
+    ## Increase this value if you expect larger syslog messages. 
+    ## Be cautious when increasing this value, as it affects memory usage and network bandwidth.
+    ## The max value is 950000 bytes.
+    maxEventSize: 2048
  
   syslog_tcp_1514:
     type: syslog
     mode: tcp
     port: 1514
     sink: hec
+    ## Optional: Max allowed event size (default = 2048 bytes), messages larger than this will be truncated
+    ## Increase this value if you expect larger syslog messages. 
+    ## Be cautious when increasing this value, as it affects memory usage and network bandwidth.
+    ## The max value is 950000 bytes.
+    maxEventSize: 2048
      
 sinks:
   hec:
@@ -25,7 +35,6 @@ sinks:
     url: https://XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.ingest.YY-Y.crowdstrike.com
     proxy: none
     workers: 4
-    ## This sets the maximum single event size to. You can change as needed. the maximum value is 950000.
-    maxEventSize: 910000
-    ## This sets the maximum payload size for a single batch of events. The max value is maxBatchSize: 16777216.
-    maxBatchSize: 5242880
+    ## Optional: maxBatchsize generally handled automatically by FLC but can be manually set if needed
+    ## If set, as of Aug 2025, max payload before compression limit is 32M, minus 2M to account for meta-data (plus 2M buffer)
+    #maxBatchSize: 28000000

--- a/Config-Samples/Log-Shippers/Falcon-LogScale-Collector/NG-SIEM/NGS-FLC-BasicLinuxConfig.yaml
+++ b/Config-Samples/Log-Shippers/Falcon-LogScale-Collector/NG-SIEM/NGS-FLC-BasicLinuxConfig.yaml
@@ -16,6 +16,10 @@ sources:
     mode: udp
     port: 1514
     sink: next-gen-siem-syslog-udp
+    ## Optional: Max allowed event size (default = 2048 bytes), messages larger than this will be truncated
+    ## Increase this value if you expect larger syslog messages. 
+    ## Be cautious when increasing this value, as it affects memory usage and network bandwidth.
+    ## The max value is 950000 bytes.
     maxEventSize: 2048
 
   ## Collect local files.
@@ -38,8 +42,9 @@ sinks:
     ## Replace with the "Ingest URL" on the FLC download page. It must include the "https://" at the beginning.
     ## NOTE: you MUST REMOVE the "services/collector" from the URL if it exists.  
     url: https://XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.ingest.YY-Y.crowdstrike.com
-    maxEventSize: 910000
-    maxBatchSize: 12000000
+    ## Optional: maxBatchsize generally handled automatically by FLC but can be manually set if needed
+    ## If set, as of Aug 2025, max payload before compression limit is 32M, minus 2M to account for meta-data (plus 2M buffer)
+    #maxBatchSize: 28000000
     workers: 4
    
    ## This sink receives data from "var_log" source above 
@@ -50,6 +55,7 @@ sinks:
     ## Replace with the "Ingest URL" on the FLC download page. It must include the "https://" at the beginning.
     ## NOTE: you MUST REMOVE the "services/collector" from the URL if it exists.  
     url: https://XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.ingest.YY-Y.crowdstrike.com
-    maxEventSize: 910000
-    maxBatchSize: 12000000
+    ## Optional: maxBatchsize generally handled automatically by FLC but can be manually set if needed
+    ## If set, as of Aug 2025, max payload before compression limit is 32M, minus 2M to account for meta-data (plus 2M buffer)
+    #maxBatchSize: 28000000
     workers: 4

--- a/Config-Samples/Log-Shippers/Falcon-LogScale-Collector/NG-SIEM/NGS-FLC-BasicWindowsConfig.yaml
+++ b/Config-Samples/Log-Shippers/Falcon-LogScale-Collector/NG-SIEM/NGS-FLC-BasicWindowsConfig.yaml
@@ -26,6 +26,10 @@ sources:
     type: syslog
     mode: udp
     port: 1514
+    ## Optional: Max allowed event size (default = 2048 bytes), messages larger than this will be truncated
+    ## Increase this value if you expect larger syslog messages. 
+    ## Be cautious when increasing this value, as it affects memory usage and network bandwidth.
+    ## The max value is 950000 bytes.
     maxEventSize: 2048
     sink: next-gen-siem-syslog-udp
 
@@ -40,8 +44,9 @@ sinks:
     ## Replace with the "Ingest URL" on the FLC download page. It must include the "https://" at the beginning.
     ## NOTE: you MUST REMOVE the "services/collector" from the URL if it exists.  
     url: https://XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.ingest.YY-Y.crowdstrike.com
-    maxEventSize: 910000
-    maxBatchSize: 12000000
+    ## Optional: maxBatchsize generally handled automatically by FLC but can be manually set if needed
+    ## If set, as of Aug 2025, max payload before compression limit is 32M, minus 2M to account for meta-data (plus 2M buffer)
+    #maxBatchSize: 28000000
     workers: 4
   
   ## This sink receives data from "syslog_udp_1514" source above  
@@ -52,6 +57,7 @@ sinks:
     ## Replace with the "Ingest URL" on the FLC download page. It must include the "https://" at the beginning.
     ## NOTE: you MUST REMOVE the "services/collector" from the URL if it exists.  
     url: https://XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.ingest.YY-Y.crowdstrike.com
-    maxEventSize: 910000
-    maxBatchSize: 12000000
+    ## Optional: maxBatchsize generally handled automatically by FLC but can be manually set if needed
+    ## If set, as of Aug 2025, max payload before compression limit is 32M, minus 2M to account for meta-data (plus 2M buffer)
+    #maxBatchSize: 28000000
     workers: 4

--- a/Config-Samples/Log-Shippers/Falcon-LogScale-Collector/NG-SIEM/NGS-FLC-MultiSourceWindowsConfig.yaml
+++ b/Config-Samples/Log-Shippers/Falcon-LogScale-Collector/NG-SIEM/NGS-FLC-MultiSourceWindowsConfig.yaml
@@ -72,7 +72,7 @@ sources:
     ## Increase this value if you expect larger syslog messages. 
     ## Be cautious when increasing this value, as it affects memory usage and network bandwidth.
     ## The max value is 950000 bytes.
-    maxEventSize: 900000 
+    maxEventSize: 2048
      
 ## Each sink will have a unique token and url that correspond to Data Connector you wish to send data to.     
 sinks:
@@ -87,10 +87,9 @@ sinks:
     url: https://XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.ingest.YY-Y.crowdstrike.com
     ## Keep this option as "none" unless you actually need a proxy.
     proxy: none  
-    ## This sets the maximum single event size to 900KB. You can change as needed.
-    maxEventSize: 910000
-    ## This sets the maximum payload size (bytes) for a single batch of events. The max value is maxBatchSize: 12000000.
-    maxBatchSize: 12000000
+    ## Optional: maxBatchsize generally handled automatically by FLC but can be manually set if needed
+    ## If set, as of Aug 2025, max payload before compression limit is 32M, minus 2M to account for meta-data (plus 2M buffer)
+    #maxBatchSize: 28000000
     ## Uncomment if you would like to force a specific level of gzip compression. 9 is the highest.
     #compression: gzip
     #compressionLevel: 9
@@ -114,10 +113,9 @@ sinks:
     url: https://XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.ingest.YY-Y.crowdstrike.com
     ## Keep this option as "none" unless you actually need a proxy.
     proxy: none  
-    ## This sets the maximum single event size to 900KB. You can change as needed.
-    maxEventSize: 910000
-    ## This sets the maximum payload size (bytes) for a single batch of events. The max value is maxBatchSize: 12000000.
-    maxBatchSize: 12000000
+    ## Optional: maxBatchsize generally handled automatically by FLC but can be manually set if needed
+    ## If set, as of Aug 2025, max payload before compression limit is 32M, minus 2M to account for meta-data (plus 2M buffer)
+    #maxBatchSize: 28000000
     ## Uncomment if you would like to force a specific level of gzip compression. 9 is the highest.
     #compression: gzip
     #compressionLevel: 9
@@ -139,10 +137,9 @@ sinks:
     url: https://XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.ingest.YY-Y.crowdstrike.com
     ## Keep this option as "none" unless you actually need a proxy.
     proxy: none
-    ## This sets the maximum single event size (bytes). The max value is maxEventSize: 950000.
-    maxEventSize: 910000
-    ## This sets the maximum payload size (bytes) for a single batch of events. The max value is maxBatchSize: 12000000.
-    maxBatchSize: 12000000
+    ## Optional: maxBatchsize generally handled automatically by FLC but can be manually set if needed
+    ## If set, as of Aug 2025, max payload before compression limit is 32M, minus 2M to account for meta-data (plus 2M buffer)
+    #maxBatchSize: 28000000
     ## Uncomment if you would like to force a specific level of type and level compression. 9 is the highest.
     ## Default is "auto", which attempts "gzip" and its default compression but falls back to "none" if unsupported.
     #compression: gzip
@@ -169,10 +166,9 @@ sinks:
     url: https://XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.ingest.YY-Y.crowdstrike.com
     ## Keep this option as "none" unless you actually need a proxy.
     proxy: none
-    ## This sets the maximum single event size (bytes). The max value is maxEventSize: 950000.
-    maxEventSize: 910000
-    ## This sets the maximum payload size (bytes) for a batch of events being uploaded together. The max value is maxBatchSize: 12000000.
-    maxBatchSize: 12000000
+    ## Optional: maxBatchsize generally handled automatically by FLC but can be manually set if needed
+    ## If set, as of Aug 2025, max payload before compression limit is 32M, minus 2M to account for meta-data (plus 2M buffer)
+    #maxBatchSize: 28000000
     ## Uncomment if you would like to force a specific level of type and level compression. 9 is the highest.
     ## Default is "auto", which attempts "gzip" and its default compression but falls back to "none" if unsupported.
     #compression: gzip

--- a/Config-Samples/Log-Shippers/Falcon-LogScale-Collector/NG-SIEM/NGS-FLC-SyslogOnly.yaml
+++ b/Config-Samples/Log-Shippers/Falcon-LogScale-Collector/NG-SIEM/NGS-FLC-SyslogOnly.yaml
@@ -11,12 +11,22 @@ sources:
     mode: udp
     port: 1514
     sink: next-gen-siem
+    ## Optional: Max allowed event size (default = 2048 bytes), messages larger than this will be truncated
+    ## Increase this value if you expect larger syslog messages. 
+    ## Be cautious when increasing this value, as it affects memory usage and network bandwidth.
+    ## The max value is 950000 bytes.
+    maxEventSize: 2048
  
   syslog_tcp_1514:
     type: syslog
     mode: tcp
     port: 1514
     sink: next-gen-siem
+    ## Optional: Max allowed event size (default = 2048 bytes), messages larger than this will be truncated
+    ## Increase this value if you expect larger syslog messages. 
+    ## Be cautious when increasing this value, as it affects memory usage and network bandwidth.
+    ## The max value is 950000 bytes.
+    maxEventSize: 2048
      
 sinks:
   next-gen-siem:
@@ -25,7 +35,6 @@ sinks:
     url: https://XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.ingest.YY-Y.crowdstrike.com
     proxy: none
     workers: 4
-    ## This sets the maximum single event size to. You can change as needed. the maximum value is 950000.
-    maxEventSize: 910000
-    ## This sets the maximum payload size for a single batch of events. The max value is maxBatchSize: 12000000.
-    maxBatchSize: 12000000
+    ## Optional: maxBatchsize generally handled automatically by FLC but can be manually set if needed
+    ## If set, as of Aug 2025, max payload before compression limit is 32M, minus 2M to account for meta-data (plus 2M buffer)
+    #maxBatchSize: 28000000


### PR DESCRIPTION
To avoid truncation, maxEventSize needs to be in sources section

NG-SIEM recently updated maxBatchSize allowed up to 32M (minus 2M for meta-data overhead, and I added extra 2M buffer if option used) - mainly just makes visible warnings / errors go away as FLC will re-send if needed (if uncompressed payload > 32M)