### PR TITLE
queryjobs Pagination examples

### DIFF
--- a/Misc/queryjobs-pagination/README.md
+++ b/Misc/queryjobs-pagination/README.md
@@ -1,7 +1,7 @@
 ---
 title: QueryJobs API Pagination
 created: 2026-04-29
-updated: 2026-05-06
+updated: 2026-05-11
 tags: [logscale, ngsiem, api, python, pagination]
 ---
 
@@ -63,17 +63,42 @@ python queryjob_paginator.py -h
 # One-time setup (same venv)
 pip install crowdstrike-falconpy
 
-# Environment variables (required)
+# Environment variables (required — or use -k/-s flags)
 export FALCON_CLIENT_ID="your-client-id"
 export FALCON_CLIENT_SECRET="your-client-secret"
-export FALCON_BASE_URL="https://api.us-2.crowdstrike.com"  # optional, defaults to US-1
-export CA_BUNDLE="/path/to/ca-bundle.pem"                  # optional, for corporate proxy
+
+# Optional environment variables
+export FALCON_BASE_URL="https://api.us-2.crowdstrike.com"  # defaults to US-1
+export FALCON_MEMBER_CID="child-cid"                       # for MSSP / flight control
+export CA_BUNDLE="/path/to/ca-bundle.pem"                  # for corporate proxy
 
 # Run
-python ngsiem_queryjob_paginator.py
+python ngsiem_queryjob_paginator.py -q '#event_simpleName=ProcessRollup2'
+
+# With options
+python ngsiem_queryjob_paginator.py -q '...' -r search-all --start 1h --end now
+python ngsiem_queryjob_paginator.py -q '...' -b https://api.us-2.crowdstrike.com
+python ngsiem_queryjob_paginator.py -q '...' -m CHILD_CID  # MSSP
+
+# Help
+python ngsiem_queryjob_paginator.py -h
 ```
 
-Configuration is in the script's `Configuration` section (REPO, QUERY_STRING, START, END, PAGE_SIZE, MAX_EVENTS).
+**Parameters:**
+
+| Flag | Env Var | Description | Default |
+|------|---------|-------------|---------|
+| `-k, --client-id` | `FALCON_CLIENT_ID` | OAuth2 client ID (required) | — |
+| `-s, --client-secret` | `FALCON_CLIENT_SECRET` | OAuth2 client secret (required) | — |
+| `-q, --query` | — | CQL query string (required) | — |
+| `-r, --repo` | — | NG-SIEM repository | `search-all` |
+| `--start` | — | Start time | `15m` |
+| `--end` | — | End time | `now` |
+| `-o, --output` | — | Output JSON file | `ngsiem_queryjob_results.json` |
+| `--max-events` | — | Max events to retrieve | unlimited |
+| `--page-size` | — | Events per cursor page | `200` |
+| `-b, --base-url` | `FALCON_BASE_URL` | CrowdStrike API base URL | US-1 |
+| `-m, --member-cid` | `FALCON_MEMBER_CID` | Child CID (MSSP / flight control) | — |
 
 Required API scope: **NGSIEM: Read + Write**
 
@@ -143,7 +168,8 @@ The `around` parameter creates a new QueryJob anchored on a specific event:
       - numberOfEventsAfter = 0
    c. Poll new job until done, collect events
    d. Deduplicate by @id (boundary event may repeat)
-   e. Repeat from (a) until no new events returned
+   e. Delete consumed QueryJob
+   f. Repeat from (a) until no new events returned
 ```
 
 ## API Endpoints
@@ -169,17 +195,22 @@ NG-SIEM repositories: `search-all`, `investigate_view`, `third-party`, `falcon_f
 ```python
 from falconpy import NGSIEM
 
-ngsiem = NGSIEM(client_id="...", client_secret="...", ssl_verify=False)
+with NGSIEM(client_id="...", client_secret="...") as ngsiem:
+    if ngsiem.token_fail_reason:
+        raise SystemExit(f"Auth failed: {ngsiem.token_fail_reason}")
 
-# Create
-resp = ngsiem.start_search(repository="search-all", query_string="...", start="1h", end="now")
-job_id = resp["resources"]["id"]
+    # Create
+    resp = ngsiem.start_search(repository="search-all", query_string="...", start="1h", end="now")
+    job_id = resp["resources"]["id"]
 
-# Poll (response is in resp["body"], not resp["resources"])
-resp = ngsiem.get_search_status(repository="search-all", id=job_id)
-data = resp.get("resources") or resp.get("body", {})
-events = data["events"]
-done = data["done"]
+    # Poll (response is in resp["body"], not resp["resources"])
+    resp = ngsiem.get_search_status(repository="search-all", id=job_id)
+    data = resp.get("resources") or resp.get("body", {})
+    events = data["events"]
+    done = data["done"]
+
+    # Cleanup
+    ngsiem.stop_search(repository="search-all", id=job_id)
 ```
 
 ## Important Notes
@@ -192,11 +223,10 @@ done = data["done"]
 
 ## SSL / Corporate Proxy
 
-For Zscaler environments, set `CA_BUNDLE` env var pointing to the CA certificate bundle. The FalconPy script reads this and passes it as `ssl_verify`. If the bundle doesn't cover the API endpoint, use `ssl_verify=False`.
+For Zscaler environments, set `CA_BUNDLE` env var pointing to the CA certificate bundle. The FalconPy script reads this and passes it as `ssl_verify`. If unset, SSL verification is enabled by default.
 
 ## References
 
 - [LogScale API — Query Jobs](https://library.humio.com/logscale-api/api-search-query.html)
-- [LogScale API — Pagination](https://library.humio.com/logscale-api/api-search-pagination.html)
-- [LogScale API — Query Result Pagination API](https://library.humio.com/logscale-api/api-search-pagination-api.html)
+- [LogScale API — Pagination](https://library.humio.com/logscale-api/api-search-pagination-api.html)
 - [NG-SIEM Search APIs (CrowdStrike docs)](https://falcon.crowdstrike.com/documentation/page/bda96fc1)

--- a/Misc/queryjobs-pagination/README.md
+++ b/Misc/queryjobs-pagination/README.md
@@ -1,0 +1,202 @@
+---
+title: QueryJobs API Pagination
+created: 2026-04-29
+updated: 2026-05-06
+tags: [logscale, ngsiem, api, python, pagination]
+---
+
+# QueryJobs API Pagination
+
+## Overview
+
+The LogScale/NG-SIEM QueryJobs API returns a **200-event result buffer** for filter (non-aggregate) queries. To retrieve all matching events, you must use **cursor-based pagination** via the `around` parameter.
+
+Scripts: 
+`queryjob_paginator.py` (direct LogScale) 
+`ngsiem_queryjob_paginator.py` (FalconPy/NG-SIEM)
+
+## Script Usage
+
+### LogScale (direct API)
+
+```bash
+# One-time setup
+cd _LogScale/script
+python3 -m venv .venv
+source .venv/bin/activate
+pip install requests
+
+# Environment variables (required)
+export LOGSCALE_TOKEN="your-api-token"
+export LOGSCALE_BASE_URL="https://your-logscale-instance.com/"
+export LOGSCALE_REPO="your-repo-name"
+
+# Run (wrap query in single quotes to preserve double quotes in CQL)
+python queryjob_paginator.py -q '#event_simpleName=ProcessRollup2'
+
+# With double quotes in the query
+python queryjob_paginator.py -q '#event_simpleName=ProcessRollup2 | groupBy([aid], function=[count(as="Event Count")]) | sort("Event Count", limit=max)'
+
+# Optional flags
+python queryjob_paginator.py -q '...' -s 1h -e now -o results.json --max-events 5000 --page-size 200
+
+# Help
+python queryjob_paginator.py -h
+```
+
+**Parameters:**
+
+| Flag | Description | Default |
+|------|--------------|----------|
+| `-q, --query` | CQL query string (required) | — |
+| `-s, --start` | Start time | `15m` |
+| `-e, --end` | End time | `now` |
+| `-o, --output` | Output JSON file | `queryjob_results.json` |
+| `--max-events` | Max events to retrieve | unlimited |
+| `--page-size` | Events per cursor page | `200` |
+
+
+
+### NG-SIEM (FalconPy)
+
+```bash
+# One-time setup (same venv)
+pip install crowdstrike-falconpy
+
+# Environment variables (required)
+export FALCON_CLIENT_ID="your-client-id"
+export FALCON_CLIENT_SECRET="your-client-secret"
+export FALCON_BASE_URL="https://api.us-2.crowdstrike.com"  # optional, defaults to US-1
+export CA_BUNDLE="/path/to/ca-bundle.pem"                  # optional, for corporate proxy
+
+# Run
+python ngsiem_queryjob_paginator.py
+```
+
+Configuration is in the script's `Configuration` section (REPO, QUERY_STRING, START, END, PAGE_SIZE, MAX_EVENTS).
+
+Required API scope: **NGSIEM: Read + Write**
+
+## How QueryJobs Work
+
+1. **Create** a QueryJob → returns a job ID
+2. **Poll** (GET) → returns up to 200 events + metadata
+3. **Check metadata** → `hasMoreEvents="true"` means more events exist beyond the buffer
+4. **Paginate** using the `around` parameter to walk through remaining events
+
+## Key Metadata Fields
+
+| Field | Meaning |
+|-------|---------|
+| `metaData.resultBufferSize` | Events in the buffer (default 200 for filter queries) |
+| `metaData.eventCount` | Number of events in current result set |
+| `metaData.processedEvents` | Total matching events found by the query |
+| `metaData.extraData.hasMoreEvents` | `"true"` (string!) if results exceed buffer |
+| `metaData.isAggregate` | Aggregate queries return all results in one shot |
+| `metaData.pollAfter` | Milliseconds to wait before next poll |
+
+## Pagination Mechanisms
+
+### 1. Offset/Limit (within the buffer only)
+
+Query parameters on the GET poll request:
+- `?paginationLimit=50&paginationOffset=0` — page within the 200-event buffer
+- Only useful for paging within what's already buffered, **not** for getting more events
+
+### 2. Cursor-Based (`around` parameter) — for results beyond the buffer
+
+The `around` parameter creates a new QueryJob anchored on a specific event:
+
+```json
+{
+  "queryString": "#event_simpleName=ProcessRollup2",
+  "start": "15m",
+  "end": "now",
+  "around": {
+    "eventId": "@id of anchor event",
+    "timestamp": 1777469793821,
+    "numberOfEventsBefore": 200,
+    "numberOfEventsAfter": 0
+  }
+}
+```
+
+**Critical detail:** LogScale returns **newest events first**. The last event in the buffer is the **oldest**. To get more events, anchor on the oldest event and request `numberOfEventsBefore` (older events).
+
+### 3. What Does NOT Work
+
+- **Automatic cursor advancement** — the server does NOT track which segments you've consumed. Repeated polls return the same 200 events.
+- **`dataspaces` endpoint** — legacy alias; use `/api/v1/repositories/` instead.
+- **Offset/limit beyond the buffer** — `paginationOffset` only pages within `resultBufferSize`, not beyond it.
+
+## Pagination Algorithm
+
+```
+1. Create QueryJob, poll until done=true
+2. Collect initial 200 events
+3. If hasMoreEvents="true":
+   a. Take the LAST event (oldest, since results are newest-first)
+   b. Create NEW QueryJob with `around`:
+      - eventId = last event's @id
+      - timestamp = last event's @timestamp
+      - numberOfEventsBefore = 200
+      - numberOfEventsAfter = 0
+   c. Poll new job until done, collect events
+   d. Deduplicate by @id (boundary event may repeat)
+   e. Repeat from (a) until no new events returned
+```
+
+## API Endpoints
+
+### Direct LogScale
+```
+POST /api/v1/repositories/{repo}/queryjobs     — Create
+GET  /api/v1/repositories/{repo}/queryjobs/{id} — Poll
+DELETE /api/v1/repositories/{repo}/queryjobs/{id} — Cancel
+```
+
+### NG-SIEM (via CrowdStrike API gateway)
+```
+POST /humio/api/v1/repositories/{repo}/queryjobs     — Create
+GET  /humio/api/v1/repositories/{repo}/queryjobs/{id} — Poll
+DELETE /humio/api/v1/repositories/{repo}/queryjobs/{id} — Cancel
+```
+
+NG-SIEM repositories: `search-all`, `investigate_view`, `third-party`, `falcon_for_it_view`, `forensics_view`
+
+## FalconPy Usage
+
+```python
+from falconpy import NGSIEM
+
+ngsiem = NGSIEM(client_id="...", client_secret="...", ssl_verify=False)
+
+# Create
+resp = ngsiem.start_search(repository="search-all", query_string="...", start="1h", end="now")
+job_id = resp["resources"]["id"]
+
+# Poll (response is in resp["body"], not resp["resources"])
+resp = ngsiem.get_search_status(repository="search-all", id=job_id)
+data = resp.get("resources") or resp.get("body", {})
+events = data["events"]
+done = data["done"]
+```
+
+## Important Notes
+
+- `hasMoreEvents` is a **string** (`"true"` / `"false"`), not a boolean
+- `done=true` means the query finished, NOT that all results are delivered
+- QueryJobs auto-delete after **90 seconds** of no polling
+- Aggregate queries (`groupBy`, `count`, etc.) return all results in one response — no pagination needed
+- Rate limit: 6000 concurrent query jobs per CID
+
+## SSL / Corporate Proxy
+
+For Zscaler environments, set `CA_BUNDLE` env var pointing to the CA certificate bundle. The FalconPy script reads this and passes it as `ssl_verify`. If the bundle doesn't cover the API endpoint, use `ssl_verify=False`.
+
+## References
+
+- [LogScale API — Query Jobs](https://library.humio.com/logscale-api/api-search-query.html)
+- [LogScale API — Pagination](https://library.humio.com/logscale-api/api-search-pagination.html)
+- [LogScale API — Query Result Pagination API](https://library.humio.com/logscale-api/api-search-pagination-api.html)
+- [NG-SIEM Search APIs (CrowdStrike docs)](https://falcon.crowdstrike.com/documentation/page/bda96fc1)

--- a/Misc/queryjobs-pagination/ngsiem_queryjob_paginator.py
+++ b/Misc/queryjobs-pagination/ngsiem_queryjob_paginator.py
@@ -13,13 +13,19 @@ The pagination mechanism is identical to direct LogScale QueryJobs:
 Usage:
     export FALCON_CLIENT_ID="your-client-id"
     export FALCON_CLIENT_SECRET="your-client-secret"
-    **OPTIONAL: export FALCON_BASE_URL="" # e.g. "https://api.us-2.crowdstrike.com" — leave empty for US-1
-    python ngsiem_queryjob_paginator.py
+    python ngsiem_queryjob_paginator.py -q '#event_simpleName=ProcessRollup2'
+
+    # Optional flags:
+    python ngsiem_queryjob_paginator.py -q '...' -r search-all --start 1h --end now
+    python ngsiem_queryjob_paginator.py -q '...' -b https://api.us-2.crowdstrike.com
+    python ngsiem_queryjob_paginator.py -q '...' -m CHILD_CID  # MSSP / flight control
 
 Requirements:
     pip install crowdstrike-falconpy
 """
+from __future__ import annotations
 
+import argparse
 import json
 import os
 import sys
@@ -27,43 +33,72 @@ import time
 
 from falconpy import NGSIEM
 
-# ── Configuration ──────────────────────────────────────────────────────
-REPO = "search-all"  # search-all | investigate_view | third-party | falcon_for_it_view | forensics_view
-QUERY_STRING = "#event_simpleName=ProcessRollup2 | tail(500)"
+# ── Defaults ──────────────────────────────────────────────────────────
 START = "15m"
 END = "now"
-BASE_URL = os.environ.get("FALCON_BASE_URL", "")
-
-PAGE_SIZE = 500
+PAGE_SIZE = 200
 MAX_EVENTS = 0      # 0 = unlimited
 OUTPUT_FILE = "ngsiem_queryjob_results.json"
-
-# SSL: set to CA bundle path for corporate proxy, or False to skip verification
-SSL_VERIFY = os.environ.get("CA_BUNDLE") or False
+DEFAULT_REPO = "search-all"
 # ──────────────────────────────────────────────────────────────────────
 
-CLIENT_ID = os.environ.get("FALCON_CLIENT_ID")
-CLIENT_SECRET = os.environ.get("FALCON_CLIENT_SECRET")
-if not CLIENT_ID or not CLIENT_SECRET:
-    sys.exit("Error: set FALCON_CLIENT_ID and FALCON_CLIENT_SECRET environment variables")
 
-ngsiem_kwargs = {
-    "client_id": CLIENT_ID,
-    "client_secret": CLIENT_SECRET,
-    "ssl_verify": SSL_VERIFY,
-}
-if BASE_URL:
-    ngsiem_kwargs["base_url"] = BASE_URL
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="NG-SIEM QueryJob paginator with cursor-based pagination (FalconPy).",
+        epilog="""Authentication (flags take precedence over environment variables):
+  -k / FALCON_CLIENT_ID       OAuth2 client ID
+  -s / FALCON_CLIENT_SECRET   OAuth2 client secret
+  -b / FALCON_BASE_URL        CrowdStrike API base URL (default: US-1)
+  -m / FALCON_MEMBER_CID      Child CID for MSSP / flight control
 
-ngsiem = NGSIEM(**ngsiem_kwargs)
+NG-SIEM repositories: search-all, investigate_view, third-party,
+                      falcon_for_it_view, forensics_view""",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "-k", "--client-id",
+        default=os.environ.get("FALCON_CLIENT_ID", ""),
+        help="OAuth2 client ID (or set FALCON_CLIENT_ID)",
+    )
+    parser.add_argument(
+        "-s", "--client-secret",
+        default=os.environ.get("FALCON_CLIENT_SECRET", ""),
+        help="OAuth2 client secret (or set FALCON_CLIENT_SECRET)",
+    )
+    parser.add_argument(
+        "-b", "--base-url",
+        default=os.environ.get("FALCON_BASE_URL", ""),
+        help="CrowdStrike API base URL (default: US-1)",
+    )
+    parser.add_argument(
+        "-m", "--member-cid",
+        default=os.environ.get("FALCON_MEMBER_CID", ""),
+        help="Child CID for MSSP / flight control",
+    )
+    parser.add_argument(
+        "-q", "--query",
+        required=True,
+        help="CQL query string. Wrap in single quotes to preserve double quotes.",
+    )
+    parser.add_argument("-r", "--repo", default=DEFAULT_REPO, help=f"Repository (default: {DEFAULT_REPO})")
+    parser.add_argument("--start", default=START, help=f"Start time (default: {START})")
+    parser.add_argument("--end", default=END, help=f"End time (default: {END})")
+    parser.add_argument("-o", "--output", default=OUTPUT_FILE, help=f"Output file (default: {OUTPUT_FILE})")
+    parser.add_argument("--max-events", type=int, default=MAX_EVENTS, help="Max events to retrieve (default: unlimited)")
+    parser.add_argument("--page-size", type=int, default=PAGE_SIZE, help=f"Events per page (default: {PAGE_SIZE})")
+    return parser.parse_args()
 
 
-def start_search(around: dict | None = None) -> str:
+def start_search(ngsiem: NGSIEM, repo: str, query_string: str,
+                 start: str, end: str, around: dict | None = None) -> str:
+    """Create a QueryJob and return its ID."""
     kwargs = {
-        "repository": REPO,
-        "query_string": QUERY_STRING,
-        "start": START,
-        "end": END,
+        "repository": repo,
+        "query_string": query_string,
+        "start": start,
+        "end": end,
         "is_live": False,
     }
     if around:
@@ -75,9 +110,15 @@ def start_search(around: dict | None = None) -> str:
     return resp["resources"]["id"]
 
 
-def poll_until_done(job_id: str) -> dict:
+def delete_search(ngsiem: NGSIEM, repo: str, job_id: str) -> None:
+    """Delete a QueryJob to free server resources."""
+    ngsiem.stop_search(repository=repo, id=job_id)
+
+
+def poll_until_done(ngsiem: NGSIEM, repo: str, job_id: str) -> dict:
+    """Poll a QueryJob until done and return the result payload."""
     while True:
-        resp = ngsiem.get_search_status(repository=REPO, id=job_id)
+        resp = ngsiem.get_search_status(repository=repo, id=job_id)
         if resp["status_code"] == 404:
             return {"done": True, "events": [], "metaData": {}}
         if resp["status_code"] != 200:
@@ -92,72 +133,106 @@ def poll_until_done(job_id: str) -> dict:
 
 
 def main():
-    print(f"Query:  {QUERY_STRING}")
-    print(f"Repo:   {REPO}")
-    print(f"Range:  {START} → {END}")
-    print()
+    args = parse_args()
 
-    # Step 1: Initial query
-    job_id = start_search()
-    print(f"QueryJob created: {job_id}")
+    if not args.client_id or not args.client_secret:
+        sys.exit("Error: set FALCON_CLIENT_ID and FALCON_CLIENT_SECRET "
+                 "(environment variables or -k/-s flags)")
 
-    data = poll_until_done(job_id)
-    meta = data.get("metaData", {})
-    has_more = meta.get("extraData", {}).get("hasMoreEvents", "false")
-    processed = meta.get("processedEvents", "?")
+    ssl_verify = os.environ.get("CA_BUNDLE") or True
 
-    all_events: list[dict] = list(data.get("events", []))
-    seen_ids: set[str] = {e.get("@id", "") for e in all_events}
+    ngsiem_kwargs = {
+        "client_id": args.client_id,
+        "client_secret": args.client_secret,
+        "ssl_verify": ssl_verify,
+    }
+    if args.base_url:
+        ngsiem_kwargs["base_url"] = args.base_url
+    if args.member_cid:
+        ngsiem_kwargs["member_cid"] = args.member_cid
 
-    print(f"  Initial buffer: {len(all_events)} events  "
-          f"(processedEvents={processed}  hasMoreEvents={has_more})")
+    with NGSIEM(**ngsiem_kwargs) as ngsiem:
+        if ngsiem.token_fail_reason:
+            sys.exit(f"Authentication failed: {ngsiem.token_fail_reason}")
 
-    # Step 2: Cursor pagination using `around`
-    # LogScale returns newest events first; the last event in the buffer is
-    # the oldest. Anchor on it and request numberOfEventsBefore to walk
-    # backward through time.
-    page = 0
-    while has_more == "true" and all_events:
-        if MAX_EVENTS and len(all_events) >= MAX_EVENTS:
-            all_events = all_events[:MAX_EVENTS]
-            break
+        repo = args.repo
+        query_string = args.query
+        start = args.start
+        end = args.end
+        output_file = args.output
+        max_events = args.max_events
+        page_size = args.page_size
 
-        oldest = all_events[-1]
-        anchor_id = oldest.get("@id", "")
-        anchor_ts = oldest.get("@timestamp")
-        if not anchor_id or anchor_ts is None:
-            break
+        print(f"Query:  {query_string}")
+        print(f"Repo:   {repo}")
+        print(f"Range:  {start} → {end}")
+        print()
 
-        page += 1
-        cursor_job_id = start_search(around={
-            "eventId": anchor_id,
-            "timestamp": int(anchor_ts),
-            "numberOfEventsBefore": PAGE_SIZE,
-            "numberOfEventsAfter": 0,
-        })
+        # Step 1: Initial query
+        job_id = start_search(ngsiem, repo, query_string, start, end)
+        print(f"QueryJob created: {job_id}")
 
-        cursor_data = poll_until_done(cursor_job_id)
-        events = cursor_data.get("events", [])
-        new_events = [e for e in events if e.get("@id", "") not in seen_ids]
+        data = poll_until_done(ngsiem, repo, job_id)
+        delete_search(ngsiem, repo, job_id)
 
-        if not new_events:
-            break
+        meta = data.get("metaData", {})
+        has_more = meta.get("extraData", {}).get("hasMoreEvents", "false")
+        processed = meta.get("processedEvents", "?")
 
-        for e in new_events:
-            seen_ids.add(e.get("@id", ""))
-        all_events.extend(new_events)
+        all_events: list[dict] = list(data.get("events", []))
+        seen_ids: set[str] = {e.get("@id", "") for e in all_events}
 
-        print(f"  page {page}: +{len(new_events)} events  (total: {len(all_events)})")
-        time.sleep(0.5)
+        print(f"  Initial buffer: {len(all_events)} events  "
+              f"(processedEvents={processed}  hasMoreEvents={has_more})")
 
-    if MAX_EVENTS and len(all_events) > MAX_EVENTS:
-        all_events = all_events[:MAX_EVENTS]
+        # Step 2: Cursor pagination using `around`
+        # LogScale returns newest events first; the last event in the buffer is
+        # the oldest. Anchor on it and request numberOfEventsBefore to walk
+        # backward through time.
+        page = 0
+        while has_more == "true" and all_events:
+            if max_events and len(all_events) >= max_events:
+                all_events = all_events[:max_events]
+                break
+
+            oldest = all_events[-1]
+            anchor_id = oldest.get("@id", "")
+            anchor_ts = oldest.get("@timestamp")
+            if not anchor_id or anchor_ts is None:
+                break
+
+            page += 1
+            cursor_job_id = start_search(ngsiem, repo, query_string, start, end, around={
+                "eventId": anchor_id,
+                "timestamp": int(anchor_ts),
+                "numberOfEventsBefore": page_size,
+                "numberOfEventsAfter": 0,
+            })
+
+            cursor_data = poll_until_done(ngsiem, repo, cursor_job_id)
+            delete_search(ngsiem, repo, cursor_job_id)
+
+            events = cursor_data.get("events", [])
+            new_events = [e for e in events if e.get("@id", "") not in seen_ids]
+
+            if not new_events:
+                break
+
+            for e in new_events:
+                seen_ids.add(e.get("@id", ""))
+            all_events.extend(new_events)
+
+            print(f"  page {page}: +{len(new_events)} events  (total: {len(all_events)})")
+            time.sleep(0.5)
+
+        if max_events and len(all_events) > max_events:
+            all_events = all_events[:max_events]
 
     print(f"\nDone. {len(all_events)} total events.")
 
-    with open(OUTPUT_FILE, "w") as f:
+    with open(output_file, "w") as f:
         json.dump(all_events, f, indent=2)
-    print(f"Results written to {OUTPUT_FILE}")
+    print(f"Results written to {output_file}")
 
 
 if __name__ == "__main__":

--- a/Misc/queryjobs-pagination/ngsiem_queryjob_paginator.py
+++ b/Misc/queryjobs-pagination/ngsiem_queryjob_paginator.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""
+NG-SIEM QueryJob paginator (FalconPy) — retrieves all results from a
+QueryJob using cursor-based pagination via the `around` parameter.
+
+Uses the FalconPy NGSIEM service class with OAuth2 authentication.
+The pagination mechanism is identical to direct LogScale QueryJobs:
+  1. Create a QueryJob and poll until done
+  2. Collect the initial 200-event buffer
+  3. If hasMoreEvents="true", use cursor-based `around` pagination to
+     walk backward through time and collect remaining events
+
+Usage:
+    export FALCON_CLIENT_ID="your-client-id"
+    export FALCON_CLIENT_SECRET="your-client-secret"
+    **OPTIONAL: export FALCON_BASE_URL="" # e.g. "https://api.us-2.crowdstrike.com" — leave empty for US-1
+    python ngsiem_queryjob_paginator.py
+
+Requirements:
+    pip install crowdstrike-falconpy
+"""
+
+import json
+import os
+import sys
+import time
+
+from falconpy import NGSIEM
+
+# ── Configuration ──────────────────────────────────────────────────────
+REPO = "search-all"  # search-all | investigate_view | third-party | falcon_for_it_view | forensics_view
+QUERY_STRING = "#event_simpleName=ProcessRollup2 | tail(500)"
+START = "15m"
+END = "now"
+BASE_URL = os.environ.get("FALCON_BASE_URL", "")
+
+PAGE_SIZE = 500
+MAX_EVENTS = 0      # 0 = unlimited
+OUTPUT_FILE = "ngsiem_queryjob_results.json"
+
+# SSL: set to CA bundle path for corporate proxy, or False to skip verification
+SSL_VERIFY = os.environ.get("CA_BUNDLE") or False
+# ──────────────────────────────────────────────────────────────────────
+
+CLIENT_ID = os.environ.get("FALCON_CLIENT_ID")
+CLIENT_SECRET = os.environ.get("FALCON_CLIENT_SECRET")
+if not CLIENT_ID or not CLIENT_SECRET:
+    sys.exit("Error: set FALCON_CLIENT_ID and FALCON_CLIENT_SECRET environment variables")
+
+ngsiem_kwargs = {
+    "client_id": CLIENT_ID,
+    "client_secret": CLIENT_SECRET,
+    "ssl_verify": SSL_VERIFY,
+}
+if BASE_URL:
+    ngsiem_kwargs["base_url"] = BASE_URL
+
+ngsiem = NGSIEM(**ngsiem_kwargs)
+
+
+def start_search(around: dict | None = None) -> str:
+    kwargs = {
+        "repository": REPO,
+        "query_string": QUERY_STRING,
+        "start": START,
+        "end": END,
+        "is_live": False,
+    }
+    if around:
+        kwargs["around"] = around
+
+    resp = ngsiem.start_search(**kwargs)
+    if resp["status_code"] != 200:
+        sys.exit(f"Failed to start search: {resp}")
+    return resp["resources"]["id"]
+
+
+def poll_until_done(job_id: str) -> dict:
+    while True:
+        resp = ngsiem.get_search_status(repository=REPO, id=job_id)
+        if resp["status_code"] == 404:
+            return {"done": True, "events": [], "metaData": {}}
+        if resp["status_code"] != 200:
+            sys.exit(f"Poll failed ({resp['status_code']}): {resp}")
+
+        resources = resp.get("resources") or resp.get("body", {})
+        if resources.get("done", False):
+            return resources
+
+        wait_ms = resources.get("metaData", {}).get("pollAfter", 500)
+        time.sleep(wait_ms / 1000.0)
+
+
+def main():
+    print(f"Query:  {QUERY_STRING}")
+    print(f"Repo:   {REPO}")
+    print(f"Range:  {START} → {END}")
+    print()
+
+    # Step 1: Initial query
+    job_id = start_search()
+    print(f"QueryJob created: {job_id}")
+
+    data = poll_until_done(job_id)
+    meta = data.get("metaData", {})
+    has_more = meta.get("extraData", {}).get("hasMoreEvents", "false")
+    processed = meta.get("processedEvents", "?")
+
+    all_events: list[dict] = list(data.get("events", []))
+    seen_ids: set[str] = {e.get("@id", "") for e in all_events}
+
+    print(f"  Initial buffer: {len(all_events)} events  "
+          f"(processedEvents={processed}  hasMoreEvents={has_more})")
+
+    # Step 2: Cursor pagination using `around`
+    # LogScale returns newest events first; the last event in the buffer is
+    # the oldest. Anchor on it and request numberOfEventsBefore to walk
+    # backward through time.
+    page = 0
+    while has_more == "true" and all_events:
+        if MAX_EVENTS and len(all_events) >= MAX_EVENTS:
+            all_events = all_events[:MAX_EVENTS]
+            break
+
+        oldest = all_events[-1]
+        anchor_id = oldest.get("@id", "")
+        anchor_ts = oldest.get("@timestamp")
+        if not anchor_id or anchor_ts is None:
+            break
+
+        page += 1
+        cursor_job_id = start_search(around={
+            "eventId": anchor_id,
+            "timestamp": int(anchor_ts),
+            "numberOfEventsBefore": PAGE_SIZE,
+            "numberOfEventsAfter": 0,
+        })
+
+        cursor_data = poll_until_done(cursor_job_id)
+        events = cursor_data.get("events", [])
+        new_events = [e for e in events if e.get("@id", "") not in seen_ids]
+
+        if not new_events:
+            break
+
+        for e in new_events:
+            seen_ids.add(e.get("@id", ""))
+        all_events.extend(new_events)
+
+        print(f"  page {page}: +{len(new_events)} events  (total: {len(all_events)})")
+        time.sleep(0.5)
+
+    if MAX_EVENTS and len(all_events) > MAX_EVENTS:
+        all_events = all_events[:MAX_EVENTS]
+
+    print(f"\nDone. {len(all_events)} total events.")
+
+    with open(OUTPUT_FILE, "w") as f:
+        json.dump(all_events, f, indent=2)
+    print(f"Results written to {OUTPUT_FILE}")
+
+
+if __name__ == "__main__":
+    main()

--- a/Misc/queryjobs-pagination/queryjob_paginator.py
+++ b/Misc/queryjobs-pagination/queryjob_paginator.py
@@ -21,8 +21,8 @@ Activate venv (each session):
 
 Environment variables:
     export LOGSCALE_TOKEN="your-api-token"              # Required
-    export LOGSCALE_BASE_URL="https://your-instance/"   # Optional (default: sa-cluster)
-    export LOGSCALE_REPO="your-repo"                    # Optional (default: FDR_Talon_1)
+    export LOGSCALE_BASE_URL="https://your-instance/"   # Required
+    export LOGSCALE_REPO="your-repo"                    # Required
 
 Usage:
     python queryjob_paginator.py -q '#event_simpleName=ProcessRollup2'
@@ -33,6 +33,7 @@ Usage:
     # Optional flags:
     python queryjob_paginator.py -q '...' -s 1h -e now -o results.json --max-events 5000
 """
+from __future__ import annotations
 
 import argparse
 import json
@@ -42,12 +43,9 @@ import time
 
 import requests
 
-# ── Configuration ──────────────────────────────────────────────────────
-BASE_URL = os.environ.get("LOGSCALE_BASE_URL", "")
-REPO = os.environ.get("LOGSCALE_REPO", "")
+# ── Defaults ──────────────────────────────────────────────────────────
 START = "15m"
 END = "now"
-
 PAGE_SIZE = 200
 MAX_EVENTS = 0      # 0 = unlimited
 OUTPUT_FILE = "queryjob_results.json"
@@ -55,6 +53,7 @@ OUTPUT_FILE = "queryjob_results.json"
 
 
 def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
     parser = argparse.ArgumentParser(
         description="LogScale QueryJob paginator with cursor-based pagination.",
         epilog="""Required environment variables:
@@ -77,8 +76,9 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def create_queryjob(query_string: str, start: str, end: str,
-                    page_size: int, around: dict | None = None) -> str:
+def create_queryjob(api_base: str, headers: dict, query_string: str,
+                    start: str, end: str, around: dict | None = None) -> str:
+    """Create a QueryJob and return its ID."""
     body = {
         "queryString": query_string,
         "start": start,
@@ -88,16 +88,22 @@ def create_queryjob(query_string: str, start: str, end: str,
     if around:
         body["around"] = around
 
-    resp = requests.post(API_BASE, headers=HEADERS, json=body)
+    resp = requests.post(api_base, headers=headers, json=body)
     resp.raise_for_status()
     return resp.json()["id"]
 
 
-def poll_until_done(job_id: str) -> dict:
-    poll_url = f"{API_BASE}/{job_id}"
+def delete_queryjob(api_base: str, headers: dict, job_id: str) -> None:
+    """Delete a QueryJob to free server resources."""
+    requests.delete(f"{api_base}/{job_id}", headers=headers)
+
+
+def poll_until_done(api_base: str, headers: dict, job_id: str) -> dict:
+    """Poll a QueryJob until done and return the result payload."""
+    poll_url = f"{api_base}/{job_id}"
 
     while True:
-        resp = requests.get(poll_url, headers=HEADERS)
+        resp = requests.get(poll_url, headers=headers)
         if resp.status_code == 404:
             return {"done": True, "events": [], "metaData": {}}
         resp.raise_for_status()
@@ -113,20 +119,21 @@ def poll_until_done(job_id: str) -> dict:
 def main():
     args = parse_args()
 
+    base_url = os.environ.get("LOGSCALE_BASE_URL", "")
+    repo = os.environ.get("LOGSCALE_REPO", "")
     token = os.environ.get("LOGSCALE_TOKEN")
     missing = []
     if not token:
         missing.append("LOGSCALE_TOKEN")
-    if not BASE_URL:
+    if not base_url:
         missing.append("LOGSCALE_BASE_URL")
-    if not REPO:
+    if not repo:
         missing.append("LOGSCALE_REPO")
     if missing:
         sys.exit(f"Error: set required environment variables: {', '.join(missing)}")
 
-    global API_BASE, HEADERS
-    API_BASE = f"{BASE_URL.rstrip('/')}/api/v1/repositories/{REPO}/queryjobs"
-    HEADERS = {
+    api_base = f"{base_url.rstrip('/')}/api/v1/repositories/{repo}/queryjobs"
+    headers = {
         "Authorization": f"Bearer {token}",
         "Content-Type": "application/json",
     }
@@ -139,15 +146,17 @@ def main():
     page_size = args.page_size
 
     print(f"Query:  {query_string}")
-    print(f"Repo:   {REPO}")
+    print(f"Repo:   {repo}")
     print(f"Range:  {start} → {end}")
     print()
 
     # Step 1: Initial query — get the first buffer of events
-    job_id = create_queryjob(query_string, start, end, page_size)
+    job_id = create_queryjob(api_base, headers, query_string, start, end)
     print(f"QueryJob created: {job_id}")
 
-    data = poll_until_done(job_id)
+    data = poll_until_done(api_base, headers, job_id)
+    delete_queryjob(api_base, headers, job_id)
+
     meta = data.get("metaData", {})
     has_more = meta.get("extraData", {}).get("hasMoreEvents", "false")
     processed = meta.get("processedEvents", "?")
@@ -175,14 +184,16 @@ def main():
             break
 
         page += 1
-        cursor_job_id = create_queryjob(query_string, start, end, page_size, around={
+        cursor_job_id = create_queryjob(api_base, headers, query_string, start, end, around={
             "eventId": anchor_id,
             "timestamp": int(anchor_ts),
             "numberOfEventsBefore": page_size,
             "numberOfEventsAfter": 0,
         })
 
-        cursor_data = poll_until_done(cursor_job_id)
+        cursor_data = poll_until_done(api_base, headers, cursor_job_id)
+        delete_queryjob(api_base, headers, cursor_job_id)
+
         events = cursor_data.get("events", [])
         new_events = [e for e in events if e.get("@id", "") not in seen_ids]
 

--- a/Misc/queryjobs-pagination/queryjob_paginator.py
+++ b/Misc/queryjobs-pagination/queryjob_paginator.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""
+LogScale QueryJob paginator — retrieves all results from a QueryJob using
+cursor-based pagination via the `around` parameter.
+
+The QueryJobs API returns a result buffer of 200 events (for filter queries).
+To retrieve all matching events, this script:
+  1. Creates a QueryJob and polls until done
+  2. Collects the initial 200-event buffer
+  3. If hasMoreEvents="true", uses the `around` parameter to create new
+     QueryJobs anchored on the oldest event, walking backward through time
+     until all events are collected
+
+Setup (one-time):
+    python3 -m venv .venv
+    source .venv/bin/activate
+    pip install requests
+
+Activate venv (each session):
+    source .venv/bin/activate
+
+Environment variables:
+    export LOGSCALE_TOKEN="your-api-token"              # Required
+    export LOGSCALE_BASE_URL="https://your-instance/"   # Optional (default: sa-cluster)
+    export LOGSCALE_REPO="your-repo"                    # Optional (default: FDR_Talon_1)
+
+Usage:
+    python queryjob_paginator.py -q '#event_simpleName=ProcessRollup2'
+
+    # Queries with double quotes — wrap in single quotes:
+    python queryjob_paginator.py -q '#event_simpleName=ProcessRollup2 | groupBy([aid], function=[count(as="Event Count")])'
+
+    # Optional flags:
+    python queryjob_paginator.py -q '...' -s 1h -e now -o results.json --max-events 5000
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+
+import requests
+
+# ── Configuration ──────────────────────────────────────────────────────
+BASE_URL = os.environ.get("LOGSCALE_BASE_URL", "")
+REPO = os.environ.get("LOGSCALE_REPO", "")
+START = "15m"
+END = "now"
+
+PAGE_SIZE = 200
+MAX_EVENTS = 0      # 0 = unlimited
+OUTPUT_FILE = "queryjob_results.json"
+# ──────────────────────────────────────────────────────────────────────
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="LogScale QueryJob paginator with cursor-based pagination.",
+        epilog="""Required environment variables:
+  LOGSCALE_TOKEN      API token for authentication
+  LOGSCALE_BASE_URL   LogScale instance URL (e.g. https://cloud.us-1.crowdstrike.com/)
+  LOGSCALE_REPO       Repository name to query against""",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "-q", "--query",
+        required=True,
+        help="CQL query string. Wrap in single quotes to preserve double quotes: "
+             "-q '#event_simpleName=ProcessRollup2 | groupBy([aid], function=[count(as=\"Event Count\")])'",
+    )
+    parser.add_argument("-s", "--start", default=START, help=f"Start time (default: {START})")
+    parser.add_argument("-e", "--end", default=END, help=f"End time (default: {END})")
+    parser.add_argument("-o", "--output", default=OUTPUT_FILE, help=f"Output file (default: {OUTPUT_FILE})")
+    parser.add_argument("--max-events", type=int, default=MAX_EVENTS, help="Max events to retrieve (default: unlimited)")
+    parser.add_argument("--page-size", type=int, default=PAGE_SIZE, help=f"Events per page (default: {PAGE_SIZE})")
+    return parser.parse_args()
+
+
+def create_queryjob(query_string: str, start: str, end: str,
+                    page_size: int, around: dict | None = None) -> str:
+    body = {
+        "queryString": query_string,
+        "start": start,
+        "end": end,
+        "isLive": False,
+    }
+    if around:
+        body["around"] = around
+
+    resp = requests.post(API_BASE, headers=HEADERS, json=body)
+    resp.raise_for_status()
+    return resp.json()["id"]
+
+
+def poll_until_done(job_id: str) -> dict:
+    poll_url = f"{API_BASE}/{job_id}"
+
+    while True:
+        resp = requests.get(poll_url, headers=HEADERS)
+        if resp.status_code == 404:
+            return {"done": True, "events": [], "metaData": {}}
+        resp.raise_for_status()
+        data = resp.json()
+
+        if data["done"]:
+            return data
+
+        wait_ms = data["metaData"].get("pollAfter", 500)
+        time.sleep(wait_ms / 1000.0)
+
+
+def main():
+    args = parse_args()
+
+    token = os.environ.get("LOGSCALE_TOKEN")
+    missing = []
+    if not token:
+        missing.append("LOGSCALE_TOKEN")
+    if not BASE_URL:
+        missing.append("LOGSCALE_BASE_URL")
+    if not REPO:
+        missing.append("LOGSCALE_REPO")
+    if missing:
+        sys.exit(f"Error: set required environment variables: {', '.join(missing)}")
+
+    global API_BASE, HEADERS
+    API_BASE = f"{BASE_URL.rstrip('/')}/api/v1/repositories/{REPO}/queryjobs"
+    HEADERS = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+    }
+
+    query_string = args.query
+    start = args.start
+    end = args.end
+    output_file = args.output
+    max_events = args.max_events
+    page_size = args.page_size
+
+    print(f"Query:  {query_string}")
+    print(f"Repo:   {REPO}")
+    print(f"Range:  {start} → {end}")
+    print()
+
+    # Step 1: Initial query — get the first buffer of events
+    job_id = create_queryjob(query_string, start, end, page_size)
+    print(f"QueryJob created: {job_id}")
+
+    data = poll_until_done(job_id)
+    meta = data.get("metaData", {})
+    has_more = meta.get("extraData", {}).get("hasMoreEvents", "false")
+    processed = meta.get("processedEvents", "?")
+
+    all_events: list[dict] = list(data.get("events", []))
+    seen_ids: set[str] = {e.get("@id", "") for e in all_events}
+
+    print(f"  Initial buffer: {len(all_events)} events  "
+          f"(processedEvents={processed}  hasMoreEvents={has_more})")
+
+    # Step 2: Cursor pagination — walk backward through time using `around`
+    # LogScale returns newest events first; the last event in the buffer is
+    # the oldest. We anchor on it and request numberOfEventsBefore to get
+    # progressively older events.
+    page = 0
+    while has_more == "true" and all_events:
+        if max_events and len(all_events) >= max_events:
+            all_events = all_events[:max_events]
+            break
+
+        oldest = all_events[-1]
+        anchor_id = oldest.get("@id", "")
+        anchor_ts = oldest.get("@timestamp")
+        if not anchor_id or anchor_ts is None:
+            break
+
+        page += 1
+        cursor_job_id = create_queryjob(query_string, start, end, page_size, around={
+            "eventId": anchor_id,
+            "timestamp": int(anchor_ts),
+            "numberOfEventsBefore": page_size,
+            "numberOfEventsAfter": 0,
+        })
+
+        cursor_data = poll_until_done(cursor_job_id)
+        events = cursor_data.get("events", [])
+        new_events = [e for e in events if e.get("@id", "") not in seen_ids]
+
+        if not new_events:
+            break
+
+        for e in new_events:
+            seen_ids.add(e.get("@id", ""))
+        all_events.extend(new_events)
+
+        print(f"  page {page}: +{len(new_events)} events  (total: {len(all_events)})")
+        time.sleep(0.5)
+
+    if max_events and len(all_events) > max_events:
+        all_events = all_events[:max_events]
+
+    print(f"\nDone. {len(all_events)} total events.")
+
+    with open(output_file, "w") as f:
+        json.dump(all_events, f, indent=2)
+    print(f"Results written to {output_file}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Example scripts for queryjobs API and paginating through results. NG-SIEM uses FalconPy
LogScale uses Python only