### PR TITLE
Add Cool Query Friday archive: 89 staff editions (2021–2026) + index

### DIFF
--- a/Queries-Only/Cool-Query-Friday/2020-03-19 - Cool Query Friday - Historic MITRE ATT&CK Footprint Data.md
+++ b/Queries-Only/Cool-Query-Friday/2020-03-19 - Cool Query Friday - Historic MITRE ATT&CK Footprint Data.md
@@ -55,3 +55,20 @@ earliest=-1month ExternalApiType=Event_DetectionSummaryEvent MachineDomain="acme
 | timechart count(AgentIdString) as detectionCount by Tactic span=1w
 | sort + _time
 ```
+
+## Community & Staff Additions
+*Harvested from this post's [r/CrowdStrike](https://www.reddit.com/r/crowdstrike/) comment thread — not part of the original CQF post. **[CS]** = CrowdStrike staff · **[Community]** = other r/CrowdStrike users. Upvote scores shown for context.*
+
+### Query variants
+
+```cql
+ExternalApiType=Event_DetectionSummaryEvent 
+| rename AgentIdString AS aid | lookup local=true aid_master aid OUTPUT aip | iplocation aip | geostats latfield=lat longfield=lon count by Tactic
+```
+— [CS] Andrew-CS · comment score 3
+
+### Q&A
+
+**Q — [Community] MaxSecurity:** Do you know if Sub-Technique is plan to be add by Crowdstrike in the log ?
+
+**A — [CS] Andrew-CS:** Yup! https://supportportal.crowdstrike.com/s/article/Tech-Alert-1st-Notice-MITRE-ATT-CK-Framework-Changes-in-31-Days

--- a/Queries-Only/Cool-Query-Friday/2020-03-19 - Cool Query Friday - Historic MITRE ATT&CK Footprint Data.md
+++ b/Queries-Only/Cool-Query-Friday/2020-03-19 - Cool Query Friday - Historic MITRE ATT&CK Footprint Data.md
@@ -1,0 +1,57 @@
+---
+title: "Historic MITRE ATT&CK Footprint Data"
+date: 2020-03-19
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/m8gpto/20200319_cool_query_friday_historic_mitre_attck/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Historic MITRE ATT&CK Footprint Data
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/m8gpto/20200319_cool_query_friday_historic_mitre_attck/](https://www.reddit.com/r/crowdstrike/comments/m8gpto/20200319_cool_query_friday_historic_mitre_attck/) — by Andrew-CS (CrowdStrike) — 2020-03-19
+
+Welcome to our third installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/?f=flair_name%3A%22CQF%22). The format will be: (1) description of what we're doing (2) walk though of each step (3) application in the wild.
+
+## Query 1
+```cql
+earliest=-365d ExternalApiType=Event_DetectionSummaryEvent 
+| stats dc(AgentIdString) as uniqueEndpoints count(AgentIdString) as detectionCount by Tactic, Technique
+| sort - detectionCount
+```
+
+## Query 2
+```cql
+earliest=-365d ExternalApiType=Event_DetectionSummaryEvent 
+| stats dc(AgentIdString) as uniqueEndpoints count(AgentIdString) as detectionCount by Tactic, Technique
+| eval detectsPerEndpoint=round(detectionCount/uniqueEndpoints,0)
+| sort - detectionCount
+```
+
+## Query 3
+```cql
+earliest=-365d ExternalApiType=Event_DetectionSummaryEvent 
+| timechart count(AgentIdString) as detectionCount by Tactic span=1month
+| sort + _time
+```
+
+## Query 4
+```cql
+earliest=-7d@d ExternalApiType=Event_DetectionSummaryEvent 
+| timechart count(AgentIdString) as detectionCount by Tactic span=1d
+| sort + _time
+```
+
+## Query 5
+```cql
+earliest=-1month ExternalApiType=Event_DetectionSummaryEvent 
+| timechart count(AgentIdString) as detectionCount by Tactic span=1w
+| sort + _time
+```
+
+## Query 6
+```cql
+earliest=-1month ExternalApiType=Event_DetectionSummaryEvent MachineDomain="acme.co"
+| timechart count(AgentIdString) as detectionCount by Tactic span=1w
+| sort + _time
+```

--- a/Queries-Only/Cool-Query-Friday/2020-04-30 - Cool Query Friday - System Resources.md
+++ b/Queries-Only/Cool-Query-Friday/2020-04-30 - Cool Query Friday - System Resources.md
@@ -1,0 +1,77 @@
+---
+title: "System Resources"
+date: 2020-04-30
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/n1tbwn/20200430_cqf_system_resources/"
+mitre: []
+series: Cool Query Friday
+---
+
+# System Resources
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/n1tbwn/20200430_cqf_system_resources/](https://www.reddit.com/r/crowdstrike/comments/n1tbwn/20200430_cqf_system_resources/) — by Andrew-CS (CrowdStrike) — 2020-04-30
+
+Welcome to our ninth installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk though of each step (3) application in the wild.
+
+## Query 1
+```cql
+event_simpleName=SystemCapacity
+| lookup aid_master aid OUTPUT ComputerName Version MachineDomain OU SiteName
+```
+
+## Query 2
+```cql
+| inputlookup aid_master
+```
+
+## Query 3
+```cql
+event_simpleName=SystemCapacity
+| lookup aid_master aid OUTPUT ComputerName Version MachineDomain OU SiteName Timezone
+```
+
+## Query 4
+```cql
+event_simpleName=SystemCapacity
+| lookup aid_master aid OUTPUT ComputerName Version MachineDomain OU SiteName Timezone
+| eval CpuClockSpeed_decimal=round(CpuClockSpeed_decimal/1000,1)
+| eval MemoryTotal_decimal=round(MemoryTotal_decimal/1.074e+9,2)
+```
+
+## Query 5
+```cql
+event_simpleName=SystemCapacity
+| lookup aid_master aid OUTPUT ComputerName Version MachineDomain OU SiteName Timezone
+| eval CpuClockSpeed_decimal=round(CpuClockSpeed_decimal/1000,1)
+| eval MemoryTotal_decimal=round(MemoryTotal_decimal/1.074e+9,2)
+| stats latest(CpuProcessorName) as "CPU" latest(CpuClockSpeed_decimal) as "CPU Clock Speed (GHz)" latest(PhysicalCoreCount_decimal) as "CPU Physical Cores" latest(LogicalCoreCount_decimal) as "CPU Logical Cores" latest(MemoryTotal_decimal) as "RAM (GB)" latest(aip) as "External IP" latest(LocalAddressIP4) as "Internal IP" by aid, ComputerName, MachineDomain, OU, SiteName, Version, Timezone
+```
+
+## Query 6
+```cql
+event_simpleName=SystemCapacity
+| lookup aid_master aid OUTPUT ComputerName Version MachineDomain OU SiteName Timezone
+| eval CpuClockSpeed_decimal=round(CpuClockSpeed_decimal/1000,1)
+| eval MemoryTotal_decimal=round(MemoryTotal_decimal/1.074e+9,2)
+| stats latest(CpuProcessorName) as "CPU" latest(CpuClockSpeed_decimal) as "CPU Clock Speed (GHz)" latest(PhysicalCoreCount_decimal) as "CPU Physical Cores" latest(LogicalCoreCount_decimal) as "CPU Logical Cores" latest(MemoryTotal_decimal) as "RAM (GB)" latest(aip) as "External IP" latest(LocalAddressIP4) as "Internal IP" by aid, ComputerName, MachineDomain, OU, SiteName, Version, Timezone
+| rename aid as "Falcon AgentID" ComputerName as "Endpoint Name" Version as "Operating System" MachineDomain as "Domain" SiteName as "Site" Timezone as "System Clock Timezone"
+```
+
+## Query 7
+```cql
+[…]
+| where MemoryTotal_deciaml<1
+[…]
+```
+
+## Query 8
+```cql
+earliest=-7d event_simpleName=SystemCapacity
+| eval CpuClockSpeed_decimal=round(CpuClockSpeed_decimal/1000,1)
+| eval MemoryTotal_decimal=round(MemoryTotal_decimal/1.074e+9,2) 
+| stats latest(MemoryTotal_decimal) as totalMemory latest(CpuClockSpeed_decimal) as cpuSpeed latest(LogicalCoreCount_decimal) as logicalCores by aid, cid
+| stats sum(totalMemory) as totalMemory sum(cpuSpeed) as totalCPU sum(logicalCores) as totalCores dc(aid) as totalEndpoints
+| eval avgMemory=round(totalMemory/totalEndpoints,2)
+| eval avgCPU=round(totalCPU/totalEndpoints,2)
+| eval avgCores=round(totalCores/totalEndpoints,2)
+```

--- a/Queries-Only/Cool-Query-Friday/2021-03-05 - Cool Query Friday - Hunting For Renamed Command Line Programs.md
+++ b/Queries-Only/Cool-Query-Friday/2021-03-05 - Cool Query Friday - Hunting For Renamed Command Line Programs.md
@@ -1,0 +1,67 @@
+---
+title: "Hunting For Renamed Command Line Programs"
+date: 2021-03-05
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/lyhga8/20210305_cool_query_friday_hunting_for_renamed/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Hunting For Renamed Command Line Programs
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/lyhga8/20210305_cool_query_friday_hunting_for_renamed/](https://www.reddit.com/r/crowdstrike/comments/lyhga8/20210305_cool_query_friday_hunting_for_renamed/) — by Andrew-CS (CrowdStrike) — 2021-03-05
+
+Okay, we're going to try something here. Welcome to the first "Cool Query Friday." We're going to (try!) to publish a new, cool threat hunting query every Friday to the community. The format will be: (1) description of what we're doing (2) walk though of each step (3) application in the wild.
+
+## Query 1
+```cql
+| inputlookup appinfo.csv
+```
+
+## Query 2
+```cql
+event_platform=win event_simpleName=ProcessRollup2 ImageSubsystem_decimal=3 
+| rename FileName as runningExe
+```
+
+## Query 3
+```cql
+event_platform=win event_simpleName=ProcessRollup2 ImageSubsystem_decimal=3 
+| rename FileName as runningExe
+| lookup local=true appinfo.csv SHA256HashData OUTPUT FileName FileDescription
+| eval runningExe=lower(runningExe)
+| eval FileName=lower(FileName)
+```
+
+## Query 4
+```cql
+event_platform=win event_simpleName=ProcessRollup2 ImageSubsystem_decimal=3 
+| rename FileName as runningExe
+| lookup local=true appinfo.csv SHA256HashData OUTPUT FileName FileDescription
+| eval runningExe=lower(runningExe)
+| eval FileName=lower(FileName)
+| where runningExe!=FileName
+```
+
+## Query 5
+```cql
+event_platform=win event_simpleName=ProcessRollup2 ImageSubsystem_decimal=3 
+| rename FileName as runningExe
+| lookup local=true appinfo.csv SHA256HashData OUTPUT FileName FileDescription
+| eval runningExe=lower(runningExe)
+| eval FileName=lower(FileName)
+| where runningExe!=FileName
+| stats dc(aid) as "System Count" count(aid) as "Execution Count" values(runningExe) as "File On Disk" values(FileName) as "Cloud File Name" values(FileDescription) as "File Description" by SHA256HashData
+```
+
+## Query 6
+```cql
+event_platform=win event_simpleName=ProcessRollup2 ImageSubsystem_decimal=3 
+| rename FileName as runningExe
+| lookup local=true appinfo.csv SHA256HashData OUTPUT FileName FileDescription
+| eval runningExe=lower(runningExe)
+| eval FileName=lower(FileName)
+| where runningExe!=FileName
+| search FileName=cmd.exe
+| stats dc(aid) as "System Count" count(aid) as "Execution Count" values(runningExe) as "File On Disk" values(FileName) as "Cloud File Name" values(FileDescription) as "File Description" by SHA256HashData
+```

--- a/Queries-Only/Cool-Query-Friday/2021-03-05 - Cool Query Friday - Hunting For Renamed Command Line Programs.md
+++ b/Queries-Only/Cool-Query-Friday/2021-03-05 - Cool Query Friday - Hunting For Renamed Command Line Programs.md
@@ -65,3 +65,24 @@ event_platform=win event_simpleName=ProcessRollup2 ImageSubsystem_decimal=3
 | search FileName=cmd.exe
 | stats dc(aid) as "System Count" count(aid) as "Execution Count" values(runningExe) as "File On Disk" values(FileName) as "Cloud File Name" values(FileDescription) as "File Description" by SHA256HashData
 ```
+
+## Community & Staff Additions
+*Harvested from this post's [r/CrowdStrike](https://www.reddit.com/r/crowdstrike/) comment thread — not part of the original CQF post. **[CS]** = CrowdStrike staff · **[Community]** = other r/CrowdStrike users. Upvote scores shown for context.*
+
+### Query variants
+
+```cql
+| search NOT FileName IN (cmd.exe, powershell.exe)
+```
+— [CS] Andrew-CS · comment score 1
+
+```cql
+| search NOT SHA256HashData IN (hash1, hash2)
+```
+— [CS] Andrew-CS · comment score 1
+
+### Q&A
+
+**Q — [Community] yankeesfan01x:** Is there a way to exclude a specific file on disk by chance (say if you know it's a legit action)?
+
+**A — [CS] Andrew-CS:** Sure thing. Add this between the first and the second line of the query... | search NOT FileName IN (cmd.exe, powershell.exe) You could also do by SHA256 | search NOT SHA256HashData IN (hash1, hash2)

--- a/Queries-Only/Cool-Query-Friday/2021-03-12 - Cool Query Friday - Parsing and Hunting Failed User Logons in Windows.md
+++ b/Queries-Only/Cool-Query-Friday/2021-03-12 - Cool Query Friday - Parsing and Hunting Failed User Logons in Windows.md
@@ -1,0 +1,107 @@
+---
+title: "Parsing and Hunting Failed User Logons in Windows"
+date: 2021-03-12
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/m3i45l/20210312_cool_query_friday_parsing_and_hunting/"
+mitre: [T1078]
+series: Cool Query Friday
+---
+
+# Parsing and Hunting Failed User Logons in Windows
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/m3i45l/20210312_cool_query_friday_parsing_and_hunting/](https://www.reddit.com/r/crowdstrike/comments/m3i45l/20210312_cool_query_friday_parsing_and_hunting/) — by Andrew-CS (CrowdStrike) — 2021-03-12
+
+Welcome to our second installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/?f=flair_name%3A%22CQF%22). The format will be: (1) description of what we're doing (2) walk though of each step (3) application in the wild.
+
+## Query 1
+```cql
+| eval SubStatus_hex=tostring(SubStatus_decimal,"hex")
+| rename SubStatus_decimal as Status_code_decimal
+| lookup local=true LogonType.csv LogonType_decimal OUTPUT LogonType
+| lookup local=true win_status_codes.csv Status_code_decimal OUTPUT Description
+```
+
+## Query 2
+```cql
+| stats count(aid) as failCount earliest(ContextTimeStamp_decimal) as firstLogonAttempt latest(ContextTimeStamp_decimal) as lastLogonAttempt values(LocalAddressIP4) as localIP values(aip) as externalIP by aid, ComputerName, UserName, LogonType, SubStatus_hex, Description
+```
+
+## Query 3
+```cql
+| eval firstLastDeltaHours=round((lastLogonAttempt-firstLogonAttempt)/60/60,2)
+| eval logonAttemptsPerHour=round(failCount/firstLastDeltaHours,0)
+```
+
+## Query 4
+```cql
+| convert ctime(firstLogonAttempt) ctime(lastLogonAttempt)
+| sort - failCount
+```
+
+## Query 5
+```cql
+event_platform=win event_simpleName=UserLogonFailed2 
+| eval SubStatus_hex=tostring(SubStatus_decimal,"hex")
+| rename SubStatus_decimal as Status_code_decimal
+| lookup local=true LogonType.csv LogonType_decimal OUTPUT LogonType
+| lookup local=true win_status_codes.csv Status_code_decimal OUTPUT Description 
+| stats count(aid) as failCount earliest(ContextTimeStamp_decimal) as firstLogonAttempt latest(ContextTimeStamp_decimal) as lastLogonAttempt values(LocalAddressIP4) as localIP values(aip) as externalIP by aid, ComputerName, UserName, LogonType, SubStatus_hex, Description 
+| eval firstLastDeltaHours=round((lastLogonAttempt-firstLogonAttempt)/60/60,2)
+| eval logonAttemptsPerHour=round(failCount/firstLastDeltaHours,0)
+| convert ctime(firstLogonAttempt) ctime(lastLogonAttempt)
+| sort - failCount
+```
+
+## Query 6
+```cql
+| where failCount >= 50
+```
+
+## Query 7
+```cql
+| search LogonType="Terminal Server"
+| where failCount >= 50
+```
+
+## Query 8
+```cql
+event_platform=win event_simpleName=UserLogonFailed2 
+| eval SubStatus_hex=tostring(SubStatus_decimal,"hex")
+| rename SubStatus_decimal as Status_code_decimal
+| lookup local=true LogonType.csv LogonType_decimal OUTPUT LogonType
+| lookup local=true win_status_codes.csv Status_code_decimal OUTPUT Description 
+| stats count(aid) as failCount dc(aid) as endpointsAttemptedAgainst earliest(ContextTimeStamp_decimal) as firstLogonAttempt latest(ContextTimeStamp_decimal) as lastLogonAttempt by RemoteIP 
+| eval firstLastDeltaHours=round((lastLogonAttempt-firstLogonAttempt)/60/60,2)
+| eval logonAttemptsPerHour=round(failCount/firstLastDeltaHours,0)
+| convert ctime(firstLogonAttempt) ctime(lastLogonAttempt)
+| sort - failCount
+```
+
+## Query 9
+```cql
+event_platform=win event_simpleName=UserLogonFailed2 
+| iplocation RemoteIP
+| eval SubStatus_hex=tostring(SubStatus_decimal,"hex")
+| rename SubStatus_decimal as Status_code_decimal
+| lookup local=true LogonType.csv LogonType_decimal OUTPUT LogonType
+| lookup local=true win_status_codes.csv Status_code_decimal OUTPUT Description 
+| stats count(aid) as failCount dc(aid) as endpointsAttemptedAgainst earliest(ContextTimeStamp_decimal) as firstLogonAttempt latest(ContextTimeStamp_decimal) as lastLogonAttempt by RemoteIP, Country, Region, City 
+| eval firstLastDeltaHours=round((lastLogonAttempt-firstLogonAttempt)/60/60,2)
+| eval logonAttemptsPerHour=round(failCount/firstLastDeltaHours,0)
+| convert ctime(firstLogonAttempt) ctime(lastLogonAttempt)
+| sort - failCount
+```
+
+## Query 10
+```cql
+event_platform=win event_simpleName=UserLogonFailed2 
+| eval SubStatus_hex=tostring(SubStatus_decimal,"hex")
+| rename SubStatus_decimal as Status_code_decimal
+| lookup local=true LogonType.csv LogonType_decimal OUTPUT LogonType
+| lookup local=true win_status_codes.csv Status_code_decimal OUTPUT Description 
+| stats count(aid) as failCount dc(aid) as endpointsAttemptedAgainst earliest(ContextTimeStamp_decimal) as firstLogonAttempt latest(ContextTimeStamp_decimal) as lastLogonAttempt by UserName, Description
+| eval firstLastDeltaHours=round((lastLogonAttempt-firstLogonAttempt)/60/60,2)
+| eval logonAttemptsPerHour=round(failCount/firstLastDeltaHours,0)
+| convert ctime(firstLogonAttempt) ctime(lastLogonAttempt)
+| sort - failCount
+```

--- a/Queries-Only/Cool-Query-Friday/2021-03-26 - Cool Query Friday - Hunting Process Integrity Levels in Windows.md
+++ b/Queries-Only/Cool-Query-Friday/2021-03-26 - Cool Query Friday - Hunting Process Integrity Levels in Windows.md
@@ -1,0 +1,121 @@
+---
+title: "Hunting Process Integrity Levels in Windows"
+date: 2021-03-26
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/mdo3dx/20210326_cool_query_friday_hunting_process/"
+mitre: [T0004]
+series: Cool Query Friday
+---
+
+# Hunting Process Integrity Levels in Windows
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/mdo3dx/20210326_cool_query_friday_hunting_process/](https://www.reddit.com/r/crowdstrike/comments/mdo3dx/20210326_cool_query_friday_hunting_process/) — by Andrew-CS (CrowdStrike) — 2021-03-26
+
+Welcome to our fourth installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/?f=flair_name%3A%22CQF%22). The format will be: (1) description of what we're doing (2) walk though of each step (3) application in the wild.
+
+## Query 1
+```cql
+event_platform=win ComputerName=COMPUTERNAME event_simpleName=ProcessRollup2 FileName=cmd.exe 
+| table _time ComputerName UserName FileName FilePath IntegrityLevel_decimal
+```
+
+## Query 2
+```cql
+event_platform=win ComputerName=COMPUTERNAME event_simpleName=ProcessRollup2 FileName=cmd.exe 
+| eval IntegrityLevel_hex=tostring(IntegrityLevel_decimal,"hex")
+```
+
+## Query 3
+```cql
+event_platform=win ComputerName=COMPUTERNAME event_simpleName=ProcessRollup2 FileName=cmd.exe 
+| eval IntegrityLevel_hex=tostring(IntegrityLevel_decimal,"hex")
+| table _time ComputerName UserName FileName FilePath IntegrityLevel_hex IntegrityLevel_decimal
+```
+
+## Query 4
+```cql
+event_platform=win ComputerName=COMPUTERNAME event_simpleName=ProcessRollup2 FileName=cmd.exe 
+| eval IntegrityLevel_hex=tostring(IntegrityLevel_decimal,"hex")
+| eval TokenType_decimal = replace(TokenType_decimal,"1", "PRIMARY")
+| eval TokenType_decimal = replace(TokenType_decimal,"2", "IMPERSONATION")
+| eval IntegrityLevel_hex = replace(IntegrityLevel_hex,"0x0000", "UNSTRUSTED")
+| eval IntegrityLeve_hex = replace(IntegrityLevel_hex,"0x1000", "LOW")
+| eval IntegrityLevel_hex = replace(IntegrityLevel_hex,"0x2000", "MEDIUM")
+| eval IntegrityLevel_hex = replace(IntegrityLevel_hex,"0x2100", "MEDIUM-HIGH")
+| eval IntegrityLevel_hex = replace(IntegrityLevel_hex,"0x3000", "HIGH")
+| eval IntegrityLevel_hex = replace(IntegrityLevel_hex,"0x4000", "SYSTEM")
+| eval IntegrityLevel_hex = replace(IntegrityLevel_hex,"0x5000", "PROTECTED")
+| table _time ComputerName UserName FileName FilePath TokenType_decimal IntegrityLevel_hex
+```
+
+## Query 5
+```cql
+event_platform=win event_simpleName=ProcessRollup2 ImageSubsystem_decimal=3 UserSid_readable=S-1-5-21-*
+| eval IntegrityLevel_hex=tostring(IntegrityLevel_decimal,"hex")
+| eval TokenType_decimal = replace(TokenType_decimal,"1", "PRIMARY")
+| eval TokenType_decimal = replace(TokenType_decimal,"2", "IMPERSONATION")
+| eval IntegrityLevel_hex = replace(IntegrityLevel_hex,"0x0000", "UNSTRUSTED")
+| eval IntegrityLeve_hex = replace(IntegrityLevel_hex,"0x1000", "LOW")
+| eval IntegrityLevel_hex = replace(IntegrityLevel_hex,"0x2000", "MEDIUM")
+| eval IntegrityLevel_hex = replace(IntegrityLevel_hex,"0x2100", "MEDIUM-HIGH")
+| eval IntegrityLevel_hex = replace(IntegrityLevel_hex,"0x3000", "HIGH")
+| eval IntegrityLevel_hex = replace(IntegrityLevel_hex,"0x4000", "SYSTEM")
+| eval IntegrityLevel_hex = replace(IntegrityLevel_hex,"0x5000", "PROTECTED")
+| search IntegrityLevel_hex=HIGH
+| stats count(aid) as executionCount dc(aid) as endpointCount dc(UserSid_readable) as userCount values(UserSid_readable) as - userSIDs by FileName FilePath TokenType_decimal IntegrityLevel_hex
+| sort - executionCount
+```
+
+## Query 6
+```cql
+event_platform=win event_simpleName=ProcessRollup2 ImageSubsystem_decimal=3 UserSid_readable=S-1-5-21-* FileName=powershell.exe
+| eval IntegrityLevel_hex=tostring(IntegrityLevel_decimal,"hex")
+| eval TokenType_decimal = replace(TokenType_decimal,"1", "PRIMARY")
+| eval TokenType_decimal = replace(TokenType_decimal,"2", "IMPERSONATION")
+| eval IntegrityLevel_hex = replace(IntegrityLevel_hex,"0x0000", "UNSTRUSTED")
+| eval IntegrityLeve_hex = replace(IntegrityLevel_hex,"0x1000", "LOW")
+| eval IntegrityLevel_hex = replace(IntegrityLevel_hex,"0x2000", "MEDIUM")
+| eval IntegrityLevel_hex = replace(IntegrityLevel_hex,"0x2100", "MEDIUM-HIGH")
+| eval IntegrityLevel_hex = replace(IntegrityLevel_hex,"0x3000", "HIGH")
+| eval IntegrityLevel_hex = replace(IntegrityLevel_hex,"0x4000", "SYSTEM")
+| eval IntegrityLevel_hex = replace(IntegrityLevel_hex,"0x5000", "PROTECTED")
+| search IntegrityLevel_hex=HIGH
+| stats count(aid) as executionCount dc(aid) as endpointCount dc(UserSid_readable) as userCount by FileName FilePath TokenType_decimal IntegrityLevel_hex CommandLine
+| sort - executionCount
+```
+
+## Query 7
+```cql
+event_platform=win event_simpleName=ProcessRollup2 UserSid_readable=S-1-5-21-* FilePath=*\\AppData\\*
+| eval IntegrityLevel_hex=tostring(IntegrityLevel_decimal,"hex")
+| eval TokenType_decimal = replace(TokenType_decimal,"1", "PRIMARY")
+| eval TokenType_decimal = replace(TokenType_decimal,"2", "IMPERSONATION")
+| eval IntegrityLevel_hex = replace(IntegrityLevel_hex,"0x0000", "UNSTRUSTED")
+| eval IntegrityLeve_hex = replace(IntegrityLevel_hex,"0x1000", "LOW")
+| eval IntegrityLevel_hex = replace(IntegrityLevel_hex,"0x2000", "MEDIUM")
+| eval IntegrityLevel_hex = replace(IntegrityLevel_hex,"0x2100", "MEDIUM-HIGH")
+| eval IntegrityLevel_hex = replace(IntegrityLevel_hex,"0x3000", "HIGH")
+| eval IntegrityLevel_hex = replace(IntegrityLevel_hex,"0x4000", "SYSTEM")
+| eval IntegrityLevel_hex = replace(IntegrityLevel_hex,"0x5000", "PROTECTED")
+| search IntegrityLevel_hex=HIGH
+| stats count(aid) as executionCount dc(aid) as endpointCount dc(UserSid_readable) as userCount by FileName FilePath TokenType_decimal IntegrityLevel_hex CommandLine
+| sort - executionCount
+```
+
+## Query 8
+```cql
+event_platform=win event_simpleName=ProcessRollup2 UserSid_readable=S-1-5-21-*
+| eval IntegrityLevel_hex=tostring(IntegrityLevel_decimal,"hex")
+| eval TokenType_decimal = replace(TokenType_decimal,"1", "PRIMARY")
+| eval TokenType_decimal = replace(TokenType_decimal,"2", "IMPERSONATION")
+| eval IntegrityLevel_hex = replace(IntegrityLevel_hex,"0x0000", "UNSTRUSTED")
+| eval IntegrityLeve_hex = replace(IntegrityLevel_hex,"0x1000", "LOW")
+| eval IntegrityLevel_hex = replace(IntegrityLevel_hex,"0x2000", "MEDIUM")
+| eval IntegrityLevel_hex = replace(IntegrityLevel_hex,"0x2100", "MEDIUM-HIGH")
+| eval IntegrityLevel_hex = replace(IntegrityLevel_hex,"0x3000", "HIGH")
+| eval IntegrityLevel_hex = replace(IntegrityLevel_hex,"0x4000", "SYSTEM")
+| eval IntegrityLevel_hex = replace(IntegrityLevel_hex,"0x5000", "PROTECTED")
+| search IntegrityLevel_hex=SYSTEM
+| stats count(aid) as executionCount dc(aid) as endpointCount dc(UserSid_readable) as userCount by FileName FilePath TokenType_decimal IntegrityLevel_hex CommandLine
+| sort - executionCount
+```

--- a/Queries-Only/Cool-Query-Friday/2021-04-02 - Cool Query Friday - Hunting macOS Kernel Extensions.md
+++ b/Queries-Only/Cool-Query-Friday/2021-04-02 - Cool Query Friday - Hunting macOS Kernel Extensions.md
@@ -1,0 +1,78 @@
+---
+title: "Hunting macOS Kernel Extensions"
+date: 2021-04-02
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/mijvb0/20210402_cool_query_friday_hunting_macos_kernel/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Hunting macOS Kernel Extensions
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/mijvb0/20210402_cool_query_friday_hunting_macos_kernel/](https://www.reddit.com/r/crowdstrike/comments/mijvb0/20210402_cool_query_friday_hunting_macos_kernel/) — by Andrew-CS (CrowdStrike) — 2021-04-02
+
+Welcome to our fifth installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk though of each step (3) application in the wild.
+
+## Query 1
+```cql
+event_platform=mac event_simpleName=KextLoad 
+| stats dc(aid) as systemCount by BundleID
+| sort - systemCount
+```
+
+## Query 2
+```cql
+kextstat | grep -v com.apple
+```
+
+## Query 3
+```cql
+event_platform=mac event_simpleName=KextLoad 
+| lookup aid_master aid OUTPUT Version
+```
+
+## Query 4
+```cql
+event_platform=mac event_simpleName=KextLoad 
+| lookup aid_master aid OUTPUT Version
+| rex field=Version "^(?<osVersion>[^.]*)\("
+```
+
+## Query 5
+```cql
+event_platform=mac event_simpleName=KextLoad 
+| lookup aid_master aid OUTPUT Version
+| rex field=Version "^(?<osVersion>[^.]*)\("
+| stats dc(aid) as systemCount by BundleID, osVersion
+| sort - systemCount
+```
+
+## Query 6
+```cql
+event_platform=mac event_simpleName=KextLoad 
+| search BundleID!=com.apple.*
+| lookup aid_master aid OUTPUT Version
+| rex field=Version "^(?<osVersion>[^.]*)\("
+| fillnull osVersion value="Unknown"
+| stats dc(aid) as systemCount by BundleID, osVersion
+| sort - systemCount
+```
+
+## Query 7
+```cql
+event_platform=mac event_simpleName=KextLoad 
+| search BundleID!=com.apple.* 
+| lookup aid_master aid OUTPUT Version, SystemProductName
+| rex field=Version "^(?<osVersion>[^.]*)\("
+| fillnull osVersion value="Unknown"
+| stats values(ComputerName) as endpointName dc(BundleID) as nonAppleKernelCount values(BundleID) as nonAppleKernelExt by aid, osVersion, SystemProductName
+| sort - nonAppleKernelCount
+```
+
+## Query 8
+```cql
+event_platform=mac event_simpleName=ProcessRollup2 MachOSubType_decimal=5 FilePath="/Applications/*" 
+| stats  dc(aid) as systemCount count(aid) as executionCount by FileName SHA256HashData   
+| lookup  local=true appinfo.csv SHA256HashData OUTPUT ProductName , ProductVersion , FileDescription , FileVersion , CompanyName  
+ sort  - systemCount
+```

--- a/Queries-Only/Cool-Query-Friday/2021-04-08 - Cool Query Friday - Windows Dump Files.md
+++ b/Queries-Only/Cool-Query-Friday/2021-04-08 - Cool Query Friday - Windows Dump Files.md
@@ -1,0 +1,60 @@
+---
+title: "Windows Dump Files"
+date: 2021-04-08
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/mngo2l/20210408_cool_query_friday_windows_dump_files/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Windows Dump Files
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/mngo2l/20210408_cool_query_friday_windows_dump_files/](https://www.reddit.com/r/crowdstrike/comments/mngo2l/20210408_cool_query_friday_windows_dump_files/) — by Andrew-CS (CrowdStrike) — 2021-04-08
+
+Welcome to our sixth installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk though of each step (3) application in the wild.
+
+## Query 1
+```cql
+event_platform=win (event_simpleName=ProcessRollup2 OR event_simpleName=SyntheticProcessRollup2) AND FileName=werfault.exe
+| stats dc(aid) as endpointCount count(aid) as crashCount by ParentBaseFileName
+| sort - crashCount
+| rename ParentBaseFileName as crashingProgram
+```
+
+## Query 2
+```cql
+| sort + crashCount
+```
+
+## Query 3
+```cql
+event_platform=win (event_simpleName=ProcessRollup2 OR event_simpleName=SyntheticProcessRollup2) AND FileName=werfault.exe
+| rare ParentBaseFileName limit=25
+```
+
+## Query 4
+```cql
+event_platform=win (event_simpleName=ProcessRollup2 OR event_simpleName=SyntheticProcessRollup2) AND FileName=werfault.exe
+| common ParentBaseFileName limit=25
+```
+
+## Query 5
+```cql
+(event_simpleName=ProcessRollup2 OR event_simpleName=SyntheticProcessRollup2) AND FileName=WerFault.exe AND ParentBaseFileName=prunsrv-amd64.exe
+| rename TargetProcessId_decimal AS ContextProcessId_decimal, FileName as crashProcessor, ParentBaseFileName as crashingProgram, RawProcessId_decimal as osPID
+| join aid, ContextProcessId_decimal 
+    [search event_simpleName=DmpFileWritten]
+```
+
+## Query 6
+```cql
+(event_simpleName=ProcessRollup2 OR event_simpleName=SyntheticProcessRollup2) AND FileName=WerFault.exe AND ParentBaseFileName=prunsrv-amd64.exe
+| rename TargetProcessId_decimal AS ContextProcessId_decimal, FileName as crashProcessor, ParentBaseFileName as crashingProgram, RawProcessId_decimal as osPID
+| join aid, ContextProcessId_decimal 
+    [search event_simpleName=DmpFileWritten]
+| table timestamp aid ComputerName UserName crashProcessor crashingProgram TargetFileName ContextProcessId_decimal, osPID
+| sort + timestamp
+| eval timestamp=timestamp/1000
+| convert ctime(timestamp)
+| rename ComputerName as endpointName, UserName as userName, TargetFileName as dmpFile, ContextTimeStamp_decimal, as crashTime, ContextProcessId_decimal as falconPID
+```

--- a/Queries-Only/Cool-Query-Friday/2021-04-16 - Cool Query Friday - Windows RDP User Login Events, Kilometers, and MACH 1.md
+++ b/Queries-Only/Cool-Query-Friday/2021-04-16 - Cool Query Friday - Windows RDP User Login Events, Kilometers, and MACH 1.md
@@ -142,3 +142,16 @@ event_platform=win event_simpleName=UserLogon (RemoteIP!=172.16.0.0/12 AND Remot
 | where speed > 1234
 [...]
 ```
+
+## Community & Staff Additions
+*Harvested from this post's [r/CrowdStrike](https://www.reddit.com/r/crowdstrike/) comment thread — not part of the original CQF post. **[CS]** = CrowdStrike staff · **[Community]** = other r/CrowdStrike users. Upvote scores shown for context.*
+
+### Q&A
+
+**Q — [Community] Affectionate_Will487:** In an environment that allows RDP how would you narrow down to find either a system with let’s say 100 failures on let’s say 100 hosts something like that , or a system that doesn’t use rdp and now all over sudden using rdp, or what are some strange patterns to look for ?
+
+**A — [CS] Andrew-CS:** You want to check failed user logins. CQF here: https://www.reddit.com/r/crowdstrike/comments/m3i45l/20210312\_cool\_query\_friday\_parsing\_and\_hunting/
+
+**Q — [Community] cs-del:** I have a similar scheduled search for my environment monitoring successful RDP connections (logon type 10) originating from external IP address. This is one of the areas that client is mainly interested in. One of the detection from that search is user logon event that shows up a remote IP on client …
+
+**A — [CS] Andrew-CS:** Hi there. In Process Explorer, you're only seeing outbound network connections. You can look for the event `NetworkReceiveAcceptIP4`. Authentications will always be pinned to LSASS as that handles auth for Windows systems.

--- a/Queries-Only/Cool-Query-Friday/2021-04-16 - Cool Query Friday - Windows RDP User Login Events, Kilometers, and MACH 1.md
+++ b/Queries-Only/Cool-Query-Friday/2021-04-16 - Cool Query Friday - Windows RDP User Login Events, Kilometers, and MACH 1.md
@@ -1,0 +1,144 @@
+---
+title: "Windows RDP User Login Events, Kilometers, and MACH 1"
+date: 2021-04-16
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/ms2mlz/20210416_cool_query_friday_windows_rdp_user_login/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Windows RDP User Login Events, Kilometers, and MACH 1
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/ms2mlz/20210416_cool_query_friday_windows_rdp_user_login/](https://www.reddit.com/r/crowdstrike/comments/ms2mlz/20210416_cool_query_friday_windows_rdp_user_login/) — by Andrew-CS (CrowdStrike) — 2021-04-16
+
+Welcome to our seventh installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk though of each step (3) application in the wild.
+
+## Query 1
+```cql
+event_platform=win event_simpleName=UserLogon
+| eval LogonType=case(LogonType_decimal="2", "Local Logon", LogonType_decimal="3", "Network", LogonType_decimal="4", "Batch", LogonType_decimal="5", "Service", LogonType_decimal="6", "Proxy", LogonType_decimal="7", "Unlock", LogonType_decimal="8", "Network Cleartext", LogonType_decimal="9", "New Credentials", LogonType_decimal="10", "RDP", LogonType_decimal="11", "Cached Credentials", LogonType_decimal="12", "Auditing", LogonType_decimal="13", "Unlock Workstation")
+```
+
+## Query 2
+```cql
+event_platform=win event_simpleName=UserLogon LogonType_decimal=10
+| iplocation RemoteIP
+```
+
+## Query 3
+```cql
+event_platform=win event_simpleName=UserLogon LogonType_decimal=10 (RemoteIP!=172.16.0.0/12 AND RemoteIP!=192.168.0.0/16 AND RemoteIP!=10.0.0.0/8)
+| iplocation RemoteIP
+| stats values(UserName) as userNames dc(UserSid_readable) as userAccountsUsed count(UserSid_readable) as successfulLogins dc(Country) as countriesFrom by ComputerName, aid
+| sort - successfulLogins
+```
+
+## Query 4
+```cql
+| stats values(UserName) as userNames dc(UserSid_readable) as userAccountsUsed count(UserSid_readable) as successfulLogins dc(Country) as countriesCount by ComputerName, aid
+| sort - successfulLogins
+```
+
+## Query 5
+```cql
+event_platform=win event_simpleName=UserLogon LogonType_decimal=10 (RemoteIP!=172.16.0.0/12 AND RemoteIP!=192.168.0.0/16 AND RemoteIP!=10.0.0.0/8)
+| iplocation RemoteIP
+| where Country!="United States"
+| stats values(UserName) as userNames dc(UserSid_readable) as userAccountsUsed count(UserSid_readable) as successfulLogins values(Country) as countriesFrom dc(Country) as countriesCount by ComputerName, aid
+| sort - successfulLogins
+```
+
+## Query 6
+```cql
+event_platform=win event_simpleName=UserLogon LogonType_decimal=10 (RemoteIP!=172.16.0.0/12 AND RemoteIP!=192.168.0.0/16 AND RemoteIP!=10.0.0.0/8)
+| iplocation RemoteIP
+| stats dc(aid) as systemsAccessed count(UserSid_readable) as totalRDPLogins values(Country) as countriesFrom dc(Country) as countriesCount by UserName, UserSid_readable
+| sort - totalRDPLogins
+```
+
+## Query 7
+```cql
+event_platform=win event_simpleName=UserLogon LogonType_decimal=10 ProductType=1 (RemoteIP!=172.16.0.0/12 AND RemoteIP!=192.168.0.0/16 AND RemoteIP!=10.0.0.0/8)
+| iplocation RemoteIP
+| stats dc(aid) as systemsAccessed count(UserSid_readable) as totalRDPLogins values(Country) as countriesFrom dc(Country) as countriesCount by UserName, UserSid_readable
+| sort - totalRDPLogins
+```
+
+## Query 8
+```cql
+| inputlookup aid_master 
+| eval ProductTypeName=case(ProductType=1, "Workstation", ProductType=2, "Domain Controller", ProductType=3, "Server")
+| stats values(Version) as osVersions by ProductType, ProductTypeName
+```
+
+## Query 9
+```cql
+event_platform=win event_simpleName=UserLogon (RemoteIP!=172.16.0.0/12 AND RemoteIP!=192.168.0.0/16 AND RemoteIP!=10.0.0.0/8)
+| iplocation RemoteIP
+```
+
+## Query 10
+```cql
+| stats earliest(LogonTime_decimal) as firstLogon earliest(lat) as lat1 earliest(lon) as lon1 earliest(Country) as country1 earliest(Region) as region1 earliest(City) as city1 latest(LogonTime_decimal) as lastLogon latest(lat) as lat2 latest(lon) as lon2 latest(Country) as country2 latest(Region) as region2 latest(City) as city2 dc(RemoteIP) as remoteIPCount by UserSid_readable, UserName
+```
+
+## Query 11
+```cql
+| where remoteIPCount > 1
+```
+
+## Query 12
+```cql
+| eval timeDelta=round((lastLogon-firstLogon)/60/60,2)
+```
+
+## Query 13
+```cql
+| eval rlat1 = pi()*lat1/180, rlat2=pi()*lat2/180, rlat = pi()*(lat2-lat1)/180, rlon= pi()*(lon2-lon1)/180
+| eval a = sin(rlat/2) * sin(rlat/2) + cos(rlat1) * cos(rlat2) * sin(rlon/2) * sin(rlon/2) 
+| eval c = 2 * atan2(sqrt(a), sqrt(1-a)) 
+| eval distance = round((6371 * c),0)
+```
+
+## Query 14
+```cql
+| eval speed=round((distance/timeDelta),2)
+```
+
+## Query 15
+```cql
+| table UserSid_readable, UserName, firstLogon, country1, region1, city1, lastLogon, country2, region2, city2, timeDelta, distance, speed remoteIPCount
+| convert ctime(firstLogon), ctime(lastLogon)
+| sort - speed
+```
+
+## Query 16
+```cql
+| rename UserSid_readable AS "User SID", UserName AS User, firstLogon AS "First Logon Time", country1 AS " First Country" region1 AS "First Region", city1 AS "First City", lastLogon AS "Last Logon Time", country2 AS "Last Country", region2 AS "Last Region", city2 AS "Last City", timeDelta AS "Elapsed Time (hours) ", distance AS "Kilometers Between GeoIP Locations", speed AS "Required Speed (km/h)", remoteIPCount as "Number of Remote Logins"
+```
+
+## Query 17
+```cql
+event_platform=win event_simpleName=UserLogon (RemoteIP!=172.16.0.0/12 AND RemoteIP!=192.168.0.0/16 AND RemoteIP!=10.0.0.0/8)
+| iplocation RemoteIP 
+| stats earliest(LogonTime_decimal) as firstLogon earliest(lat) as lat1 earliest(lon) as lon1 earliest(Country) as country1 earliest(Region) as region1 earliest(City) as city1 latest(LogonTime_decimal) as lastLogon latest(lat) as lat2 latest(lon) as lon2 latest(Country) as country2 latest(Region) as region2 latest(City) as city2 dc(RemoteIP) as remoteIPCount by UserSid_readable, UserName
+| where remoteIPCount > 1
+| eval timeDelta=round((lastLogon-firstLogon)/60/60,2)
+| eval rlat1 = pi()*lat1/180, rlat2=pi()*lat2/180, rlat = pi()*(lat2-lat1)/180, rlon= pi()*(lon2-lon1)/180
+| eval a = sin(rlat/2) * sin(rlat/2) + cos(rlat1) * cos(rlat2) * sin(rlon/2) * sin(rlon/2) 
+| eval c = 2 * atan2(sqrt(a), sqrt(1-a)) 
+| eval distance = round((6371 * c),0)
+| eval speed=round((distance/timeDelta),2)
+| table UserSid_readable, UserName, firstLogon, country1, region1, city1, lastLogon, country2, region2, city2, timeDelta, distance, speed remoteIPCount
+| convert ctime(firstLogon), ctime(lastLogon)
+| sort - speed
+| rename UserSid_readable AS "User SID", UserName AS User, firstLogon AS "First Logon Time", country1 AS " First Country" region1 AS "First Region", city1 AS "First City", lastLogon AS "Last Logon Time", country2 AS "Last Country", region2 AS "Last Region", city2 AS "Last City", timeDelta AS "Elapsed Time (hours) ", distance AS "Kilometers Between GeoIP Locations", speed AS "Required Speed (km/h)", remoteIPCount as "Number of Remote Logins"
+```
+
+## Query 18
+```cql
+[...]
+| eval speed=round((distance/timeDelta),2)
+| where speed > 1234
+[...]
+```

--- a/Queries-Only/Cool-Query-Friday/2021-04-23 - Cool Query Friday - Parsing the Call Stack.md
+++ b/Queries-Only/Cool-Query-Friday/2021-04-23 - Cool Query Friday - Parsing the Call Stack.md
@@ -131,3 +131,25 @@ event_platform=win event_simpleName=ProcessRollup2
 | convert ctime(ContextTimeStamp_decimal)
 | rename ContextTimeStamp_decimal as dllReflectiveLoadTime
 ```
+
+## Community & Staff Additions
+*Harvested from this post's [r/CrowdStrike](https://www.reddit.com/r/crowdstrike/) comment thread — not part of the original CQF post. **[CS]** = CrowdStrike staff · **[Community]** = other r/CrowdStrike users. Upvote scores shown for context.*
+
+### Query variants
+
+```cql
+[...]
+| eval n=mvfilter(match(CallStackModuleNames, ".*\.exe.*") OR match(CallStackModuleNames, ".*\.dll.*"))
+[...]
+```
+— [CS] Andrew-CS · comment score 1
+
+### Q&A
+
+**Q — [Community] SnooCookies3976:** How does CreateThreadReflectiveDll compare to ReflectiveDllOpenProcess?
+
+**A — [CS] Andrew-CS:** >CreateThreadReflectiveDll Signals there was a reflectively loaded DLL on the callstack, or that the target address is in a reflectively loaded DLL. >ReflectiveDllOpenProcess Signals a userspace thread attempted to open a process which appeared to originate from a reflectively loaded DLL.
+
+**Q — [Community] AnalogJones:** "Cool Query Friday" is awesome. I am new to this column and I've been playing with all of the queries offered! I was having trouble with this Call Stack thread, though. Starting on Step #3 I would continue to get Event data, but no stats/visualization data. Can you help me understand what is broken? …
+
+**A — [CS] Andrew-CS:** >event\_platform=win event\_simpleName=ProcessRollup2 CallStackModuleNames=\* > >| eval CallStackModuleNames=split(CallStackModuleNames, "|") > >| eval n=mvfilter(match(CallStackModuleNames, "exe") OR match(CallStackModuleNames, "dll")) > >| rex field=n ".\*\\\\\\\\Device\\\\\\\\HarddiskVolume\\d+(?<loadedFile>.\*(\\.dll|\\.exe)).\*" > >| table ComputerName FileName CallStackModuleNames loadedFile > >| head 2 Hi there. Both should work as what is in those quotes (in the bolded line) is a regular …

--- a/Queries-Only/Cool-Query-Friday/2021-04-23 - Cool Query Friday - Parsing the Call Stack.md
+++ b/Queries-Only/Cool-Query-Friday/2021-04-23 - Cool Query Friday - Parsing the Call Stack.md
@@ -1,0 +1,133 @@
+---
+title: "Parsing the Call Stack"
+date: 2021-04-23
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/mwuz92/20210423_cool_query_friday_parsing_the_call_stack/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Parsing the Call Stack
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/mwuz92/20210423_cool_query_friday_parsing_the_call_stack/](https://www.reddit.com/r/crowdstrike/comments/mwuz92/20210423_cool_query_friday_parsing_the_call_stack/) — by Andrew-CS (CrowdStrike) — 2021-04-23
+
+Welcome to our eighth installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk though of each step (3) application in the wild.
+
+## Query 1
+```cql
+event_platform=win event_simpleName=ProcessRollup2
+| where isnotnull(CallStackModuleNames) 
+| table ComputerName FileName CommandLine CallStackModuleNames
+```
+
+## Query 2
+```cql
+0<-1>\Device\HarddiskVolume1\Windows\System32\ntdll.dll+0x9f8a4:0x1ec000:0x6e7b7e33|\Device\HarddiskVolume1\Windows\System32\KernelBase.dll+0x5701e:0x294000:0xc97af40a|1+0x56d84|1+0x55a0d|1+0x54dda|1+0x547ed|0+0x25d37|0+0x285e9|0+0x28854|0+0x2887e|0+0x29551|0+0x26921|0+0x23238|0+0x22794|0+0xd53e9|0+0x7837b|0+0x78203|0+0x781ae
+```
+
+## Query 3
+```cql
+event_platform=win event_simpleName=ProcessRollup2 CallStackModuleNames=*JIT-DOTNET*
+| table ComputerName FileName CommandLine CallStackModuleNames
+```
+
+## Query 4
+```cql
+event_platform=win event_simpleName=ProcessRollup2 CallStackModuleNames=*
+| eval CallStackModuleNames=split(CallStackModuleNames, "|")
+| eval n=mvfilter(match(CallStackModuleNames, ".*exe") OR match(CallStackModuleNames, ".*dll"))
+| rex field=n ".*\\\\Device\\\\HarddiskVolume\d+(?<loadedFile>.*(\.dll|\.exe)).*"
+```
+
+## Query 5
+```cql
+| eval n=mvfilter(match(CallStackModuleNames, ".*exe") OR match(CallStackModuleNames, ".*dll"))
+```
+
+## Query 6
+```cql
+| rex field=n ".*\\\\Device\\\\HarddiskVolume\d+(?<loadedFile>.*(\.dll|\.exe)).*"
+```
+
+## Query 7
+```cql
+event_platform=win event_simpleName=ProcessRollup2 CallStackModuleNames=*
+| eval CallStackModuleNames=split(CallStackModuleNames, "|")
+| eval n=mvfilter(match(CallStackModuleNames, ".*exe") OR match(CallStackModuleNames, ".*dll"))
+| rex field=n ".*\\\\Device\\\\HarddiskVolume\d+(?<loadedFile>.*(\.dll|\.exe)).*"
+| table ComputerName FileName CallStackModuleNames loadedFile
+| head 2
+```
+
+## Query 8
+```cql
+event_platform=win event_simpleName=ProcessRollup2 CallStackModuleNames=*
+| eval CallStackModuleNames=split(CallStackModuleNames, "|")
+| eval n=mvfilter(match(CallStackModuleNames, ".*exe") OR match(CallStackModuleNames, ".*dll"))
+| rex field=n ".*\\\\Device\\\\HarddiskVolume\d+(?<loadedFile>.*(\.dll|\.exe)).*"
+| stats dc(SHA256HashData) as SHA256values values(loadedFile) as loadedFiles dc(aid) as endpointCount count(aid) as loadCount by FileName
+| eval loadedFiles=mvfilter(match(loadedFiles, "\\\\temp\\\\"))
+| where isnotnull(loadedFiles)
+| sort + loadCount
+```
+
+## Query 9
+```cql
+| stats dc(SHA256HashData) as SHA256values values(loadedFile) as loadedFiles dc(aid) as endpointCount count(aid) as loadCount by FileName
+```
+
+## Query 10
+```cql
+| eval loadedFiles=mvfilter(match(loadedFiles, "\\\\temp\\\\"))
+```
+
+## Query 11
+```cql
+| where isnotnull(loadedFiles)
+```
+
+## Query 12
+```cql
+| sort + loadCount
+```
+
+## Query 13
+```cql
+event_platform=win event_simpleName=ProcessRollup2 ImageSubsystem_decimal=3 CallStackModuleNames=*
+| eval CallStackModuleNames=split(CallStackModuleNames, "|")
+| eval n=mvfilter(match(CallStackModuleNames, ".*exe") OR match(CallStackModuleNames, ".*dll"))
+| rex field=n ".*\\\\Device\\\\HarddiskVolume\d+(?<loadedFile>.*(\.dll|\.exe)).*"
+| stats dc(SHA256HashData) as SHA256values values(loadedFile) as loadedFiles dc(aid) as endpointCount count(aid) as loadCount by FileName
+| eval loadedFiles=mvfilter(match(loadedFiles, "\\\\temp\\\\"))
+| where isnotnull(loadedFiles)
+| sort + loadCount
+```
+
+## Query 14
+```cql
+event_platform=win event_simpleName=ProcessRollup2 CallStackModuleNames=*
+| eval CallStackModuleNames=split(CallStackModuleNames, "|")
+| eval n=mvfilter(match(CallStackModuleNames, ".*exe") OR match(CallStackModuleNames, ".*dll"))
+| rex field=n ".*\\\\Device\\\\HarddiskVolume\d+(?<loadedFile>.*(\.dll|\.exe)).*"
+| stats dc(SHA256HashData) as SHA256count values(loadedFile) as loadedFiles dc(aid) as endpointCount count(aid) as loadCount by FileName
+| eval loadedFiles=mvfilter(!match(loadedFiles, "\\\\Windows\\\\System32\\\\*"))
+| eval loadedFiles=mvfilter(!match(loadedFiles, "\\\\Windows\\\\SysWOW64\\\\*"))
+| eval loadedFiles=mvfilter(!match(loadedFiles, "\\\\Windows\\\\assembly\\\\*"))
+| where isnotnull(loadedFiles)
+| sort + loadCount
+```
+
+## Query 15
+```cql
+event_platform=win event_simpleName=ProcessRollup2 
+| rename TargetProcessId_decimal AS ContextProcessId_decimal, CallStackModuleNames as exeCallStack
+| join aid, ContextProcessId_decimal
+    [search event_platform=win event_simpleName=CreateThreadReflectiveDll]
+| eval ShortCmd=substr(CommandLine,1,100)
+| eval CallStackModuleNames=split(CallStackModuleNames, "|")
+| eval n=mvfilter(match(CallStackModuleNames, ".*exe") OR match(CallStackModuleNames, ".*dll"))
+| rex field=n "(?<callStack>.*(\.dll|\.exe)).*"
+| table ContextTimeStamp_decimal ComputerName UserName FileName ShortCmd ReflectiveDllName callStack
+| convert ctime(ContextTimeStamp_decimal)
+| rename ContextTimeStamp_decimal as dllReflectiveLoadTime
+```

--- a/Queries-Only/Cool-Query-Friday/2021-05-07 - Cool Query Friday - If You're Listening.md
+++ b/Queries-Only/Cool-Query-Friday/2021-05-07 - Cool Query Friday - If You're Listening.md
@@ -1,0 +1,99 @@
+---
+title: "If You're Listening"
+date: 2021-05-07
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/n6xwv6/20210507_cool_query_friday_if_youre_listening/"
+mitre: []
+series: Cool Query Friday
+---
+
+# If You're Listening
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/n6xwv6/20210507_cool_query_friday_if_youre_listening/](https://www.reddit.com/r/crowdstrike/comments/n6xwv6/20210507_cool_query_friday_if_youre_listening/) — by Andrew-CS (CrowdStrike) — 2021-05-07
+
+Welcome to our tenth installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk though of each step (3) application in the wild.
+
+## Query 1
+```cql
+event_simpleName=NetworkListenIP4 OR event_simpleName=NetworkListenIP6
+| stats dc(aid) as endpointCount dc(LPort) as listeningPorts by event_simpleName
+```
+
+## Query 2
+```cql
+event_platform=win event_simpleName=NetworkListenIP4 
+| fields aid, aip, LocalAddressIP4, ComputerName, Protocol_decimal, LPort
+```
+
+## Query 3
+```cql
+event_platform=win event_simpleName=NetworkListenIP4 
+| fields aid, aip, LocalAddressIP4, ComputerName, Protocol_decimal, LPort 
+| lookup aid_master aid OUTPUT ProductType Version
+| eval Protocol=case(Protocol_decimal=1, "ICMP", Protocol_decimal=6, "TCP", Protocol_decimal=17, "UDP", Protocol_decimal=58, "IPv6-ICMP") 
+| eval SystemType=case(ProductType=1, "Workstation", ProductType=2, "Domain Controller", ProductType=3, "Server")
+```
+
+## Query 4
+```cql
+event_platform=win event_simpleName=NetworkListenIP4 
+| fields aid, aip, LocalAddressIP4, ComputerName, Protocol_decimal, LPort 
+| lookup aid_master aid OUTPUT ProductType Version
+| eval Protocol=case(Protocol_decimal=1, "ICMP", Protocol_decimal=6, "TCP", Protocol_decimal=17, "UDP", Protocol_decimal=58, "IPv6-ICMP") 
+| eval SystemType=case(ProductType=1, "Workstation", ProductType=2, "Domain Controller", ProductType=3, "Server")
+| stats dc(LPort) as openPortCount values(LPort) as openPorts by aid, ComputerName, SystemType, Version, Protocol, aip, LocalAddressIP4
+| sort -openPortCount, +ComputerName
+```
+
+## Query 5
+```cql
+event_platform=win event_simpleName=NetworkListenIP4 
+| fields aid, aip, LocalAddressIP4, ComputerName, Protocol_decimal, LPort 
+| lookup aid_master aid OUTPUT ProductType Version
+| eval Protocol=case(Protocol_decimal=1, "ICMP", Protocol_decimal=6, "TCP", Protocol_decimal=17, "UDP", Protocol_decimal=58, "IPv6-ICMP") 
+| eval SystemType=case(ProductType=1, "Workstation", ProductType=2, "Domain Controller", ProductType=3, "Server")
+| stats values(Protocol) as listeningProtocols dc(aid) as systemCount values(Version) as osVersions by SystemType, LPort
+| rename LPort as listeningPort, SystemType as systemType
+| sort - systemCount
+```
+
+## Query 6
+```cql
+event_platform=win event_simpleName=NetworkListenIP4 LPort<10000
+| fields aid, aip, LocalAddressIP4, ComputerName, Protocol_decimal, LPort 
+| lookup aid_master aid OUTPUT ProductType Version
+| eval Protocol=case(Protocol_decimal=1, "ICMP", Protocol_decimal=6, "TCP", Protocol_decimal=17, "UDP", Protocol_decimal=58, "IPv6-ICMP") 
+| eval SystemType=case(ProductType=1, "Workstation", ProductType=2, "Domain Controller", ProductType=3, "Server")
+| stats values(Protocol) as listeningProtocols dc(aid) as systemCount values(Version) as osVersions by SystemType, LPort
+| rename LPort as listeningPort, SystemType as systemType
+| sort - systemCount
+```
+
+## Query 7
+```cql
+| eval falconPID=mvappend(TargetProcessId_decimal, ContextProcessId_decimal)
+```
+
+## Query 8
+```cql
+| lookup aid_master aid OUTPUT ProductType Version
+| eval Protocol=case(Protocol_decimal=1, "ICMP", Protocol_decimal=6, "TCP", Protocol_decimal=17, "UDP", Protocol_decimal=58, "IPv6-ICMP") 
+| eval SystemType=case(ProductType=1, "Workstation", ProductType=2, "Domain Controller", ProductType=3, "Server")
+```
+
+## Query 9
+```cql
+| stats dc(event_simpleName) as events values(SystemType) as systemType values(Version) as osVersion latest(aip) as externalIP latest(LocalAddressIP4) as internalIP values(FileName) as listeningFile values(UserName) as userName values(UserSid_readable) as userSID values(LPort) as listeningPort values(Protocol) as listeningProtocol by aid, ComputerName, falconPID
+| where events > 1
+```
+
+## Query 10
+```cql
+(event_platform=win AND event_simpleName=NetworkListenIP4 AND LPort>10000) OR (event_platform=win AND event_simpleName=ProcessRollup2) 
+| eval falconPID=mvappend(TargetProcessId_decimal, ContextProcessId_decimal)
+| lookup aid_master aid OUTPUT ProductType Version
+| eval Protocol=case(Protocol_decimal=1, "ICMP", Protocol_decimal=6, "TCP", Protocol_decimal=17, "UDP", Protocol_decimal=58, "IPv6-ICMP") 
+| eval SystemType=case(ProductType=1, "Workstation", ProductType=2, "Domain Controller", ProductType=3, "Server")
+| stats dc(event_simpleName) as events latest(SystemType) as systemType latest(Version) as osVersion latest(aip) as externalIP latest(LocalAddressIP4) as internalIP values(FileName) as listeningFile values(UserName) as userName values(UserSid_readable) as userSID values(LPort) as listeningPort values(Protocol) as listeningProtocol by aid, ComputerName, falconPID
+| where events > 1
+```

--- a/Queries-Only/Cool-Query-Friday/2021-05-07 - Cool Query Friday - If You're Listening.md
+++ b/Queries-Only/Cool-Query-Friday/2021-05-07 - Cool Query Friday - If You're Listening.md
@@ -97,3 +97,11 @@ event_platform=win event_simpleName=NetworkListenIP4 LPort<10000
 | stats dc(event_simpleName) as events latest(SystemType) as systemType latest(Version) as osVersion latest(aip) as externalIP latest(LocalAddressIP4) as internalIP values(FileName) as listeningFile values(UserName) as userName values(UserSid_readable) as userSID values(LPort) as listeningPort values(Protocol) as listeningProtocol by aid, ComputerName, falconPID
 | where events > 1
 ```
+
+## Community & Staff Additions
+*Harvested from this post's [r/CrowdStrike](https://www.reddit.com/r/crowdstrike/) comment thread — not part of the original CQF post. **[CS]** = CrowdStrike staff · **[Community]** = other r/CrowdStrike users. Upvote scores shown for context.*
+
+### Operational caveats
+
+> Hi there. You have to enable network events for Linux. It's in the Linux prevention policy: [https://imgur.com/a/sW4MqW1](https://imgur.com/a/sW4MqW1) We provide this option on Linux in the event customers want to disable it on high-performance compute clusters that are calibrated to a very, very precise performance metric.
+— [CS] Andrew-CS · score 2

--- a/Queries-Only/Cool-Query-Friday/2021-05-14 - Cool Query Friday - Password Age and Reused Local Passwords.md
+++ b/Queries-Only/Cool-Query-Friday/2021-05-14 - Cool Query Friday - Password Age and Reused Local Passwords.md
@@ -1,0 +1,74 @@
+---
+title: "Password Age and Reused Local Passwords"
+date: 2021-05-14
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/ncb5z7/20210514_cool_query_friday_password_age_and/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Password Age and Reused Local Passwords
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/ncb5z7/20210514_cool_query_friday_password_age_and/](https://www.reddit.com/r/crowdstrike/comments/ncb5z7/20210514_cool_query_friday_password_age_and/) — by Andrew-CS (CrowdStrike) — 2021-05-14
+
+Welcome to our eleventh installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk though of each step (3) application in the wild.
+
+## Query 1
+```cql
+| fields, aid, event_platform, ComputerName, LocalAddressIP4, LogonDomain, LogonServer, LogonTime_decimal, LogonType_decimal, PasswordLastSet_decimal, ProductType, UserIsAdmin_decimal, UserName, UserSid_readable
+```
+
+## Query 2
+```cql
+| where isnotnull(PasswordLastSet_decimal)
+| eval LogonType=case(LogonType_decimal="2", "Interactive", LogonType_decimal="3", "Network", LogonType_decimal="4", "Batch", LogonType_decimal="5", "Service", LogonType_decimal="6", "Proxy", LogonType_decimal="7", "Unlock", LogonType_decimal="8", "Network Cleartext", LogonType_decimal="9", "New Credentials", LogonType_decimal="10", "RDP", LogonType_decimal="11", "Cached Credentials", LogonType_decimal="12", "Auditing", LogonType_decimal="13", "Unlock Workstation")
+| eval Product=case(ProductType = "1","Workstation", ProductType = "2","Domain Controller", ProductType = "3","Server") 
+| eval UserIsAdmin=case(UserIsAdmin_decimal = "1","Admin", UserIsAdmin_decimal = "0","Standard")
+```
+
+## Query 3
+```cql
+| eval passwordAge=now()-PasswordLastSet_decimal
+```
+
+## Query 4
+```cql
+| eval passwordAge=round(passwordAge/60/60/24,0)
+```
+
+## Query 5
+```cql
+| stats values(event_platform) as Platform latest(passwordAge) as passwordAge values(UserIsAdmin) as adminStatus by UserName, UserSid_readable
+| sort - passwordAge
+```
+
+## Query 6
+```cql
+| where passwordAge > 179
+```
+
+## Query 7
+```cql
+event_simpleName=UserLogon
+| where isnotnull(PasswordLastSet_decimal)
+| fields, aid, event_platform, ComputerName, LocalAddressIP4, LogonDomain, LogonServer, LogonTime_decimal, LogonType_decimal, PasswordLastSet_decimal, ProductType, UserIsAdmin_decimal, UserName, UserSid_readable
+| eval LogonType=case(LogonType_decimal="2", "Interactive", LogonType_decimal="3", "Network", LogonType_decimal="4", "Batch", LogonType_decimal="5", "Service", LogonType_decimal="6", "Proxy", LogonType_decimal="7", "Unlock", LogonType_decimal="8", "Network Cleartext", LogonType_decimal="9", "New Credentials", LogonType_decimal="10", "RDP", LogonType_decimal="11", "Cached Credentials", LogonType_decimal="12", "Auditing", LogonType_decimal="13", "Unlock Workstation")
+| eval Product=case(ProductType = "1","Workstation", ProductType = "2","Domain Controller", ProductType = "3","Server") 
+| eval UserIsAdmin=case(UserIsAdmin_decimal = "1","Admin", UserIsAdmin_decimal = "0","Standard")
+| eval passwordAge=now()-PasswordLastSet_decimal
+| eval passwordAge=round(passwordAge/60/60/24,0)
+| stats values(event_platform) as Platform latest(passwordAge) as passwordAge values(UserIsAdmin) as adminStatus by UserName, UserSid_readable
+| sort - passwordAge
+| where passwordAge > 179
+```
+
+## Query 8
+```cql
+event_simpleName=UserLogon
+| where isnotnull(PasswordLastSet_decimal)
+| where LogonDomain=ComputerName
+| stats dc(UserSid_readable) as distinctSID values(UserSid_readable) as userSIDs dc(UserName) as distinctUserNames values(UserName) as userNames count(aid) as totalLogins dc(aid) as distinctEndpoints by PasswordLastSet_decimal, event_platform
+| sort - distinctEndpoints
+| convert ctime(PasswordLastSet_decimal) 
+| where distinctEndpoints > 1
+```

--- a/Queries-Only/Cool-Query-Friday/2021-05-14 - Cool Query Friday - Password Age and Reused Local Passwords.md
+++ b/Queries-Only/Cool-Query-Friday/2021-05-14 - Cool Query Friday - Password Age and Reused Local Passwords.md
@@ -72,3 +72,31 @@ event_simpleName=UserLogon
 | convert ctime(PasswordLastSet_decimal) 
 | where distinctEndpoints > 1
 ```
+
+## Community & Staff Additions
+*Harvested from this post's [r/CrowdStrike](https://www.reddit.com/r/crowdstrike/) comment thread — not part of the original CQF post. **[CS]** = CrowdStrike staff · **[Community]** = other r/CrowdStrike users. Upvote scores shown for context.*
+
+### Query variants
+
+```cql
+event_simpleName=UserLogon
+| eval UserName=lower(UserName) 
+[...]
+```
+— [CS] Andrew-CS · comment score 1
+
+```cql
+event_simpleName=UserLogon UserIsAdmin_decimal=0
+| where isnotnull(PasswordLastSet_decimal) | fields company, cid, aid, event_platform, ComputerName, LocalAddressIP4, LogonDomain, LogonServer, LogonTime_decimal, LogonType_decimal, PasswordLastSet_decimal, ProductType, UserIsAdmin_decimal, UserName, UserSid_readable | eval LogonType=case(LogonType_decimal="2", "Interactive", LogonType_decimal="3", "Network", LogonType_decimal="4", "Batch", LogonType_decimal="5", "Service", LogonType_decimal="6", "Proxy", LogonType_decimal="7", "Unlock", LogonType_decimal="8", "Network Cleartext", LogonType_decimal="9", "New Credentials", LogonType_decimal="10", "RDP", LogonType_decimal="11", "Cached Credentials", LogonType_decimal="12", "Auditing", LogonType_decimal="13", "Unlock Workstation") | eval Product=case(ProductType = "1","Workstation", ProductType = "2","Domain Controller", ProductType = "3","Server") | eval UserIsAdmin=case(UserIsAdmin_decimal = "1","Admin", UserIsAdmin_decimal = "0","Standard") | eval passwordAge=now()-PasswordLastSet_decimal | eval passwordAge=round(passwordAge/60/60/24,0) | stats values(event_platform) as Platform latest(passwordAge) as passwordAge values(UserIsAdmin) as adminStatus by UserName, UserSid_readable, company, cid | sort - passwordAge | where passwordAge > 179
+```
+— [CS] Andrew-CS · comment score 3
+
+### Q&A
+
+**Q — [Community] BinaryN1nja:** If you have multiple companies and you want to show that in the query...where would you put "company" to show in stats? Also, if you wanted to remove standard users where would you put | where adminStatus!=Standard ?
+
+**A — [CS] Andrew-CS:** Hi there. Try this: event_simpleName=UserLogon UserIsAdmin_decimal=0 | where isnotnull(PasswordLastSet_decimal) | fields company, cid, aid, event_platform, ComputerName, LocalAddressIP4, LogonDomain, LogonServer, LogonTime_decimal, LogonType_decimal, PasswordLastSet_decimal, ProductType, UserIsAdmin_decimal, UserName, UserSid_readable | eval LogonType=case(LogonType_decimal="2", "Interactive", LogonType_decimal="3", "Network", LogonType_decimal="4", "Batch", LogonType_decimal="5", "Service", Log …
+
+**Q — [Community] amjcyb:** If I didn't understund wrong this will get a username that has the same password in different endpoints, so it's nice to hunt for those localadmins with same password. But is it possible to hunt for different users with same password?
+
+**A — [CS] Andrew-CS:** Hi there. What we're looking for here are local passwords that have an identical "last set" date right down to the microsecond. This works really well for local accounts that have been cloned onto a system via imaging or some other means, however... this does not cover all use cases where local admin accounts might share a password... If I set my local password to `fluffybunny11` and then you set your password to `fluffybunny11` a minute later, the "last set" date will be completely different bu …

--- a/Queries-Only/Cool-Query-Friday/2021-05-21 - Cool Query Friday - Internal Network Connections and Firewall Rules.md
+++ b/Queries-Only/Cool-Query-Friday/2021-05-21 - Cool Query Friday - Internal Network Connections and Firewall Rules.md
@@ -1,0 +1,106 @@
+---
+title: "Internal Network Connections and Firewall Rules"
+date: 2021-05-21
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/nhs906/20210521_cool_query_friday_internal_network/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Internal Network Connections and Firewall Rules
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/nhs906/20210521_cool_query_friday_internal_network/](https://www.reddit.com/r/crowdstrike/comments/nhs906/20210521_cool_query_friday_internal_network/) — by Andrew-CS (CrowdStrike) — 2021-05-21
+
+Welcome to our twelfth installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk though of each step (3) application in the wild.
+
+## Query 1
+```cql
+event_simpleName=NetworkListenIP4
+| fields aid, ComputerName, LocalAddressIP4, LocalPort_decimal, ProductType, Protocol_decimal
+```
+
+## Query 2
+```cql
+event_simpleName=NetworkListenIP4 ProductType!=1
+| fields aid, ComputerName, LocalAddressIP4, LocalPort_decimal, ProductType, Protocol_decimal
+```
+
+## Query 3
+```cql
+event_simpleName=NetworkListenIP4 ProductType!=1
+| lookup local=true aid_master aid OUTPUT Version, MachineDomain, OU, SiteName, Timezone 
+| fields aid, ComputerName, LocalAddressIP4, LocalPort_decimal, MachineDomain, OU, ProductType, Protocol_decimal, SiteName, Timezone, Version
+```
+
+## Query 4
+```cql
+event_simpleName=NetworkListenIP4 ProductType!=1 (LocalAddressIP4=172.16.0.0/12 OR LocalAddressIP4=192.168.0.0/16 OR LocalAddressIP4=10.0.0.0/8)
+| lookup local=true aid_master aid OUTPUT Version, MachineDomain, OU, SiteName, Timezone 
+| fields aid, ComputerName, LocalAddressIP4, LocalPort_decimal, MachineDomain, OU, ProductType, Protocol_decimal, SiteName, Timezone, Version
+```
+
+## Query 5
+```cql
+| lookup local=true aid_master aid OUTPUT Version, MachineDomain, OU, SiteName, Timezone
+```
+
+## Query 6
+```cql
+| eval Protocol_decimal=case(Protocol_decimal=1, "ICMP", Protocol_decimal=6, "TCP", Protocol_decimal=17, "UDP", Protocol_decimal=58, "IPv6-ICMP") 
+| stats values(ComputerName) as hostNames values(LocalAddressIP4) as localIPs values(Version) as osVersion values(MachineDomain) as machineDomain values(OU) as organizationalUnit values(SiteName) as siteName values(Timezone) as timeZone values(LocalPort_decimal) as listeningPorts values(Protocol_decimal) as protocolsUsed by aid
+```
+
+## Query 7
+```cql
+event_simpleName=NetworkListenIP4 ProductType!=1 (LocalAddressIP4=172.16.0.0/12 OR LocalAddressIP4=192.168.0.0/16 OR LocalAddressIP4=10.0.0.0/8)
+| lookup local=true aid_master aid OUTPUT Version, MachineDomain, OU, SiteName, Timezone 
+| fields aid, ComputerName, LocalAddressIP4, LocalPort_decimal, MachineDomain, OU, ProductType, Protocol_decimal, SiteName, Timezone, Version
+| where LocalPort_decimal < 10000
+| eval Protocol_decimal=case(Protocol_decimal=1, "ICMP", Protocol_decimal=6, "TCP", Protocol_decimal=17, "UDP", Protocol_decimal=58, "IPv6-ICMP") 
+| stats values(ComputerName) as hostNames values(LocalAddressIP4) as localIPs values(Version) as osVersion values(MachineDomain) as machineDomain values(OU) as organizationalUnit values(SiteName) as siteName values(Timezone) as timeZone values(LocalPort_decimal) as listeningPorts values(Protocol_decimal) as protocolsUsed by aid
+```
+
+## Query 8
+```cql
+event_simpleName=NetworkListenIP4 ProductType!=1 (LocalAddressIP4=172.16.0.0/12 OR LocalAddressIP4=192.168.0.0/16 OR LocalAddressIP4=10.0.0.0/8)
+| where LocalPort_decimal < 10000
+| eval Protocol_decimal=case(Protocol_decimal=1, "ICMP", Protocol_decimal=6, "TCP", Protocol_decimal=17, "UDP", Protocol_decimal=58, "IPv6-ICMP") 
+| stats dc(aid) as uniqueServers by LocalPort_decimal, Protocol_decimal
+| sort - uniqueServers
+| rename LocalPort_decimal as listeningPort, Protocol_decimal as Protocol
+```
+
+## Query 9
+```cql
+event_simpleName=NetworkListenIP4 ProductType=1 (RemoteIP=172.16.0.0/12 OR RemoteIP=192.168.0.0/16 OR RemoteIP=10.0.0.0/8)
+| where RPort<10000
+| eval Protocol_decimal=case(Protocol_decimal=1, "ICMP", Protocol_decimal=6, "TCP", Protocol_decimal=17, "UDP", Protocol_decimal=58, "IPv6-ICMP") 
+| stats dc(aid) as uniqueEndpoints count(aid) as totalConnections by RPort, Protocol_decimal
+| rename RPort as remotePort, Protocol_decimal as Protocol
+| sort +Protocol -uniqueEndpoints
+```
+
+## Query 10
+```cql
+| where RPort<10000
+```
+
+## Query 11
+```cql
+| eval Protocol_decimal=case(Protocol_decimal=1, "ICMP", Protocol_decimal=6, "TCP", Protocol_decimal=17, "UDP", Protocol_decimal=58, "IPv6-ICMP")
+```
+
+## Query 12
+```cql
+| stats dc(aid) as uniqueEndpoints count(aid) as totalConnections by RPort, Protocol_decimal
+```
+
+## Query 13
+```cql
+| rename RPort as remotePort, Protocol_decimal as Protocol
+```
+
+## Query 14
+```cql
+| sort +Protocol -uniqueEndpoints
+```

--- a/Queries-Only/Cool-Query-Friday/2021-06-04 - Cool Query Friday - Stats.md
+++ b/Queries-Only/Cool-Query-Friday/2021-06-04 - Cool Query Friday - Stats.md
@@ -1,0 +1,86 @@
+---
+title: "Stats"
+date: 2021-06-04
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/ns4k9q/20210604_cool_query_friday_stats/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Stats
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/ns4k9q/20210604_cool_query_friday_stats/](https://www.reddit.com/r/crowdstrike/comments/ns4k9q/20210604_cool_query_friday_stats/) — by Andrew-CS (CrowdStrike) — 2021-06-04
+
+Welcome to our thirteenth installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk though of each step (3) application in the wild.
+
+## Query 1
+```cql
+[...]
+| stats function(field) as outputName by field
+```
+
+## Query 2
+```cql
+event_platform=win event_simpleName=ProcessRollup2 FileName=PowerShell.exe
+| stats count(aid) as psExecutionCount by FileName
+```
+
+## Query 3
+```cql
+event_platform=win event_simpleName=ProcessRollup2 FileName=PowerShell.exe
+| stats count(aid) as psExecutionCount dc(aid) as uniqueSystemCount by FileName
+```
+
+## Query 4
+```cql
+event_platform=win event_simpleName=ProcessRollup2 FileName=PowerShell.exe
+| stats count(aid) as psExecutionCount dc(aid) as uniqueSystemCount earliest(ProcessStartTime_decimal) as earliestExecution latest(ProcessStartTime_decimal) as latestExecution by FileName
+```
+
+## Query 5
+```cql
+event_platform=win event_simpleName=ProcessRollup2 FileName=PowerShell.exe
+| stats count(aid) as psExecutionCount dc(aid) as uniqueSystemCount earliest(ProcessStartTime_decimal) as earliestExecution latest(ProcessStartTime_decimal) as latestExecution by FileName
+| convert ctime(earliestExecution) ctime(latestExecution)
+```
+
+## Query 6
+```cql
+event_platform=win event_simpleName=ProcessRollup2 FileName=PowerShell.exe
+| stats count(aid) as psExecutionCount dc(aid) as uniqueSystemCount earliest(ProcessStartTime_decimal) as earliestExecution latest(ProcessStartTime_decimal) as latestExecution values(ComputerName) as endpointHostnames by FileName
+| convert ctime(earliestExecution) ctime(latestExecution)
+```
+
+## Query 7
+```cql
+| stats sum(NumberField) as mySumOutput
+```
+
+## Query 8
+```cql
+| stats avg(NumberField) as myAvgOutput
+```
+
+## Query 9
+```cql
+event_platform=win event_simpleName=ProcessRollup2 FileName=PowerShell.exe
+| stats count(aid) as psExecutionCount dc(aid) as uniqueSystemCount earliest(ProcessStartTime_decimal) as earliestExecution latest(ProcessStartTime_decimal) as latestExecution values(ComputerName) as endpointHostnames by aid
+| convert ctime(earliestExecution) ctime(latestExecution)
+| sort - psExecutionCount
+```
+
+## Query 10
+```cql
+event_platform=win event_simpleName=ProcessRollup2 FileName=PowerShell.exe
+| stats count(aid) as psExecutionCount dc(aid) as uniqueSystemCount earliest(ProcessStartTime_decimal) as earliestExecution latest(ProcessStartTime_decimal) as latestExecution values(ComputerName) as endpointHostnames by SHA256HashData
+| convert ctime(earliestExecution) ctime(latestExecution)
+| sort - psExecutionCount
+```
+
+## Query 11
+```cql
+event_platform=win event_simpleName=ProcessRollup2 FileName=PowerShell.exe
+| stats count(aid) as psExecutionCount dc(aid) as uniqueSystemCount earliest(ProcessStartTime_decimal) as earliestExecution latest(ProcessStartTime_decimal) as latestExecution values(ComputerName) as endpointHostnames by ParentBaseFileName 
+| convert ctime(earliestExecution) ctime(latestExecution)
+| sort - psExecutionCount
+```

--- a/Queries-Only/Cool-Query-Friday/2021-06-11 - Cool Query Friday - Hunting Rogue DNS Servers.md
+++ b/Queries-Only/Cool-Query-Friday/2021-06-11 - Cool Query Friday - Hunting Rogue DNS Servers.md
@@ -1,0 +1,84 @@
+---
+title: "Hunting Rogue DNS Servers"
+date: 2021-06-11
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/nxfcnu/20210611_cool_query_friday_hunting_rogue_dns/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Hunting Rogue DNS Servers
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/nxfcnu/20210611_cool_query_friday_hunting_rogue_dns/](https://www.reddit.com/r/crowdstrike/comments/nxfcnu/20210611_cool_query_friday_hunting_rogue_dns/) — by Andrew-CS (CrowdStrike) — 2021-06-11
+
+Welcome to our fourteenth installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk though of each step (3) application in the wild.
+
+## Query 1
+```cql
+event_simpleName=DnsRequest 
+| where isnotnull(RespondingDnsServer)
+| fields aip, aid, cid, company, ComputerName, DomainName, RespondingDnsServer
+```
+
+## Query 2
+```cql
+[...]
+| rex field=DomainName "[@\.](?<tlDomain>\w+\.\w+)$"
+```
+
+## Query 3
+```cql
+[...]
+| stats dc(aid) as uniqueEndpoints count(aid) as totalResoultions dc(tlDomain) as domainsResolved by RespondingDnsServer
+| sort - totalResoultions
+```
+
+## Query 4
+```cql
+event_simpleName=DnsRequest 
+| where isnotnull(RespondingDnsServer)
+| fields aip, aid, cid, company, ComputerName, DomainName, RespondingDnsServer
+| rex field=DomainName "[\.](?<tlDomain>\w+\.\w+)$"
+| stats dc(aid) as uniqueEndpoints count(aid) as totalResoultions dc(tlDomain) as domainsResolved by RespondingDnsServer
+| sort - totalResoultions
+```
+
+## Query 5
+```cql
+event_simpleName=DnsRequest 
+| where isnotnull(RespondingDnsServer)
+| fields aip, aid, cid, company, ComputerName, DomainName, RespondingDnsServer, LocalAddressIP4
+| rex field=DomainName "[\.](?<tlDomain>\w+\.\w+)$"
+| top tlDomain limit=50
+```
+
+## Query 6
+```cql
+event_simpleName=DnsRequest 
+| where isnotnull(RespondingDnsServer)
+| fields aip, aid, cid, company, ComputerName, DomainName, RespondingDnsServer, LocalAddressIP4
+| rex field=DomainName "[\.](?<tlDomain>\w+\.\w+)$"
+| top tlDomain by RespondingDnsServer limit=1
+| sort +RespondingDnsServer, -count
+```
+
+## Query 7
+```cql
+event_simpleName=DnsRequest 
+| where isnotnull(RespondingDnsServer)
+| fields aip, aid, cid, company, ComputerName, DomainName, RespondingDnsServer, LocalAddressIP4
+| rex field=DomainName "[\.](?<tlDomain>\w+\.\w+)$" 
+| top DomainName by tlDomain limit=5
+| stats values(DomainName) as domainName by tlDomain
+| sort + tlDomain
+```
+
+## Query 8
+```cql
+event_simpleName=DnsRequest 
+| where isnotnull(RespondingDnsServer)
+| fields aip, aid, cid, company, ComputerName, DomainName, RespondingDnsServer, LocalAddressIP4
+| rex field=DomainName "[\.](?<tlDomain>\w+\.\w+)$" 
+| stats values(ComputerName) as endpointName count(DomainName) as totalResolutions by aid
+| sort - totalResolutions
+```

--- a/Queries-Only/Cool-Query-Friday/2021-06-18 - Cool Query Friday - User Added To Group.md
+++ b/Queries-Only/Cool-Query-Friday/2021-06-18 - Cool Query Friday - User Added To Group.md
@@ -84,3 +84,19 @@ event_simpleName=UserAccountAddedToGroup
 | convert ctime(endpointTime) ctime(cloudTime)
 | sort + endpointTime
 ```
+
+## Community & Staff Additions
+*Harvested from this post's [r/CrowdStrike](https://www.reddit.com/r/crowdstrike/) comment thread — not part of the original CQF post. **[CS]** = CrowdStrike staff · **[Community]** = other r/CrowdStrike users. Upvote scores shown for context.*
+
+### Query variants
+
+```cql
+| search NOT GrouRid_dec IN (500, 501)
+```
+— [CS] Andrew-CS · comment score 2
+
+### Q&A
+
+**Q — [Community] fang8280:** How do you exempt well known domain groups from being looked up? OR lets say if we know a set of Domain SID's that we want to exempt from the lookup process, how can those be exempted.
+
+**A — [CS] Andrew-CS:** >event\_simpleName=UserAccountAddedToGroup | fields aid, ComputerName, ContextTimeStamp\_decimal, DomainSid, GroupRid, LocalAddressIP4, UserRid, timestamp | eval GroupRid\_dec=tonumber(ltrim(tostring(GroupRid), "0"), 16) | eval UserRid\_dec=tonumber(ltrim(tostring(UserRid), "0"), 16) | eval UserSid\_readable=DomainSid. "-" .UserRid\_dec | lookup local=true usersid\_username\_win.csv UserSid\_readable OUTPUT UserName | lookup local=true grouprid\_wingroup.csv GroupRid\_dec OUTPUT WinGroup | filln …

--- a/Queries-Only/Cool-Query-Friday/2021-06-18 - Cool Query Friday - User Added To Group.md
+++ b/Queries-Only/Cool-Query-Friday/2021-06-18 - Cool Query Friday - User Added To Group.md
@@ -1,0 +1,86 @@
+---
+title: "User Added To Group"
+date: 2021-06-18
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/o2onsf/20210618_cool_query_friday_user_added_to_group/"
+mitre: [T1098]
+series: Cool Query Friday
+---
+
+# User Added To Group
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/o2onsf/20210618_cool_query_friday_user_added_to_group/](https://www.reddit.com/r/crowdstrike/comments/o2onsf/20210618_cool_query_friday_user_added_to_group/) — by Andrew-CS (CrowdStrike) — 2021-06-18
+
+Welcome to our fourteenth installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk though of each step (3) application in the wild.
+
+## Query 1
+```cql
+event_simpleName=UserAccountAddedToGroup 
+| fields aid, ComputerName, ContextTimeStamp_decimal, DomainSid, GroupRid, LocalAddressIP4, UserRid, timestamp
+```
+
+## Query 2
+```cql
+event_simpleName=UserAccountAddedToGroup 
+| fields aid, ComputerName, ContextTimeStamp_decimal, DomainSid, GroupRid, LocalAddressIP4, UserRid, timestamp
+| eval GroupRid_dec=tonumber(ltrim(tostring(GroupRid), "0"), 16)
+| eval UserRid_dec=tonumber(ltrim(tostring(UserRid), "0"), 16)
+```
+
+## Query 3
+```cql
+event_simpleName=UserAccountAddedToGroup 
+| fields aid, ComputerName, ContextTimeStamp_decimal, DomainSid, GroupRid, LocalAddressIP4, UserRid, timestamp
+| eval GroupRid_dec=tonumber(ltrim(tostring(GroupRid), "0"), 16)
+| eval UserRid_dec=tonumber(ltrim(tostring(UserRid), "0"), 16)
+| eval UserSid_readable=DomainSid. "-" .UserRid_dec
+```
+
+## Query 4
+```cql
+[...]
+| lookup local=true usersid_username_win.csv UserSid_readable OUTPUT UserName
+| lookup local=true grouprid_wingroup.csv GroupRid_dec OUTPUT WinGroup
+```
+
+## Query 5
+```cql
+[...]
+| fillnull value="Unknown" UserName, WinGroup
+| stats values(ContextTimeStamp_decimal) as endpointTime values(timestamp) as cloudTime by UserSid_readable, UserName, WinGroup, GroupRid_dec, ComputerName, aid
+| eval cloudTime=cloudTime/1000
+| convert ctime(endpointTime) ctime(cloudTime)
+| sort + endpointTime
+```
+
+## Query 6
+```cql
+event_simpleName=UserAccountAddedToGroup 
+| fields aid, ComputerName, ContextTimeStamp_decimal, DomainSid, GroupRid, LocalAddressIP4, UserRid, timestamp
+| eval GroupRid_dec=tonumber(ltrim(tostring(GroupRid), "0"), 16)
+| eval UserRid_dec=tonumber(ltrim(tostring(UserRid), "0"), 16)
+| eval UserSid_readable=DomainSid. "-" .UserRid_dec
+| lookup local=true usersid_username_win.csv UserSid_readable OUTPUT UserName
+| lookup local=true grouprid_wingroup.csv GroupRid_dec OUTPUT WinGroup
+| fillnull value="Unknown" UserName, WinGroup
+| stats values(ContextTimeStamp_decimal) as endpointTime values(timestamp) as cloudTime by UserSid_readable, UserName, WinGroup, GroupRid_dec, ComputerName, aid
+| eval cloudTime=cloudTime/1000
+| convert ctime(endpointTime) ctime(cloudTime)
+| sort + endpointTime
+```
+
+## Query 7
+```cql
+event_simpleName=UserAccountAddedToGroup 
+| fields aid, ComputerName, ContextTimeStamp_decimal, DomainSid, GroupRid, LocalAddressIP4, UserRid, timestamp
+| eval GroupRid_dec=tonumber(ltrim(tostring(GroupRid), "0"), 16)
+| eval UserRid_dec=tonumber(ltrim(tostring(UserRid), "0"), 16)
+| eval UserSid_readable=DomainSid. "-" .UserRid_dec
+| lookup local=true usersid_username_win.csv UserSid_readable OUTPUT UserName
+| lookup local=true grouprid_wingroup.csv GroupRid_dec OUTPUT WinGroup
+| fillnull value="Unknown" UserName, WinGroup
+| stats dc(UserSid_readable) as userAccountsAdded values(WinGroup) as windowsGroupsManipulated values(GroupRid_dec) as groupRIDs by ComputerName, aid
+| eval cloudTime=cloudTime/1000
+| convert ctime(endpointTime) ctime(cloudTime)
+| sort + endpointTime
+```

--- a/Queries-Only/Cool-Query-Friday/2021-06-25 - Cool Query Friday - Queries, Custom IOAs, and You A Love Story.md
+++ b/Queries-Only/Cool-Query-Friday/2021-06-25 - Cool Query Friday - Queries, Custom IOAs, and You A Love Story.md
@@ -1,0 +1,39 @@
+---
+title: "Queries, Custom IOAs, and You: A Love Story"
+date: 2021-06-25
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/o7nvts/20210625_cool_query_friday_queries_custom_ioas/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Queries, Custom IOAs, and You: A Love Story
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/o7nvts/20210625_cool_query_friday_queries_custom_ioas/](https://www.reddit.com/r/crowdstrike/comments/o7nvts/20210625_cool_query_friday_queries_custom_ioas/) — by Andrew-CS (CrowdStrike) — 2021-06-25
+
+Welcome to our fifteenth installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk though of each step (3) application in the wild.
+
+## Query 1
+```cql
+event_platform=win event_simpleName=ProcessRollup2 FileName=powershell.exe ProductType=3 
+| stats  dc(aid) as endpointCount count(aid) as executionCount by ParentBaseFileName, FileName  
+| sort  - executionCount
+```
+
+## Query 2
+```cql
+event_platform=win event_simpleName=ProcessRollup2 FileName=powershell.exe ProductType=3 
+| lookup aid_policy.csv aid OUTPUT groups
+| eval groups=replace(groups, "'", "\"")
+| spath input=groups output=group_id path={}
+| mvexpand group_id
+| lookup group_info.csv group_id OUTPUT name 
+| stats  dc(aid) as endpointCount count(aid) as executionCount by ParentBaseFileName, FileName, name  
+| sort  - executionCount
+```
+
+## Query 3
+```cql
+event_simpleName=CustomIOABasicProcessDetectionInfoEvent TemplateInstanceId_decimal=226 
+|  stats dc(aid) as endpointCount count(aid) as alertCount by ParentImageFileName
+```

--- a/Queries-Only/Cool-Query-Friday/2021-06-25 - Cool Query Friday - Queries, Custom IOAs, and You A Love Story.md
+++ b/Queries-Only/Cool-Query-Friday/2021-06-25 - Cool Query Friday - Queries, Custom IOAs, and You A Love Story.md
@@ -37,3 +37,20 @@ event_platform=win event_simpleName=ProcessRollup2 FileName=powershell.exe Produ
 event_simpleName=CustomIOABasicProcessDetectionInfoEvent TemplateInstanceId_decimal=226 
 |  stats dc(aid) as endpointCount count(aid) as alertCount by ParentImageFileName
 ```
+
+## Community & Staff Additions
+*Harvested from this post's [r/CrowdStrike](https://www.reddit.com/r/crowdstrike/) comment thread — not part of the original CQF post. **[CS]** = CrowdStrike staff · **[Community]** = other r/CrowdStrike users. Upvote scores shown for context.*
+
+### Query variants
+
+```cql
+event_platform=win event_simpleName=ProcessRollup2 FileName=powershell.exe ProductType=3
+| lookup local=true aid_policy.csv aid OUTPUT groups
+| eval groups=replace(groups, "'", "\"")
+| spath input=groups output=group_id path={}
+| mvexpand group_id
+| lookup local=true group_info.csv group_id OUTPUT name
+| stats dc(aid) as endpointCount count(aid) as executionCount by ParentBaseFileName, FileName, name
+| sort - executionCount
+```
+— [CS] Andrew-CS · comment score 2

--- a/Queries-Only/Cool-Query-Friday/2021-07-01 - Cool Query Friday - PrintNightmare POC Hunting (CVE-2021-1675).md
+++ b/Queries-Only/Cool-Query-Friday/2021-07-01 - Cool Query Friday - PrintNightmare POC Hunting (CVE-2021-1675).md
@@ -1,0 +1,47 @@
+---
+title: "PrintNightmare POC Hunting (CVE-2021-1675)"
+date: 2021-07-01
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/oblzcl/20210701_cool_query_friday_printnightmare_poc/"
+mitre: []
+series: Cool Query Friday
+---
+
+# PrintNightmare POC Hunting (CVE-2021-1675)
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/oblzcl/20210701_cool_query_friday_printnightmare_poc/](https://www.reddit.com/r/crowdstrike/comments/oblzcl/20210701_cool_query_friday_printnightmare_poc/) — by Andrew-CS (CrowdStrike) — 2021-07-01
+
+Welcome to our sixteenth installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk though of each step (3) application in the wild.
+
+## Query 1
+```cql
+event_simpleName=AsepValueUpdate RegObjectName="\\REGISTRY\\MACHINE\\SYSTEM\\ControlSet001\\Control\\Print\\Environments\\Windows x64\\Drivers\\Version-3\\123*" RegValueName="Data File" RegStringValue=* RegOperationType_decimal=1
+| lookup local=true aid_master aid OUTPUT Version MachineDomain OU SiteName
+| eval ProductType=case(ProductType = "1","Workstation", ProductType = "2","Domain Controller", ProductType = "3","Server") 
+| stats count as dllCount values(RegStringValue) as registryString, values(RegObjectName) as registryName by aid, ComputerName, ProductType, Version, MachineDomain, OU, SiteName
+```
+
+## Query 2
+```cql
+event_platform=win event_simpleName=ProcessRollup2 (ParentBaseFileName=spoolsv.exe AND FileName!=WerMgr.exe) 
+| stats dc(aid) as uniqueEndpoint count(aid) as executionCount by FileName SHA256HashData
+| sort + executionCount
+```
+
+## Query 3
+```cql
+event_platform=win event_simpleName=ProcessRollup2 FileName=spoolsv.exe
+| eval CallStackModuleNames=split(CallStackModuleNames, "|")
+| eval n=mvfilter(match(CallStackModuleNames, "(.*dll|.*exe)"))
+| rex field=n ".*\\\\Device\\\\HarddiskVolume\d+(?<loadedFile>.*(\.dll|\.exe)).*"
+| stats values(FileName) as fileName dc(SHA256HashData) as SHA256values dc(aid) as endpointCount count(aid) as loadCount by loadedFile
+| sort + loadCount
+```
+
+## Query 4
+```cql
+event_platform=win AND (event_simpleName=ProcessRollup2 AND FileName=spoolsv.exe) OR (event_simpleName=ImageHash) 
+| eval falconPID=mvappend(TargetProcessId_decimal, ContextProcessId_decimal) 
+| stats dc(event_simpleName) AS eventCount values(FileName) as dllsLoaded by aid, falconPID 
+| where eventCount > 1
+```

--- a/Queries-Only/Cool-Query-Friday/2021-07-01 - Cool Query Friday - PrintNightmare POC Hunting (CVE-2021-1675).md
+++ b/Queries-Only/Cool-Query-Friday/2021-07-01 - Cool Query Friday - PrintNightmare POC Hunting (CVE-2021-1675).md
@@ -45,3 +45,30 @@ event_platform=win AND (event_simpleName=ProcessRollup2 AND FileName=spoolsv.exe
 | stats dc(event_simpleName) AS eventCount values(FileName) as dllsLoaded by aid, falconPID 
 | where eventCount > 1
 ```
+
+## Community & Staff Additions
+*Harvested from this post's [r/CrowdStrike](https://www.reddit.com/r/crowdstrike/) comment thread — not part of the original CQF post. **[CS]** = CrowdStrike staff · **[Community]** = other r/CrowdStrike users. Upvote scores shown for context.*
+
+### Query variants
+
+```cql
+event_platform=win event_simpleName=ProcessRollup2 FileName=spoolsv.exe
+| eval CallStackModuleNames=split(CallStackModuleNames, "|")
+```
+— [CS] Andrew-CS · comment score 8
+
+```cql
+| eval n=mvfilter(match(CallStackModuleNames, "(.*dll|.*exe)"))
+```
+— [CS] Andrew-CS · comment score 8
+
+```cql
+| rex field=n ".*\\\\Device\\\\HarddiskVolume\d+(?<loadedFile>.*(\.dll|\.exe)).*"
+```
+— [CS] Andrew-CS · comment score 8
+
+### Q&A
+
+**Q — [Community] BinaryN1nja:** Can you explain these lines a bit better? I think my lack of knowledge about the Call stack and the call stack module names is hurting me here. My best guess is below... `| eval n=mvfilter(match(CallStackModuleNames, "(.*dll|.*exe)"))` `| rex field=n ".*\\\\Device\\\\HarddiskVolume\d+(?<loadedFile>. …
+
+**A — [CS] Andrew-CS:** Sure! So you have to look at the whole query event_platform=win event_simpleName=ProcessRollup2 FileName=spoolsv.exe | eval CallStackModuleNames=split(CallStackModuleNames, "|") The first line pulls up all `spoolsv` executions. The second line notes that `CallStackModuleNames` has a bunch of data in it and when you see a pipe ( `|` ) that indicates a new piece of information (kind of like how a comma works in a CSV). | eval n=mvfilter(match(CallStackModuleNames, "(.*dll|.*exe)")) The next line m …

--- a/Queries-Only/Cool-Query-Friday/2021-07-16 - Cool Query Friday - CLI Programs Running via Hidden Window.md
+++ b/Queries-Only/Cool-Query-Friday/2021-07-16 - Cool Query Friday - CLI Programs Running via Hidden Window.md
@@ -1,0 +1,75 @@
+---
+title: "CLI Programs Running via Hidden Window"
+date: 2021-07-16
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/olhnwf/20210716_cool_query_friday_cli_programs_running/"
+mitre: []
+series: Cool Query Friday
+---
+
+# CLI Programs Running via Hidden Window
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/olhnwf/20210716_cool_query_friday_cli_programs_running/](https://www.reddit.com/r/crowdstrike/comments/olhnwf/20210716_cool_query_friday_cli_programs_running/) — by Andrew-CS (CrowdStrike) — 2021-07-16
+
+Welcome to our seventeenth installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk though of each step (3) application in the wild.
+
+## Query 1
+```cql
+[...]
+| rename FileName AS runningExe
+| lookup local=true appinfo.csv SHA256HashData OUTPUT FileName FileDescription
+| fillnull FileName, FileDescription value="N/A"
+| eval cloudFileName=lower(FileName)
+| eval FileName=lower(FileName)
+```
+
+## Query 2
+```cql
+event_platform=win event_simpleName=ProcessRollup2 ImageSubsystem_decimal=3 ShowWindowFlags_decimal=0
+| rename FileName AS runningExe
+| lookup local=true appinfo.csv SHA256HashData OUTPUT FileName FileDescription
+| fillnull FileName, FileDescription value="N/A"
+| eval runningExe=lower(runningExe)
+| eval cloudFileName=lower(FileName)
+| fields aid, ComputerName, runningExe cloudFileName, FileDescription
+| rename FileDescription as cloudFileDescription
+```
+
+## Query 3
+```cql
+event_platform=win event_simpleName=ProcessRollup2 ImageSubsystem_decimal=3 ShowWindowFlags_decimal=0 UserSid_readable!=S-1-5-18
+| rename FileName AS runningExe
+| lookup local=true appinfo.csv SHA256HashData OUTPUT FileName FileDescription
+| fillnull FileName, FileDescription value="N/A"
+| eval runningExe=lower(runningExe)
+| eval cloudFileName=lower(FileName)
+| stats dc(aid) as systemCount count(aid) as runCount by runningExe, SHA256HashData, cloudFileName, FileDescription
+| rename FileDescription as cloudFileDescription, SHA256HashData as sha256
+| sort +systemCount, +runCount
+```
+
+## Query 4
+```cql
+event_platform=win event_simpleName=ProcessRollup2 ImageSubsystem_decimal=3 ShowWindowFlags_decimal=0 UserSid_readable!=S-1-5-18 FileName=powershell.exe
+| rename FileName AS runningExe
+| lookup local=true appinfo.csv SHA256HashData OUTPUT FileName FileDescription
+| fillnull FileName, FileDescription value="N/A"
+| eval runningExe=lower(runningExe)
+| eval cloudFileName=lower(FileName)
+| stats values(UserName) as userName dc(aid) as systemCount count(aid) as runCount by runningExe, CommandLine
+| rename FileDescription as cloudFileDescription, SHA256HashData as sha256
+| sort +systemCount, +runCount
+```
+
+## Query 5
+```cql
+event_platform=win event_simpleName=ProcessRollup2 ImageSubsystem_decimal=3 ShowWindowFlags_decimal=0 FileName=cmd.exe CommandLine="*powershell*"
+| rename FileName AS runningExe
+| lookup local=true appinfo.csv SHA256HashData OUTPUT FileName FileDescription
+| fillnull FileName, FileDescription value="N/A"
+| eval runningExe=lower(runningExe)
+| eval cloudFileName=lower(FileName)
+| stats values(UserName) as userName dc(aid) as systemCount count(aid) as runCount by runningExe, CommandLine
+| rename FileDescription as cloudFileDescription, SHA256HashData as sha256
+| sort +systemCount, +runCount
+```

--- a/Queries-Only/Cool-Query-Friday/2021-07-21 - Cool Query Friday - Finding and Mitigating CVE-2021-36934 (HiveNightmareSeriousSAM).md
+++ b/Queries-Only/Cool-Query-Friday/2021-07-21 - Cool Query Friday - Finding and Mitigating CVE-2021-36934 (HiveNightmareSeriousSAM).md
@@ -73,3 +73,31 @@ ServiceStarted AND FileName=vssvc.exe) OR event_simpleName=OsVersionInfo
 | table aid ComputerName MachineDomain OU SiteName AgentVersion productName buildNumber, subBuildNumber, vssProcessRunning
 | rename ComputerName as hostName, MachineDomain as machineDomain, SiteName as siteName, AgentVersion as falconVersion
 ```
+
+## Community & Staff Additions
+*Harvested from this post's [r/CrowdStrike](https://www.reddit.com/r/crowdstrike/) comment thread — not part of the original CQF post. **[CS]** = CrowdStrike staff · **[Community]** = other r/CrowdStrike users. Upvote scores shown for context.*
+
+### Operational caveats
+
+> Had to repost as original title had "PrintNightmare" instead of "HiveNightmare" which is a freudian microcosm of the last two weeks.
+— [CS] Andrew-CS · score 13
+
+> We've added detection logic to Falcon for this. As your sensors update this activity will generate alerts in the UI. EDIT – Quick clarification: by "update" I mean the sensors only have to be online as they will dynamically receive this content. You do not have to update sensor versions or anything like that.
+— [CS] Andrew-CS · score 1
+
+> >This is very cool but we are confused because the Microsoft documentation says the bad permissions should be present on affected versions of Windows 10, and doesn't say that they will only be present if the VSS service is running. The CrowdStrike support article does imply that bad permissions are only present if the VSS service is running - that may be true, and we aren't seeing the bad permissions on the Windows 10 systems we have individually checked, but it would be reassuring to see something from Microsoft that says this is true. The MSFT guidance isn't overly verbose. Original guidance indicated VSS had to be enabled for the snapshot files with the incorrect permission to be present. …
+— [CS] Andrew-CS · score 2
+
+### Q&A
+
+**Q — [Community] PauloDias79:** Is this CVE being detected by Falcon Insight? Or it is required to add new alerts?
+
+**A — [CS] Andrew-CS:** It's just a file read, not an exploit. The issue needs to be mitigated using the instructions provided by Microsoft or further patched by Microsoft. We're working on detection logic as we speak, but mitigating this is imperative.
+
+**Q — [Community] tamu_nerd:** Any IOAs we can deploy to look for processes or shells accessing one of these files?
+
+**A — [CS] Andrew-CS:** We've added detection logic to Falcon for this. As your sensors update this activity will generate alerts in the UI. EDIT – Quick clarification: by "update" I mean the sensors only have to be online as they will dynamically receive this content. You do not have to update sensor versions or anything like that.
+
+**Q — [Community] CyberBeak:** Is that to trigger an alert in falcon and see if it blocks? Can you explain a bit more what that line is performing? How can we use that? Thanks!!!
+
+**A — [CS] Andrew-CS:** It will read the file via PowerShell if your system is impacted; you can VSS file contents as a standard user when executing it.

--- a/Queries-Only/Cool-Query-Friday/2021-07-21 - Cool Query Friday - Finding and Mitigating CVE-2021-36934 (HiveNightmareSeriousSAM).md
+++ b/Queries-Only/Cool-Query-Friday/2021-07-21 - Cool Query Friday - Finding and Mitigating CVE-2021-36934 (HiveNightmareSeriousSAM).md
@@ -1,0 +1,75 @@
+---
+title: "Finding and Mitigating CVE-2021-36934 (HiveNightmare/SeriousSAM)"
+date: 2021-07-21
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/ooo6kk/20210721_cool_query_friday_finding_and_mitigating/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Finding and Mitigating CVE-2021-36934 (HiveNightmare/SeriousSAM)
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/ooo6kk/20210721_cool_query_friday_finding_and_mitigating/](https://www.reddit.com/r/crowdstrike/comments/ooo6kk/20210721_cool_query_friday_finding_and_mitigating/) — by Andrew-CS (CrowdStrike) — 2021-07-21
+
+Welcome to our eighteenth installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk though of each step (3) application in the wild.
+
+## Query 1
+```cql
+[...]
+| lookup local=true aid_master aid OUTPUT AgentVersion, MachineDomain, OU, SiteName, Version, ProductType
+```
+
+## Query 2
+```cql
+[...]
+| eval FileName=lower(FileName)
+```
+
+## Query 3
+```cql
+[...]
+| stats dc(event_simpleName) as eventCount latest(BuildNumber_decimal) as buildNumber latest(SubBuildNumber_decimal) as subBuildNumber latest(ProductName) as productName values(FileName) as vssProcessRunning by aid, ComputerName, AgentVersion, MachineDomain, OU, SiteName, ProductType
+```
+
+## Query 4
+```cql
+event_platform=win (event_simpleName=ProcessRollup2 OR event_simpleName=SyntheticProcessRollup2 OR event_simpleName=
+ServiceStarted AND FileName=vssvc.exe) OR event_simpleName=OsVersionInfo
+| lookup local=true aid_master aid OUTPUT AgentVersion, MachineDomain, OU, SiteName, Version, ProductType
+| eval FileName=lower(FileName)
+| stats dc(event_simpleName) as eventCount latest(BuildNumber_decimal) as buildNumber latest(SubBuildNumber_decimal) as subBuildNumber latest(ProductName) as productName values(FileName) as vssProcessRunning by aid, ComputerName, AgentVersion, MachineDomain, OU, SiteName, ProductType
+```
+
+## Query 5
+```cql
+[...]
+| where buildNumber>=17763
+| search ProductType=1
+```
+
+## Query 6
+```cql
+[...]
+| where isnotnull(vssProcessRunning)
+```
+
+## Query 7
+```cql
+[...]
+| table aid ComputerName MachineDomain OU SiteName AgentVersion productName buildNumber, subBuildNumber, vssProcessRunning
+| rename ComputerName as hostName, MachineDomain as machineDomain, SiteName as siteName, AgentVersion as falconVersion
+```
+
+## Query 8
+```cql
+event_platform=win (event_simpleName=ProcessRollup2 OR event_simpleName=SyntheticProcessRollup2 OR event_simpleName=
+ServiceStarted AND FileName=vssvc.exe) OR event_simpleName=OsVersionInfo
+| lookup local=true aid_master aid OUTPUT AgentVersion, MachineDomain, OU, SiteName, Version, ProductType
+| eval FileName=lower(FileName)
+| stats dc(event_simpleName) as eventCount latest(BuildNumber_decimal) as buildNumber latest(SubBuildNumber_decimal) as subBuildNumber latest(ProductName) as productName values(FileName) as vssProcessRunning by aid, ComputerName, AgentVersion, MachineDomain, OU, SiteName, ProductType
+| where buildNumber>=17763
+| search ProductType=1
+| where isnotnull(vssProcessRunning)
+| table aid ComputerName MachineDomain OU SiteName AgentVersion productName buildNumber, subBuildNumber, vssProcessRunning
+| rename ComputerName as hostName, MachineDomain as machineDomain, SiteName as siteName, AgentVersion as falconVersion
+```

--- a/Queries-Only/Cool-Query-Friday/2021-07-30 - Cool Query Friday - Command Line Scoring and Parsing.md
+++ b/Queries-Only/Cool-Query-Friday/2021-07-30 - Cool Query Friday - Command Line Scoring and Parsing.md
@@ -1,0 +1,104 @@
+---
+title: "Command Line Scoring and Parsing"
+date: 2021-07-30
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/ouk533/20210730_cool_query_friday_command_line_scoring/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Command Line Scoring and Parsing
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/ouk533/20210730_cool_query_friday_command_line_scoring/](https://www.reddit.com/r/crowdstrike/comments/ouk533/20210730_cool_query_friday_command_line_scoring/) — by Andrew-CS (CrowdStrike) — 2021-07-30
+
+Welcome to our nineteenth installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk though of each step (3) application in the wild.
+
+## Query 1
+```cql
+event_platform=win event_simpleName=ProcessRollup2 (FileName=cmd.exe OR FileName=powershell.exe)
+| eval cmdLength=len(CommandLine)
+```
+
+## Query 2
+```cql
+event_platform=win event_simpleName=ProcessRollup2 (FileName=cmd.exe OR FileName=powershell.exe)
+| eval cmdLength=len(CommandLine)
+| stats avg(cmdLength) as avgCmdLength max(cmdLength) as maxCmdLength min(cmdLength) as minCmdLength stdev(cmdLength) as stdevCmdLength by FileName
+| eval cmdBogey=avgCmdLength+stdevCmdLength
+```
+
+## Query 3
+```cql
+[...]
+| eval isLongCmd=if(cmdLength>160 AND FileName=="cmd.exe","2","0")
+| eval isLongPS=if(cmdLength>932 AND FileName=="powershell.exe","2","0")
+| eval cmdScore=isLongCmd+isLongPS
+```
+
+## Query 4
+```cql
+[...]
+| eval carrotCount = mvcount(split(CommandLine,"^"))-1
+| eval tickCount = mvcount(split(CommandLine,"`"))-1
+| eval escapeCharacters=tickCount+carrotCount
+| eval cmdNoEscape=trim(replace(CommandLine, "^", ""))
+| eval cmdNoEscape=trim(replace(cmdNoEscape, "`", ""))
+| eval cmdScore=isLongCmd+isLongPS+escapeCharacters
+```
+
+## Query 5
+```cql
+event_platform=win event_simpleName=ProcessRollup2 (FileName=cmd.exe OR FileName=powershell.exe)
+| eval cmdLength=len(CommandLine)
+| eval isLongCmd=if(cmdLength>160 AND FileName=="cmd.exe","2","0")
+| eval isLongPS=if(cmdLength>932 AND FileName=="powershell.exe","2","0")
+| eval carrotCount = mvcount(split(CommandLine,"^"))-1
+| eval tickCount = mvcount(split(CommandLine,"`"))-1
+| eval escapeCharacters=tickCount+carrotCount
+| eval cmdNoEscape=trim(replace(CommandLine, "^", ""))
+| eval cmdNoEscape=trim(replace(cmdNoEscape, "`", ""))
+| eval cmdScore=isLongCmd+isLongPS+escapeCharacters
+| fields aid ComputerName FileName CommandLine cmdLength escapeCharacters cmdScore
+```
+
+## Query 6
+```cql
+event_platform=win event_simpleName=ProcessRollup2 (FileName=cmd.exe OR FileName=powershell.exe)
+| eval cmdLength=len(CommandLine)
+| eval isLongCmd=if(cmdLength>129 AND FileName=="cmd.exe","2","0")
+| eval isLongPS=if(cmdLength>1980 AND FileName=="powershell.exe","2","0")
+| eval carrotCount = mvcount(split(CommandLine,"^"))-1
+| eval tickCount = mvcount(split(CommandLine,"`"))-1
+| eval escapeCharacters=tickCount+carrotCount
+| eval cmdNoEscape=trim(replace(CommandLine, "^", ""))
+| eval cmdNoEscape=trim(replace(cmdNoEscape, "`", ""))
+| eval isAcceptEULA=if(like(cmdNoEscape, "%accepteula%"), "10", "0")
+| eval isEncoded=if(like(cmdNoEscape, "% -e%"), "5", "0")
+| eval isBypass=if(like(cmdNoEscape, "% bypass %"), "5", "0")
+| eval invokePS=if(like(cmdNoEscape, "%powershell%"), "1", "0")
+| eval invokeWMIC=if(like(cmdNoEscape, "%wmic%"), "3", "0")
+| eval invokeCscript=if(like(cmdNoEscape, "%cscript%"), "3", "0")
+| eval invokeWscipt=if(like(cmdNoEscape, "%wscript%"), "3", "0")
+| eval invokeHttp=if(like(cmdNoEscape, "%http%"), "3", "0")
+| eval isSystemUser=if(like(cmdNoEscape, "S-1-5-18"), "0", "1")
+| eval stdOutRedirection=if(like(cmdNoEscape, "%>%"), "1", "0")
+| eval isHidden=if(like(cmdNoEscape, "%hidden%"), "3", "0")
+| eval cmdScore=isLongCmd+escapeCharacters+isAcceptEULA+isEncoded+isBypass+invokePS+invokeWMIC+invokeCscript+invokeWscipt+invokeHttp+isSystemUser+stdOutRedirection+isHidden
+| stats dc(aid) as uniqueSystems count(aid) as exeuctionCount by FileName, cmdScore, CommandLine, cmdLength, isLongCmd, escapeCharacters, isAcceptEULA, isEncoded, isBypass, invokePS, invokeWMIC, invokeCscript, invokeWscipt, invokeHttp, isSystemUser, stdOutRedirection, isHidden
+| eval CommandLine=substr(CommandLine,1,250)
+| sort - cmdScore
+```
+
+## Query 7
+```cql
+event_platform=win event_simpleName=ProcessRollup2 (FileName=cmd.exe OR FileName=powershell.exe)
+| search ParentBaseFileName!=tainium.exe
+| eval cmdLength=len(CommandLine)
+```
+
+## Query 8
+```cql
+event_platform=win event_simpleName=ProcessRollup2 (FileName=cmd.exe OR FileName=powershell.exe)
+| search CommandLine!="C:\\ProgramData\\EC2-Windows\\*"
+| eval cmdLength=len(CommandLine)
+```

--- a/Queries-Only/Cool-Query-Friday/2021-08-06 - Cool Query Friday - Scoping Discovery Via the net Command and Custom IOAs (T1087.001).md
+++ b/Queries-Only/Cool-Query-Friday/2021-08-06 - Cool Query Friday - Scoping Discovery Via the net Command and Custom IOAs (T1087.001).md
@@ -1,0 +1,50 @@
+---
+title: "Scoping Discovery Via the net Command and Custom IOAs (T1087.001)"
+date: 2021-08-06
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/oz7uvn/20210806_cool_query_friday_scoping_discovery_via/"
+mitre: [T1087]
+series: Cool Query Friday
+---
+
+# Scoping Discovery Via the net Command and Custom IOAs (T1087.001)
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/oz7uvn/20210806_cool_query_friday_scoping_discovery_via/](https://www.reddit.com/r/crowdstrike/comments/oz7uvn/20210806_cool_query_friday_scoping_discovery_via/) — by Andrew-CS (CrowdStrike) — 2021-08-06
+
+Welcome to our twentieth installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk though of each step (3) application in the wild.
+
+## Query 1
+```cql
+aid=7ce9db2ac1da4e8fb116e494a8c77a2d 65327048864
+| eval endpointTime=mvappend(ContextTimeStamp_decimal, ProcessStartTime_decimal) 
+| table endpointTime ComputerName UserName FileName CommandLine event_simpleName RawProcessId_decimal TargetProcessId_decimal ContextProcessId_decimal RpcClientProcessId_decimal
+| sort + endpointTime
+| convert ctime(endpointTime)
+```
+
+## Query 2
+```cql
+earliest=-7d event_platform=win event_simpleName=ProcessRollup2 (FileName=net.exe OR FileName=net1.exe)
+| stats dc(aid) as uniqueEndpoints count(aid) as executionCount dc(CommandLine) as cmdLineVariations by FileName, ProductType
+| sort + ProductType
+```
+
+## Query 3
+```cql
+earliest=-7d event_platform=win event_simpleName=ProcessRollup2 (FileName=net.exe OR FileName=net1.exe) CommandLine="* user *"
+| stats values(CommandLine) as cmdLineVariations
+```
+
+## Query 4
+```cql
+earliest=-7d event_platform=win event_simpleName=ProcessRollup2 (FileName=net.exe OR FileName=net1.exe) CommandLine="* user *"
+| search CommandLine="* /add*"
+| stats values(CommandLine) as cmdLineVariations
+```
+
+## Query 5
+```cql
+earliest=-7d event_platform=win event_simpleName=ProcessRollup2 (FileName=net.exe OR FileName=net1.exe) CommandLine="* user *"
+| search CommandLine="* /add*"
+| stats dc(aid) as uniqueEndpoints count(aid) as executionCount values(CommandLine) as cmdLines by ProductType
+```

--- a/Queries-Only/Cool-Query-Friday/2021-08-13 - Cool Query Friday - Matching Detections to Assigned Analysts in Event Search.md
+++ b/Queries-Only/Cool-Query-Friday/2021-08-13 - Cool Query Friday - Matching Detections to Assigned Analysts in Event Search.md
@@ -115,3 +115,41 @@ index=json AND (ExternalApiType=Event_UserActivityAuditEvent AND OperationName=d
 | convert ctime(timeStamp)
 | sort + timeStamp
 ```
+
+## Community & Staff Additions
+*Harvested from this post's [r/CrowdStrike](https://www.reddit.com/r/crowdstrike/) comment thread — not part of the original CQF post. **[CS]** = CrowdStrike staff · **[Community]** = other r/CrowdStrike users. Upvote scores shown for context.*
+
+### Query variants
+
+```cql
+earliest=-24h index=json AND (ExternalApiType=Event_UserActivityAuditEvent AND OperationName=detection_update) OR ExternalApiType=Event_DetectionSummaryEvent
+| eval OperationName=lower(OperationName)
+| rename AuditKeyValues{}.Key AS key AuditKeyValues{}.ValueString AS value
+| eval data = mvzip(key,value)
+| rex field=data "detection_id,.*:(?<aid>.*?):(?<detectId>-?\\d+)?"
+| eval detectId="ldt:".aid.":".detectId
+| rex field=data "assigned_to,(?<assigned_to>.*)"
+| rex field=data "assigned_to_uid,(?<assigned_to_uid>.*)"
+| rex field=data "new_state,(?<detectionState>.*)"
+| table *
+| eval detectId=mvappend(DetectId, detectId)
+| eval aid=mvappend(aid, AgentIdString)
+| lookup local=true aid_master aid OUTPUT FalconGroupingTags
+| eval FalconGroupingTags=split(FalconGroupingTags,";")
+| stats values(ComputerName) as computerName, values(FalconGroupingTags) as FalconTags,
+last(UTCTimestamp) as timeStamp, values(FileName) as fileNames, values(SHA256String) as sha256Values, values(assigned_to) as assignedTo, last(detectionState) as detectionState, values(DetectName) as detectName, max(Severity) as Severity, values(Tactic) as tactic, values(Technique) as technique, values(SeverityName) as SeverityNames values(FalconHostLink) as falconLink by aid, detectId
+| where isnotnull(falconLink)
+| eval Severity=case(Severity=1, "Informational", Severity=2, "Low", Severity=3, "Medium", Severity=4, "High", Severity=5, "Critical")
+| eval timeStamp=timeStamp/1000
+| convert ctime(timeStamp)
+| sort + timeStamp
+| fillnull assignedTo value="-"
+| fillnull detectionState value="new"
+```
+— [CS] Andrew-CS · comment score 3
+
+### Q&A
+
+**Q — [Community] BingBongTheArcher23:** Is there a way to include the corresponding filehash information or the status (TP/FP/Ignored/etc) of the events?
+
+**A — [CS] Andrew-CS:** Yup! earliest=-24h index=json AND (ExternalApiType=Event_UserActivityAuditEvent AND OperationName=detection_update) OR ExternalApiType=Event_DetectionSummaryEvent | eval OperationName=lower(OperationName) | rename AuditKeyValues{}.Key AS key AuditKeyValues{}.ValueString AS value | eval data = mvzip(key,value) | rex field=data "detection_id,.*:(?<aid>.*?):(?<detectId>-?\\d+)?" | eval detectId="ldt:".aid.":".detectId | rex field=data "assigned_to,(?<assigned_to>.*)" | rex field=data "assigned_to_u …

--- a/Queries-Only/Cool-Query-Friday/2021-08-13 - Cool Query Friday - Matching Detections to Assigned Analysts in Event Search.md
+++ b/Queries-Only/Cool-Query-Friday/2021-08-13 - Cool Query Friday - Matching Detections to Assigned Analysts in Event Search.md
@@ -1,0 +1,117 @@
+---
+title: "Matching Detections to Assigned Analysts in Event Search"
+date: 2021-08-13
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/p3mt5g/20210813_cool_query_friday_matching_detections_to/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Matching Detections to Assigned Analysts in Event Search
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/p3mt5g/20210813_cool_query_friday_matching_detections_to/](https://www.reddit.com/r/crowdstrike/comments/p3mt5g/20210813_cool_query_friday_matching_detections_to/) — by Andrew-CS (CrowdStrike) — 2021-08-13
+
+Welcome to our twenty-first installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk though of each step (3) application in the wild.
+
+## Query 1
+```cql
+index=json  EventType=Event_ExternalApiEvent 
+| stats values(ExternalApiType)
+```
+
+## Query 2
+```cql
+index=json EventType=Event_ExternalApiEvent ExternalApiType=Event_UserActivityAuditEvent 
+| stats values(OperationName) as OperationName
+```
+
+## Query 3
+```cql
+index=json AND (ExternalApiType=Event_UserActivityAuditEvent AND OperationName=detection_update) OR ExternalApiType=Event_DetectionSummaryEvent
+| rename AuditKeyValues{}.Key AS key AuditKeyValues{}.ValueString AS value
+```
+
+## Query 4
+```cql
+[...]
+| eval data = mvzip(key,value)
+```
+
+## Query 5
+```cql
+index=json AND (ExternalApiType=Event_UserActivityAuditEvent AND OperationName=detection_update) OR ExternalApiType=Event_DetectionSummaryEvent
+| rename AuditKeyValues{}.Key AS key AuditKeyValues{}.ValueString AS value
+| eval data = mvzip(key,value)
+| table ExternalApiType data
+| where isnotnull(data)
+```
+
+## Query 6
+```cql
+index=json AND (ExternalApiType=Event_UserActivityAuditEvent AND OperationName=detection_update) OR ExternalApiType=Event_DetectionSummaryEvent
+| rename AuditKeyValues{}.Key AS key AuditKeyValues{}.ValueString AS value
+| eval data = mvzip(key,value)
+| rex field=data "detection_id,ldt:(?<aid>.*?):(?<detectId>-?\\d+)?"
+| rex field=data "assigned_to,(?<assigned_to>.*)"
+| rex field=data "assigned_to_uid,(?<assigned_to_uid>.*)"
+```
+
+## Query 7
+```cql
+| rex field=data "detection_id,ldt:(?<aid>.*?):(?<detectId>-?\\d+)?"
+```
+
+## Query 8
+```cql
+index=json AND (ExternalApiType=Event_UserActivityAuditEvent AND OperationName=detection_update) OR ExternalApiType=Event_DetectionSummaryEvent
+| rename AuditKeyValues{}.Key AS key AuditKeyValues{}.ValueString AS value
+| eval data = mvzip(key,value)
+| rex field=data "detection_id,.*:(?<aid>.*?):(?<detectId>-?\\d+)?"
+| rex field=data "assigned_to,(?<assigned_to>.*)"
+| rex field=data "assigned_to_uid,(?<assigned_to_uid>.*)" 
+| eval detectId="ldt:".aid.":".detectId
+| table ExternalApiType, UTCTimestamp, aid, AgentIdString, ComputerName, FileName, FilePath, CommandLine, DetectId, detectId, assigned_to, assigned_to_uid, DetectName, Tactic, Technique, SeverityName, FalconHostLink
+```
+
+## Query 9
+```cql
+[...]
+| eval detectId=mvappend(DetectId, detectId)
+| eval aid=mvappend(aid, AgentIdString)
+```
+
+## Query 10
+```cql
+[...]
+| stats count(SeverityName) as totalBehaviors, values(ComputerName) as computerName, last(UTCTimestamp) as timeStamp, values(assigned_to) as assignedTo, last(assigned_to) as assignedToLast, values(DetectName) as detectName, values(Tactic) as tactic, values(Technique) as technique, values(SeverityName) as severityNames, values(FileName) as fileName, values(FilePath) as filePath, values(CommandLine) as commandLine, values(FalconHostLink) as falconLink by detectId
+```
+
+## Query 11
+```cql
+[...]
+| where isnotnull(assignedTo)
+| where isnotnull(detectName)
+| eval timeStamp=timeStamp/1000
+| convert ctime(timeStamp)
+| sort + timeStamp
+```
+
+## Query 12
+```cql
+index=json AND (ExternalApiType=Event_UserActivityAuditEvent AND OperationName=detection_update) OR ExternalApiType=Event_DetectionSummaryEvent
+| rename AuditKeyValues{}.Key AS key AuditKeyValues{}.ValueString AS value
+| eval data = mvzip(key,value)
+| rex field=data "detection_id,.*:(?<aid>.*?):(?<detectId>-?\\d+)?"
+| rex field=data "assigned_to,(?<assigned_to>.*)"
+| rex field=data "assigned_to_uid,(?<assigned_to_uid>.*)" 
+| eval detectId="ldt:".aid.":".detectId
+| table ExternalApiType, UTCTimestamp, aid, AgentIdString, ComputerName, FileName, FilePath, CommandLine, DetectId, detectId, assigned_to, assigned_to_uid, DetectName, Tactic, Technique, SeverityName, FalconHostLink
+| eval detectId=mvappend(DetectId, detectId)
+| eval aid=mvappend(aid, AgentIdString)
+| stats count(SeverityName) as totalBehaviors, values(ComputerName) as computerName, last(UTCTimestamp) as timeStamp, values(assigned_to) as assignedTo, last(assigned_to) as assignedToLast, values(DetectName) as detectName, values(Tactic) as tactic, values(Technique) as technique, values(SeverityName) as severityNames, values(FileName) as fileName, values(FilePath) as filePath, values(CommandLine) as commandLine, values(FalconHostLink) as falconLink by detectId
+| where isnotnull(assignedTo)
+| where isnotnull(detectName)
+| eval timeStamp=timeStamp/1000
+| convert ctime(timeStamp)
+| sort + timeStamp
+```

--- a/Queries-Only/Cool-Query-Friday/2021-08-20 - Cool Query Friday - Falcon Fusion Friday.md
+++ b/Queries-Only/Cool-Query-Friday/2021-08-20 - Cool Query Friday - Falcon Fusion Friday.md
@@ -1,0 +1,23 @@
+---
+title: "Falcon Fusion Friday"
+date: 2021-08-20
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/p8d0rl/20210820_cool_query_friday_falcon_fusion_friday/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Falcon Fusion Friday
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/p8d0rl/20210820_cool_query_friday_falcon_fusion_friday/](https://www.reddit.com/r/crowdstrike/comments/p8d0rl/20210820_cool_query_friday_falcon_fusion_friday/) — by Andrew-CS (CrowdStrike) — 2021-08-20
+
+Welcome to our twenty-second installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk though of each step (3) application in the wild.
+
+```cql
+earliest=-90d ExternalApiType=Event_DetectionSummaryEvent Tactic="Credential Access"
+| rename AgentIdString as aid
+| lookup local=true aid_master aid OUTPUT Version, ProductType
+| where ProductType=1
+| stats count(aid) as totalDetections dc(aid) as totalEndpoints values(Version) as osVersions by FileName
+| sort - totalDetections
+```

--- a/Queries-Only/Cool-Query-Friday/2021-09-10 - Cool Query Friday - The Cheat Sheet.md
+++ b/Queries-Only/Cool-Query-Friday/2021-09-10 - Cool Query Friday - The Cheat Sheet.md
@@ -1,0 +1,164 @@
+---
+title: "The Cheat Sheet"
+date: 2021-09-10
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/plkwqu/20210910_cool_query_friday_the_cheat_sheet/"
+mitre: []
+series: Cool Query Friday
+---
+
+# The Cheat Sheet
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/plkwqu/20210910_cool_query_friday_the_cheat_sheet/](https://www.reddit.com/r/crowdstrike/comments/plkwqu/20210910_cool_query_friday_the_cheat_sheet/) — by Andrew-CS (CrowdStrike) — 2021-09-10
+
+Welcome to our twenty-second installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk though of each step (3) application in the wild.
+
+## Query 1
+```cql
+[...]
+| convert ctime(ProcessStartTime_decimal)
+[...]
+```
+
+## Query 2
+```cql
+earliest=-1m event_simpleName IN (ProcessRollup2, DnsRequest)
+| convert ctime(ProcessStartTime_decimal) ctime(ContextTimeStamp_decimal)
+| table event_simpleName ProcessStartTime_decimal ContextTimeStamp_decimal
+```
+
+## Query 3
+```cql
+earliest=-1m event_simpleName IN (ProcessRollup2, DnsRequest)
+| convert ctime(ProcessStartTime_decimal) ctime(ContextTimeStamp_decimal)
+| table event_simpleName _time ProcessStartTime_decimal ContextTimeStamp_decimal
+```
+
+## Query 4
+```cql
+[...]
+| convert ctime(timestamp)
+[...]
+```
+
+## Query 5
+```cql
+[...]
+| eval timestamp=timestamp/1000
+| convert ctime(timestamp)
+[...]
+```
+
+## Query 6
+```cql
+earliest=-5m event_simpleName IN (ProcessRollup2, EndofProcess) 
+| stats values(ProcessStartTime_decimal) as startTime, values(ProcessEndTime_decimal) as endTime by aid, TargetProcessId_decimal, FileName
+| eval runTimeSeconds=endTime-startTime
+| where isnotnull(endTime)
+| convert ctime(startTime) ctime(endTime)
+```
+
+## Query 7
+```cql
+[...]
+| eval myUTCoffset=-4
+| eval myLocalTime=ProcessStartTime_decimal+(60*60*myUTCoffset)
+[...]
+```
+
+## Query 8
+```cql
+earliest=-1m event_simpleName IN (ProcessRollup2)
+| eval myUTCoffset=-7
+| eval myLocalTime=ProcessStartTime_decimal+(myUTCoffset*60*60)
+| table FileName _time ProcessStartTime_decimal myLocalTime
+| rename ProcessStartTime_decimal as endpointSystemClockUTC, _time as cloudTimeUTC
+| convert ctime(cloudTimeUTC), ctime(endpointSystemClockUTC), ctime(myLocalTime)
+```
+
+## Query 9
+```cql
+[...]
+| eval endpointTime=mvappend(ProcessStartTime_decimal, ContextTimeStamp_decimal)
+[...]
+```
+
+## Query 10
+```cql
+earliest=-1m event_simpleName IN (ProcessRollup2, DnsRequest)
+| eval endpointTime=mvappend(ContextTimeStamp_decimal, ProcessStartTime_decimal)
+| table event_simpleName _time endpointTime
+| convert ctime(endpointTime)
+```
+
+## Query 11
+```cql
+[...]
+| eval falconPID=mvappend(TargetProcessId_decimal, ContextProcessId_decimal)
+[...]
+```
+
+## Query 12
+```cql
+earliest=-60m event_platform=win event_simpleName IN (OsVersionInfo)
+| eval systemType=case(ProductType_decimal=1, "Workstation", ProductType_decimal=2, "Domain Controller", ProductType_decimal=3, "Server")
+| table ComputerName ProductName systemType
+```
+
+## Query 13
+```cql
+[...]
+| eval shortCmd=substr(CommandLine,1,250)
+[...]
+```
+
+## Query 14
+```cql
+earliest=-5m event_simpleName IN (ProcessRollup2)
+| eval shortCmd=substr(CommandLine,1,250)
+| eval FullCmdCharCount=len(CommandLine)
+| where FullCmdCharCount>250
+| table ComputerName FileName FullCmdCharCount shortCmd CommandLine
+```
+
+## Query 15
+```cql
+earliest=-15m event_simpleName=DnsRequest
+| rex field=DomainName "[@\.](?<tlDomain>\w+\.\w+)$"
+| stats dc(DomainName) as subDomainCount, values(DomainName) as subDomain by tlDomain
+| sort - subDomainCount
+```
+
+## Query 16
+```cql
+CHEAT SHEET
+
+*** epoch to human readable ***
+
+| convert ctime(ProcessStartTime_decimal)
+
+*** combine Context and Target timestamps **
+
+| eval endpointTime=mvappend(ProcessStartTime_decimal, ContextTimeStamp_decimal)
+
+*** UTC Localization ***
+
+| eval myUTCoffset=-4
+| eval myLocalTime=ProcessStartTime_decimal+(60*60*myUTCoffset)
+
+*** combine Falcon Process UUIDs ***
+
+| eval falconPID=mvappend(TargetProcessId_decimal, ContextProcessId_decimal)
+
+*** string swaps ***
+
+| eval systemType=case(ProductType_decimal=1, "Workstation", ProductType_decimal=2, "Domain Controller", ProductType_decimal=3, "Server")
+
+*** shorten string ***
+
+| eval shortCmd=substr(CommandLine,1,250)
+
+*** regex field ***
+
+rex field=DomainName "[@\.](?<tlDomain>\w+\.\w+)$"
+```

--- a/Queries-Only/Cool-Query-Friday/2021-09-17 - Cool Query Friday - Regular Expressions.md
+++ b/Queries-Only/Cool-Query-Friday/2021-09-17 - Cool Query Friday - Regular Expressions.md
@@ -1,0 +1,97 @@
+---
+title: "Regular Expressions"
+date: 2021-09-17
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/ppzp59/20210917_cool_query_friday_regular_expressions/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Regular Expressions
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/ppzp59/20210917_cool_query_friday_regular_expressions/](https://www.reddit.com/r/crowdstrike/comments/ppzp59/20210917_cool_query_friday_regular_expressions/) — by Andrew-CS (CrowdStrike) — 2021-09-17
+
+Welcome to our twenty-third installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk though of each step (3) application in the wild.
+
+## Query 1
+```cql
+[...]
+| rex field=fieldName "regex here"
+[...]
+```
+
+## Query 2
+```cql
+event_platform=win event_simpleName=DnsRequest
+| fields ComputerName, DomainName
+| head 5
+```
+
+## Query 3
+```cql
+[...]
+| rex field=DomainName ".*\.(?<DomainTLD>.*\..*)"
+```
+
+## Query 4
+```cql
+event_platform=win event_simpleName=DnsRequest
+| fields ComputerName, DomainName
+| rex field=DomainName ".*\.(?<DomainTLD>.*\..*)"
+| table ComputerName DomainName DomainTLD
+```
+
+## Query 5
+```cql
+event_platform=win event_simpleName=ProcessRollup2 
+| search FilePath="*\\Microsoft.Net\\*"
+| head 5
+```
+
+## Query 6
+```cql
+[...]
+| rex field=ImageFileName "\\\\Device\\\\HarddiskVolume\d+\\\\Windows\\\\Microsoft\.NET\\\\Framework(|64)\\\\v(?<dotNetVersion>\d+\.\d+\.\d+)\\\\.*"
+[...]
+```
+
+## Query 7
+```cql
+event_platform=win event_simpleName=ProcessRollup2 
+| search FilePath="*\\Microsoft.Net\\*"
+| head 25
+| rex field=ImageFileName "\\\\Device\\\\HarddiskVolume\d+\\\\Windows\\\\Microsoft\.NET\\\\Framework(|64)\\\\v(?<dotNetVersion>\d+\.\d+\.\d+)\\\\.*"
+| stats values(FileName) as fileNames by ComputerName, dotNetVersion
+```
+
+## Query 8
+```cql
+event_platform=Lin event_simpleName=OsVersionInfo 
+| rex field=OSVersionString "Linux\\s\\S+\\s(?<kernelVersion>\\S+)?\\s.*"
+```
+
+## Query 9
+```cql
+earliest=-24h event_platform=win event_simpleName=AgentOnline 
+| rex field=AgentVersion "(?<baseAgentVersion>.*)\.\d+\.\d+"
+```
+
+## Query 10
+```cql
+event_platform=win event_simpleName=ProcessRollup2 ImageSubsystem_decimal=3 
+| rex field=CommandLine "(?<suspiciousCharacter>[^[:ascii:]]+)"
+| where isnotnull(suspiciousCharacter)
+| eval suspcisousCharacterCount=len(suspiciousCharacter)
+| table FileName suspcisousCharacterCount suspiciousCharacter CommandLine
+```
+
+## Query 11
+```cql
+event_platform=win event_simpleName=ProcessRollup2 ImageSubsystem_decimal=3
+| where isnotnull(CallStackModuleNames)
+| head 50
+| eval CallStackModuleNames=split(CallStackModuleNames, "|")
+| eval n=mvfilter(match(CallStackModuleNames, ".*exe") OR match(CallStackModuleNames, ".*dll"))
+| rex field=n ".*\\\\Device\\\\HarddiskVolume\d+(?<loadedFile>.*(\.dll|\.exe)).*"
+| fields ComputerName FileName CallStackModuleNames loadedFile
+```

--- a/Queries-Only/Cool-Query-Friday/2021-09-24 - Cool Query Friday - Coalesce.md
+++ b/Queries-Only/Cool-Query-Friday/2021-09-24 - Cool Query Friday - Coalesce.md
@@ -1,0 +1,62 @@
+---
+title: "Coalesce"
+date: 2021-09-24
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/puj8w6/20210924_cool_query_friday_coalesce/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Coalesce
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/puj8w6/20210924_cool_query_friday_coalesce/](https://www.reddit.com/r/crowdstrike/comments/puj8w6/20210924_cool_query_friday_coalesce/) — by Andrew-CS (CrowdStrike) — 2021-09-24
+
+Welcome to our twenty-fourth installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk though of each step (3) application in the wild.
+
+## Query 1
+```cql
+aid=7ce9db2ac1da4e8fb116e494a8c77a2d 253714948641
+| table ProcessStartTime_decimal, ContextTimeStamp_decimal, event_simpleName, FileName, CommandLine, DomainName, RespondingDnsServer
+```
+
+## Query 2
+```cql
+aid=7ce9db2ac1da4e8fb116e494a8c77a2d 253714948641
+| eval falconPID=coalesce(TargetProcessId_decimal, ContextProcessId_decimal)
+| eval details1=coalesce(FileName, DomainName, ExitCode_decimal)
+| eval details2=coalesce(CommandLine, RespondingDnsServer)
+```
+
+## Query 3
+```cql
+aid=7ce9db2ac1da4e8fb116e494a8c77a2d 253714948641
+| eval falconPID=coalesce(TargetProcessId_decimal, ContextProcessId_decimal)
+| eval details1=coalesce(FileName, DomainName, ExitCode_decimal)
+| eval details2=coalesce(CommandLine, RespondingDnsServer)
+| table _time aid ComputerName falconPID event_simpleName details1 details2
+| sort + _time
+```
+
+## Query 4
+```cql
+aid=7ce9db2ac1da4e8fb116e494a8c77a2d 253714948641
+| eval falconPID=coalesce(TargetProcessId_decimal, ContextProcessId_decimal)
+| eval details1=coalesce(FileName, DomainName, ExitCode_decimal)
+| eval details2=coalesce(CommandLine, RespondingDnsServer)
+| table _time aid ComputerName falconPID event_simpleName details1 details2
+| sort + _time
+| rename aid AS "Falcon AID", ComputerName AS "Endpoint", falconPID as "Falcon PID", event_simpleName AS "Falcon Event", details1 AS "Process Details 1", details2 AS "ProcessDetails 2"
+```
+
+## Query 5
+```cql
+aid=d61cc3e207fb4ef08e8b941d9b4feaa8 (TargetProcessId_decimal=1357691323426 OR ContextProcessId_decimal=1357691323426) AND (event_simpleName IN (ProcessRollup2, EndofProcess, DnsRequest, NetworkConnectIP4, *FileWritten, Asep*))
+| eval Size_MB=round(Size_decimal/1024/1024,2)
+| eval falconPID=coalesce(TargetProcessId_decimal, ContextProcessId_decimal)
+| eval details1=coalesce(FileName, DomainName, ExitCode_decimal, RemoteIP, RegObjectName)
+| eval details2=coalesce(CommandLine, RespondingDnsServer, Size_MB, RPort, RegValue, RegOperationType_decimal)
+| eval details3=coalesce(Protocol_decimal, FilePath, RegStringValue)
+| table _time aid ComputerName falconPID event_simpleName details1 details2 details3
+| sort + _time
+| rename aid AS "Falcon AID", ComputerName AS "Endpoint", falconPID as "Falcon PID", event_simpleName AS "Falcon Event", details1 AS "Process Details 1", details2 AS "Process Details 2", details3 AS "Process Details 3"
+```

--- a/Queries-Only/Cool-Query-Friday/2021-10-01 - Cool Query Friday - FileVault Status in macOS.md
+++ b/Queries-Only/Cool-Query-Friday/2021-10-01 - Cool Query Friday - FileVault Status in macOS.md
@@ -1,0 +1,102 @@
+---
+title: "FileVault Status in macOS"
+date: 2021-10-01
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/pz7i14/20211001_cool_query_friday_filevault_status_in/"
+mitre: []
+series: Cool Query Friday
+---
+
+# FileVault Status in macOS
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/pz7i14/20211001_cool_query_friday_filevault_status_in/](https://www.reddit.com/r/crowdstrike/comments/pz7i14/20211001_cool_query_friday_filevault_status_in/) — by Andrew-CS (CrowdStrike) — 2021-10-01
+
+Welcome to our twenty-fifth installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk though of each step (3) application in the wild.
+
+## Query 1
+```cql
+event_platform=mac event_simpleName=FileVaultStatus
+| fields aid, FileVaultIsEnabled_decimal
+```
+
+## Query 2
+```cql
+event_platform=mac event_simpleName=FileVaultStatus
+| fields aid, FileVaultIsEnabled_decimal
+| eval fvStatus=case(FileVaultIsEnabled_decimal=1, "ENABLED", FileVaultIsEnabled_decimal=0, "DISABLED")
+```
+
+## Query 3
+```cql
+event_platform=mac event_simpleName=FileVaultStatus
+| fields aid, FileVaultIsEnabled_decimal
+| eval fvStatus=case(FileVaultIsEnabled_decimal=1, "ENABLED", FileVaultIsEnabled_decimal=0, "DISABLED")
+| lookup local=true aid_master aid OUTPUT ComputerName, Version, Country, Timezone, FirstSeen
+```
+
+## Query 4
+```cql
+event_platform=mac event_simpleName=FileVaultStatus
+| fields aid, FileVaultIsEnabled_decimal
+| eval fvStatus=case(FileVaultIsEnabled_decimal=1, "ENABLED", FileVaultIsEnabled_decimal=0, "DISABLED")
+| lookup local=true aid_master aid OUTPUT ComputerName, Version, Country, Timezone, FirstSeen
+| stats latest(fvStatus) as fvStatus by aid, ComputerName, Version, Country, Timezone, FirstSeen
+| convert ctime(FirstSeen) as "falconInstallTime"
+```
+
+## Query 5
+```cql
+event_platform=mac (event_simpleName=FileVaultStatus OR event_simpleName=AgentOnline OR event_simpleName=UserLogon)
+| fields aid, aip, FileVaultIsEnabled_decimal, SystemSerialNumber, UserPrincipal
+| eval fvStatus=case(FileVaultIsEnabled_decimal=1, "ENABLED", FileVaultIsEnabled_decimal=0, "DISABLED")
+```
+
+## Query 6
+```cql
+[...]
+| eval SystemSerialNumber=upper(SystemSerialNumber)
+| eval UserPrincipal=lower(UserPrincipal)
+| stats latest(aip) as aip, latest(fvStatus) as fvStatus, values(SystemSerialNumber) as serialNumber, values(UserPrincipal) as endpointLogons by aid
+| where isnotnull(fvStatus)
+```
+
+## Query 7
+```cql
+[...]
+| lookup local=true aid_master aid OUTPUT ComputerName, Version, Country, Timezone, FirstSeen
+```
+
+## Query 8
+```cql
+[...]
+| iplocation aip
+```
+
+## Query 9
+```cql
+[...]
+| table aid, ComputerName, serialNumber, fvStatus, aip, Country, Region, City, Timezone, Version, endpointLogons, FirstSeen
+```
+
+## Query 10
+```cql
+[...]
+| convert ctime(FirstSeen)
+| rename aid as "Falcon Agent ID", ComputerName as "Mac Hostname", serialNumber as "Serial Number", fvStatus as "FileVault", aip as "External IP", Version as "macOS Version", endpointLogons as "User Logons", FirstSeen as "Falcon Install Date"
+```
+
+## Query 11
+```cql
+event_platform=mac (event_simpleName=FileVaultStatus OR event_simpleName=AgentOnline OR event_simpleName=UserLogon)
+| fields aid, aip, FileVaultIsEnabled_decimal, SystemSerialNumber, UserPrincipal 
+| eval fvStatus=case(FileVaultIsEnabled_decimal=1, "ENABLED", FileVaultIsEnabled_decimal=0, "DISABLED")
+| eval SystemSerialNumber=upper(SystemSerialNumber)
+| eval UserPrincipal=lower(UserPrincipal)
+| stats latest(aip) as aip, latest(fvStatus) as fvStatus, values(SystemSerialNumber) as serialNumber, values(UserPrincipal) as endpointLogons by aid
+| where isnotnull(fvStatus)
+| lookup local=true aid_master aid OUTPUT ComputerName, Version, Country, Timezone, FirstSeen
+| iplocation aip
+| table aid, ComputerName, serialNumber, fvStatus, aip, Country, Region, City, Timezone, Version, endpointLogons, FirstSeen
+| convert ctime(FirstSeen)
+| rename aid as "Falcon Agent ID", ComputerName as "Mac Hostname", serialNumber as "Serial Number", fvStatus as "FileVault", aip as "External IP", Version as "macOS Version", endpointLogons as "User Logons", FirstSeen as "Falcon Install Date"
+```

--- a/Queries-Only/Cool-Query-Friday/2021-10-05 - Cool Query Friday - Mining EndOfProcess and Profiling Programs.md
+++ b/Queries-Only/Cool-Query-Friday/2021-10-05 - Cool Query Friday - Mining EndOfProcess and Profiling Programs.md
@@ -1,0 +1,116 @@
+---
+title: "Mining EndOfProcess and Profiling Programs"
+date: 2021-10-05
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/qna2ao/20211005_cool_query_friday_mining_endofprocess/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Mining EndOfProcess and Profiling Programs
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/qna2ao/20211005_cool_query_friday_mining_endofprocess/](https://www.reddit.com/r/crowdstrike/comments/qna2ao/20211005_cool_query_friday_mining_endofprocess/) — by Andrew-CS (CrowdStrike) — 2021-10-05
+
+Welcome to our thirtieth installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk though of each step (3) application in the wild.
+
+## Query 1
+```cql
+index=main sourcetype=EndOfProcess* event_platform=win event_simpleName=EndOfProcess
+| head 1
+| fields *_decimal
+```
+
+## Query 2
+```cql
+[...]
+| lookup local=true appinfo.csv SHA256HashData OUTPUT FileName
+| eval FileName=lower(FileName)
+```
+
+## Query 3
+```cql
+[...]
+| search FileName=powershell.exe
+```
+
+## Query 4
+```cql
+index=main sourcetype=EndOfProcess* event_platform=win event_simpleName=EndOfProcess ImageSubsystem_decimal=3
+| lookup local=true appinfo.csv SHA256HashData OUTPUT FileName
+| eval FileName=lower(FileName) 
+| search FileName=powershell.exe
+```
+
+## Query 5
+```cql
+[...]
+| fields cid, aid, TargetProcessId_decimal, SHA256HashData, FileName, ScreenshotsTakenCount_decimal, NewExecutableWrittenCount_decimal
+```
+
+## Query 6
+```cql
+[...]
+| stats dc(aid) as endpointSampleSize, count(aid) as executionSampleSize, max(NewExecutableWrittenCount_decimal) as maxExeWritten, median(NewExecutableWrittenCount_decimal) as medianExeWritten, avg(NewExecutableWrittenCount_decimal) as avgExeWritten, stdev(NewExecutableWrittenCount_decimal) as stdevExeWritten, max(ScreenshotsTakenCount_decimal) as maxSST, median(ScreenshotsTakenCount_decimal) as medianSST, avg(ScreenshotsTakenCount_decimal) as avgSST, stdev(ScreenshotsTakenCount_decimal) as stdevSST by FileName
+```
+
+## Query 7
+```cql
+index=main sourcetype=EndOfProcess* event_platform=win event_simpleName=EndOfProcess ImageSubsystem_decimal=3
+| lookup local=true appinfo.csv SHA256HashData OUTPUT FileName
+| eval FileName=lower(FileName) 
+| search FileName=powershell.exe
+| fields cid, aid, TargetProcessId_decimal, SHA256HashData, FileName, ScreenshotsTakenCount_decimal, NewExecutableWrittenCount_decimal 
+| search ScreenshotsTakenCount_decimal>0 OR NewExecutableWrittenCount_decimal>=2
+```
+
+## Query 8
+```cql
+[...]
+| search ScreenshotsTakenCount_decimal>0 OR (NewExecutableWrittenCount_decimal>=2 AND NewExecutableWrittenCount_decimal!=27 AND NewExecutableWrittenCount_decimal!=28)
+```
+
+## Query 9
+```cql
+[...]
+| lookup local=true appinfo.csv SHA256HashData OUTPUT FileName as cloudFileName
+```
+
+## Query 10
+```cql
+[...]
+| eval cloudFileName=lower(cloudFileName) 
+| search cloudFileName=powershell.exe
+```
+
+## Query 11
+```cql
+[...]
+| search event_simpleName=ProcessRollup2 OR (event_simpleName=EndOfProcess AND ScreenshotsTakenCount_decimal>0 OR (NewExecutableWrittenCount_decimal>=2 AND NewExecutableWrittenCount_decimal!=27 AND NewExecutableWrittenCount_decimal!=28))
+```
+
+## Query 12
+```cql
+[...]
+| stats dc(event_simpleName) as eventCount, earliest(ProcessStartTime_decimal) as procStartTime, values(ComputerName) as computerName, values(UserName) as userName, values(UserSid_readable) as userSid, values(FileName) as fileName, values(cloudFileName) as cloudFileName, values(CommandLine) as cmdLine, values(ScreenshotsTakenCount_decimal) as screenShotsTaken, values(NewExecutableWrittenCount_decimal) as ExesWritten by aid, TargetProcessId_decimal
+| where eventCount>1
+```
+
+## Query 13
+```cql
+[...]
+| table aid, computerName, userSid, userName, TargetProcessId_decimal, fileName, cloudFileName, ExesWritten, screenShotsTaken, cmdLine
+| rename TargetProcessId_decimal as falconPID
+```
+
+## Query 14
+```cql
+(index=main sourcetype=EndOfProcess* event_platform=win event_simpleName=EndOfProcess ImageSubsystem_decimal=3) OR (index=main sourcetype=ProcessRollup2* event_platform=win event_simpleName=ProcessRollup2 ImageSubsystem_decimal=3)
+| lookup local=true appinfo.csv SHA256HashData OUTPUT FileName as cloudFileName
+| eval cloudFileName=lower(cloudFileName) 
+| search cloudFileName=powershell.exe
+| search event_simpleName=ProcessRollup2 OR (event_simpleName=EndOfProcess AND ScreenshotsTakenCount_decimal>0 OR (NewExecutableWrittenCount_decimal>=2 AND NewExecutableWrittenCount_decimal!=27 AND NewExecutableWrittenCount_decimal!=28))
+| stats dc(event_simpleName) as eventCount, earliest(ProcessStartTime_decimal) as procStartTime, values(ComputerName) as computerName, values(UserName) as userName, values(UserSid_readable) as userSid, values(FileName) as fileName, values(cloudFileName) as cloudFileName, values(CommandLine) as cmdLine, values(ScreenshotsTakenCount_decimal) as screenShotsTaken, values(NewExecutableWrittenCount_decimal) as ExesWritten by aid, TargetProcessId_decimal
+| where eventCount>1
+| table aid, computerName, userSid, userName, TargetProcessId_decimal, fileName, cloudFileName, ExesWritten, screenShotsTaken, cmdLine
+| rename TargetProcessId_decimal as falconPID
+```

--- a/Queries-Only/Cool-Query-Friday/2021-10-08 - Cool Query Friday - Parsing Linux Kernel Version.md
+++ b/Queries-Only/Cool-Query-Friday/2021-10-08 - Cool Query Friday - Parsing Linux Kernel Version.md
@@ -1,0 +1,52 @@
+---
+title: "Parsing Linux Kernel Version"
+date: 2021-10-08
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/q3xscp/20211008_cool_query_friday_parsing_linux_kernel/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Parsing Linux Kernel Version
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/q3xscp/20211008_cool_query_friday_parsing_linux_kernel/](https://www.reddit.com/r/crowdstrike/comments/q3xscp/20211008_cool_query_friday_parsing_linux_kernel/) — by Andrew-CS (CrowdStrike) — 2021-10-08
+
+Welcome to our twenty-sixth installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk though of each step (3) application in the wild.
+
+## Query 1
+```cql
+|  rex field=OSVersionString "Linux\s+\S+\s+(?<kernelVersion>.*)\s+\#.*"
+```
+
+## Query 2
+```cql
+event_platform=lin event_simpleName=OsVersionInfo
+|  rex field=OSVersionString "Linux\s+\S+\s+(?<kernelVersion>.*)\s+\#.*"
+| fields aid, ComputerName, AgentVersion, kernelVersion
+```
+
+## Query 3
+```cql
+| stats latest(kernelVersion) as kernelVersion by aid
+```
+
+## Query 4
+```cql
+index=main sourcetype=OsVersionInfo* event_platform=lin event_simpleName=OsVersionInfo
+| fields aid, OSVersionString
+| rex field=OSVersionString "Linux\s+\S+\s+(?<kernelVersion>.*)\s+\#.*"
+| stats latest(kernelVersion) as kernelVersion by aid
+| lookup local=true aid_master aid OUTPUT ComputerName, Version, Timezone, AgentVersion, BiosManufacturer, Continent, Country, FirstSeen
+```
+
+## Query 5
+```cql
+index=main sourcetype=OsVersionInfo* event_platform=lin event_simpleName=OsVersionInfo
+| fields aid, OSVersionString
+|  rex field=OSVersionString "Linux\s+\S+\s+(?<kernelVersion>.*)\s+\#.*"
+| stats latest(kernelVersion) as kernelVersion by aid
+| lookup local=true aid_master aid OUTPUT ComputerName, Version, Timezone, AgentVersion, BiosManufacturer, Continent, Country, FirstSeen
+| convert ctime(FirstSeen)
+| table aid, ComputerName, Version, kernelVersion, AgentVersion, FirstSeen, BiosManufacturer, Continent, Country, Timezone
+| rename aid as "Falcon Agent ID", ComputerName as "Endpoint", Version as "OS", kernelVersion as "Kernel", AgentVersion as "Falcon Version", FirstSeen as "Falcon Install Date", BiosManufacturer as "BIOS Maker"
+```

--- a/Queries-Only/Cool-Query-Friday/2021-10-08 - Cool Query Friday - Parsing Linux Kernel Version.md
+++ b/Queries-Only/Cool-Query-Friday/2021-10-08 - Cool Query Friday - Parsing Linux Kernel Version.md
@@ -50,3 +50,11 @@ index=main sourcetype=OsVersionInfo* event_platform=lin event_simpleName=OsVersi
 | table aid, ComputerName, Version, kernelVersion, AgentVersion, FirstSeen, BiosManufacturer, Continent, Country, Timezone
 | rename aid as "Falcon Agent ID", ComputerName as "Endpoint", Version as "OS", kernelVersion as "Kernel", AgentVersion as "Falcon Version", FirstSeen as "Falcon Install Date", BiosManufacturer as "BIOS Maker"
 ```
+
+## Community & Staff Additions
+*Harvested from this post's [r/CrowdStrike](https://www.reddit.com/r/crowdstrike/) comment thread — not part of the original CQF post. **[CS]** = CrowdStrike staff · **[Community]** = other r/CrowdStrike users. Upvote scores shown for context.*
+
+### Operational caveats
+
+> Ah! Sorry, I misunderstood. In your RTR feed, do you have the field OSVersionFileData? If yes, what are you using to look at RTR? Splunk?
+— [CS] Andrew-CS · score 1

--- a/Queries-Only/Cool-Query-Friday/2021-10-15 - Cool Query Friday - Mining Windows CommandHistory for Artifacts.md
+++ b/Queries-Only/Cool-Query-Friday/2021-10-15 - Cool Query Friday - Mining Windows CommandHistory for Artifacts.md
@@ -62,3 +62,19 @@ index=main sourcetype=CommandHistory* event_platform=win event_simpleName=Comman
 | convert ctime(timestamp)
 | rename timestamp as Time, ComputerName as Endpoint, ApplicationName as "Responsible Application", TargetProcessId_decimal as "Falcon PID", passedURL as "URL Fragment", CommandHistory as "Complete Command Context"
 ```
+
+## Community & Staff Additions
+*Harvested from this post's [r/CrowdStrike](https://www.reddit.com/r/crowdstrike/) comment thread — not part of the original CQF post. **[CS]** = CrowdStrike staff · **[Community]** = other r/CrowdStrike users. Upvote scores shown for context.*
+
+### Query variants
+
+```cql
+index=main AND (sourcetype=CommandHistory* event_platform=win event_simpleName=CommandHistory) OR (sourcetype=ProcessRollup* event_platform=win event_simpleName=ProcessRollup2) | rex field=CommandHistory ".(?<passedURL>http(|s)://..(net|com|org|io)).*" | stats dc(event_simpleName) as eventCount, values(ComputerName) as ComputerName, values(FileName) as FileName, values(UserSid_readable) as UserSid_readable, values(CommandHistory) as CommandHistory, values(passedURL) as passedURL, latest(ProcessStartTime_decimal) as time by aid, TargetProcessId_decimal | where eventCount>1 AND isnotnull(passedURL) | lookup local=true userinfo.csv UserSid_readable OUTPUT UserName | table time aid ComputerName UserSid_readable UserName FileName TargetProcessId_decimal passedURL CommandHistory | sort + time | convert ctime(time) | rename time as Time, aid as "Falcon Agent ID", ComputerName as Endpoint, UserSid_readable as "User SID", UserName as User, FileName as File, TargetProcessId_decimal as "Falcon PID", passedURL as "URL", CommandHistory as "Complete Command History"
+```
+— [CS] Andrew-CS · comment score 4
+
+### Q&A
+
+**Q — [Community] Sackman_and_Throbbin:** Is there a way to query the parent process data to determine UserName info?
+
+**A — [CS] Andrew-CS:** Hi there. Try this: index=main AND (sourcetype=CommandHistory* event_platform=win event_simpleName=CommandHistory) OR (sourcetype=ProcessRollup* event_platform=win event_simpleName=ProcessRollup2) | rex field=CommandHistory ".(?<passedURL>http(|s)://..(net|com|org|io)).*" | stats dc(event_simpleName) as eventCount, values(ComputerName) as ComputerName, values(FileName) as FileName, values(UserSid_readable) as UserSid_readable, values(CommandHistory) as CommandHistory, values(passedURL) as passed …

--- a/Queries-Only/Cool-Query-Friday/2021-10-15 - Cool Query Friday - Mining Windows CommandHistory for Artifacts.md
+++ b/Queries-Only/Cool-Query-Friday/2021-10-15 - Cool Query Friday - Mining Windows CommandHistory for Artifacts.md
@@ -1,0 +1,64 @@
+---
+title: "Mining Windows CommandHistory for Artifacts"
+date: 2021-10-15
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/q8qzmp/20211015_cool_query_friday_mining_windows/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Mining Windows CommandHistory for Artifacts
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/q8qzmp/20211015_cool_query_friday_mining_windows/](https://www.reddit.com/r/crowdstrike/comments/q8qzmp/20211015_cool_query_friday_mining_windows/) — by Andrew-CS (CrowdStrike) — 2021-10-15
+
+Welcome to our twenty-seventh installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk though of each step (3) application in the wild.
+
+## Query 1
+```cql
+index=main sourcetype=CommandHistory* event_platform=win event_simpleName=CommandHistory
+| rex field=CommandHistory ".*(?<passedURL>http(|s)\:\/\/.*\.(net|com|org|io)).*"
+```
+
+## Query 2
+```cql
+http(s):\\<anything>.com|.net|.org|.io
+```
+
+## Query 3
+```cql
+index=main sourcetype=CommandHistory* event_platform=win event_simpleName=CommandHistory
+| rex field=CommandHistory ".*(?<passedURL>http(|s)\:\/\/.*\.(net|com|org|io)).*"
+| where isnotnull(passedURL)
+```
+
+## Query 4
+```cql
+[...]
+| fillnull ApplicationName value="powershell.exe"
+| eval timestamp=timestamp/1000
+| table timestamp ComputerName ApplicationName TargetProcessId_decimal passedURL CommandHistory 
+| convert ctime(timestamp)
+| rename timestamp as Time, ComputerName as Endpoint, ApplicationName as "Responsible Application", TargetProcessId_decimal as "Falcon PID", passedURL as "URL Fragment", CommandHistory as "Complete Command Context"
+```
+
+## Query 5
+```cql
+[...]
+| table timestamp ComputerName ApplicationName TargetProcessId_decimal passedURL CommandHistory 
+| search ComputerName!=DESKTOP-ICAKMS8 AND passedURL!="*.crowdstrike.*" AND passedURL!="*.microsoft.*"
+| convert ctime(timestamp)
+[...]
+```
+
+## Query 6
+```cql
+index=main sourcetype=CommandHistory* event_platform=win event_simpleName=CommandHistory
+| rex field=CommandHistory ".*(?<passedURL>http(|s)\:\/\/.*\.(net|com|org|io)).*"
+| where isnotnull(passedURL)
+| fillnull ApplicationName value="powershell.exe"
+| eval timestamp=timestamp/1000
+| table timestamp ComputerName ApplicationName TargetProcessId_decimal passedURL CommandHistory 
+| search ComputerName!=DESKTOP-ICAKMS8 AND passedURL!="*.crowdstrike.*" AND passedURL!="*.microsoft.*"
+| convert ctime(timestamp)
+| rename timestamp as Time, ComputerName as Endpoint, ApplicationName as "Responsible Application", TargetProcessId_decimal as "Falcon PID", passedURL as "URL Fragment", CommandHistory as "Complete Command Context"
+```

--- a/Queries-Only/Cool-Query-Friday/2021-10-22 - Cool Query Friday - Scheduled Searches, Failed User Logons, and Thresholds.md
+++ b/Queries-Only/Cool-Query-Friday/2021-10-22 - Cool Query Friday - Scheduled Searches, Failed User Logons, and Thresholds.md
@@ -97,3 +97,34 @@ index=main sourcetype=UserLogonFailed* event_platform=win event_simpleName=UserL
 | convert ctime(firstFailedAttmpt) ctime(lastFailedAttempt)
 | sort -failedLogonAttempts
 ```
+
+## Community & Staff Additions
+*Harvested from this post's [r/CrowdStrike](https://www.reddit.com/r/crowdstrike/) comment thread — not part of the original CQF post. **[CS]** = CrowdStrike staff · **[Community]** = other r/CrowdStrike users. Upvote scores shown for context.*
+
+### Query variants
+
+```cql
+index=main sourcetype=AgentConnect* event_simpleName=AgentConnect 
+| fields aip, aid, ConnectTime_decimal 
+| stats latest(aip) as aip latest(ConnectTime_decimal) as connectionTime by aid
+| iplocation aip 
+| lookup local=true aid_master aid OUTPUT ComputerName 
+| table aid, ComputerName, connectionTime, aip, Country, Region, City
+| convert ctime(connectionTime)
+| rename aid as "Falcon ID", ComputerName as "Endpoint", connectionTime as "Last Connection", aip as "Last External IP"
+```
+— [CS] Andrew-CS · comment score 1
+
+### Q&A
+
+**Q — [Community] Nerdcentric:** When I test the query it is defaulting back to a search window of "Last 15 minutes". If I am scheduling this to run once every 24 hours, am I only getting the events for the last 15 minutes when it runs? I feel like I missed where you set the search window to 24 hours. Or is that automatic based on …
+
+**A — [CS] Andrew-CS:** Great question. When you click "Schedule Query" the frequency you pick will also be the search window.
+
+**Q — [Community] DreadlockedSOC:** I'm a little late to this party. How do I set my every 24hr scheduled search to query the last 7 days of data? I want my query to grab the last 7 days of data every 24hrs. I tried to add 'earliest -7d' but it barked an error at me.
+
+**A — [CS] Andrew-CS:** At present, 24 hours is the max you can set as we need to assess how ~~soul crushing~~ performant the queries are :)
+
+**Q — [Community] Ballzovsteel:** When I am looking at the delta and delta seconds. What does that exactly mean, is that the time between attempts?
+
+**A — [CS] Andrew-CS:** It’s the time difference between the very first failed login and the very last failed login. So if there were 10 failed attempts, it would be the difference between 1 and 10.

--- a/Queries-Only/Cool-Query-Friday/2021-10-22 - Cool Query Friday - Scheduled Searches, Failed User Logons, and Thresholds.md
+++ b/Queries-Only/Cool-Query-Friday/2021-10-22 - Cool Query Friday - Scheduled Searches, Failed User Logons, and Thresholds.md
@@ -1,0 +1,99 @@
+---
+title: "Scheduled Searches, Failed User Logons, and Thresholds"
+date: 2021-10-22
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/qdebwx/20211022_cool_query_friday_scheduled_searches/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Scheduled Searches, Failed User Logons, and Thresholds
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/qdebwx/20211022_cool_query_friday_scheduled_searches/](https://www.reddit.com/r/crowdstrike/comments/qdebwx/20211022_cool_query_friday_scheduled_searches/) — by Andrew-CS (CrowdStrike) — 2021-10-22
+
+Welcome to our twenty-eighth installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk though of each step (3) application in the wild.
+
+## Query 1
+```cql
+[...]
+| search LogonType_decimal IN (2, 7, 10, 13)
+```
+
+## Query 2
+```cql
+[...]
+| where ComputerName=LogonDomain
+```
+
+## Query 3
+```cql
+[...]
+| table ContextTimeStamp_decimal aid ComputerName LocalAddressIP4 UserName LogonType_decimal RemoteAddressIP4 SubStatus_decimal
+```
+
+## Query 4
+```cql
+index=main sourcetype=UserLogonFailed* event_platform=win event_simpleName=UserLogonFailed2 
+| search LogonType_decimal IN (2, 7, 10, 13)
+| where ComputerName=LogonDomain
+| eval LogonType=case(LogonType_decimal="2", "Interactive", LogonType_dgecimal="7", "Unlock", LogonType_decimal="10", "RDP", LogonType_decimal="13", "Unlock Workstation")
+| eval SubStatus_decimal=tostring(SubStatus_decimal,"hex")
+| eval SubStatus_decimal=replace(SubStatus_decimal,"0xC0000064", "User name does not exist")
+| eval SubStatus_decimal=replace(SubStatus_decimal,"0xC000006A", "User name is correct but the password is wrong")
+| eval SubStatus_decimal=replace(SubStatus_decimal,"0xC0000234", "User is currently locked out")
+| eval SubStatus_decimal=replace(SubStatus_decimal,"0xC0000072", "Account is currently disabled")
+| eval SubStatus_decimal=replace(SubStatus_decimal,"0xC000006F", "User tried to logon outside his day of week or time of day restrictions")
+| eval SubStatus_decimal=replace(SubStatus_decimal,"0xC0000070", "Workstation restriction, or Authentication Policy Silo violation (look for event ID 4820 on domain controller)")
+| eval SubStatus_decimal=replace(SubStatus_decimal,"0xC0000193", "Account expiration")
+| eval SubStatus_decimal=replace(SubStatus_decimal,"0xC0000071", "Expired password")
+| eval SubStatus_decimal=replace(SubStatus_decimal,"0xC0000133", "Clocks between DC and other computer too far out of sync")
+| eval SubStatus_decimal=replace(SubStatus_decimal,"0xC0000224", "User is required to change password at next logon")
+| eval SubStatus_decimal=replace(SubStatus_decimal,"0xC0000225", "Evidently a bug in Windows and not a risk")
+| eval SubStatus_decimal=replace(SubStatus_decimal,"0xc000015b", "The user has not been granted the requested logon type (aka logon right) at this machine")
+| eval SubStatus_decimal=replace(SubStatus_decimal,"0xC000006E", "Unknown user name or bad password")
+| table ContextTimeStamp_decimal aid ComputerName LocalAddressIP4 UserName LogonType RemoteAddressIP4 SubStatus_decimal
+```
+
+## Query 5
+```cql
+[...]
+| stats values(ComputerName) as computerName, values(LocalAddressIP4) as localIPAddresses, count(aid) as failedLogonAttempts, dc(UserName) as credentialsUsed, values(UserName) as userNames, earliest(ContextTimeStamp_decimal) as firstFailedAttmpt, latest(ContextTimeStamp_decimal) as lastFailedAttempt, values(RemoteAddressIP4) as remoteIPAddresses, values(LogonType) as logonTypes, values(SubStatus_decimal) as failedLogonReasons by aid
+```
+
+## Query 6
+```cql
+[...]
+| eval failedLoginsDeltaMinutes=round((lastFailedAttempt-firstFailedAttmpt)/60,0)
+| eval failedLoginsDeltaSeconds=round((lastFailedAttempt-firstFailedAttmpt),2)
+| where failedLogonAttempts>=5
+| convert ctime(firstFailedAttmpt) ctime(lastFailedAttempt)
+| sort -failedLogonAttempts
+```
+
+## Query 7
+```cql
+index=main sourcetype=UserLogonFailed* event_platform=win event_simpleName=UserLogonFailed2 
+| search LogonType_decimal IN (2, 7, 10, 13)
+| where ComputerName=LogonDomain
+| eval LogonType=case(LogonType_decimal="2", "Interactive", LogonType_dgecimal="7", "Unlock", LogonType_decimal="10", "RDP", LogonType_decimal="13", "Unlock Workstation")
+| eval SubStatus_decimal=tostring(SubStatus_decimal,"hex")
+| eval SubStatus_decimal=replace(SubStatus_decimal,"0xC0000064", "User name does not exist")
+| eval SubStatus_decimal=replace(SubStatus_decimal,"0xC000006A", "User name is correct but the password is wrong")
+| eval SubStatus_decimal=replace(SubStatus_decimal,"0xC0000234", "User is currently locked out")
+| eval SubStatus_decimal=replace(SubStatus_decimal,"0xC0000072", "Account is currently disabled")
+| eval SubStatus_decimal=replace(SubStatus_decimal,"0xC000006F", "User tried to logon outside his day of week or time of day restrictions")
+| eval SubStatus_decimal=replace(SubStatus_decimal,"0xC0000070", "Workstation restriction, or Authentication Policy Silo violation (look for event ID 4820 on domain controller)")
+| eval SubStatus_decimal=replace(SubStatus_decimal,"0xC0000193", "Account expiration")
+| eval SubStatus_decimal=replace(SubStatus_decimal,"0xC0000071", "Expired password")
+| eval SubStatus_decimal=replace(SubStatus_decimal,"0xC0000133", "Clocks between DC and other computer too far out of sync")
+| eval SubStatus_decimal=replace(SubStatus_decimal,"0xC0000224", "User is required to change password at next logon")
+| eval SubStatus_decimal=replace(SubStatus_decimal,"0xC0000225", "Evidently a bug in Windows and not a risk")
+| eval SubStatus_decimal=replace(SubStatus_decimal,"0xc000015b", "The user has not been granted the requested logon type (aka logon right) at this machine")
+| eval SubStatus_decimal=replace(SubStatus_decimal,"0xC000006E", "Unknown user name or bad password")
+| stats values(ComputerName) as computerName, values(LocalAddressIP4) as localIPAddresses, count(aid) as failedLogonAttempts, dc(UserName) as credentialsUsed, values(UserName) as userNames, earliest(ContextTimeStamp_decimal) as firstFailedAttmpt, latest(ContextTimeStamp_decimal) as lastFailedAttempt, values(RemoteAddressIP4) as remoteIPAddresses, values(LogonType) as logonTypes, values(SubStatus_decimal) as failedLogonReasons by aid
+| eval failedLoginsDeltaMinutes=round((lastFailedAttempt-firstFailedAttmpt)/60,0)
+| eval failedLoginsDeltaSeconds=round((lastFailedAttempt-firstFailedAttmpt),2)
+| where failedLogonAttempts>=5
+| convert ctime(firstFailedAttmpt) ctime(lastFailedAttempt)
+| sort -failedLogonAttempts
+```

--- a/Queries-Only/Cool-Query-Friday/2021-11-12 - Cool Query Friday - Tagging and Tracking Lost Endpoints.md
+++ b/Queries-Only/Cool-Query-Friday/2021-11-12 - Cool Query Friday - Tagging and Tracking Lost Endpoints.md
@@ -1,0 +1,64 @@
+---
+title: "Tagging and Tracking Lost Endpoints"
+date: 2021-11-12
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/qsbtnp/20211112_cool_query_friday_tagging_and_tracking/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Tagging and Tracking Lost Endpoints
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/qsbtnp/20211112_cool_query_friday_tagging_and_tracking/](https://www.reddit.com/r/crowdstrike/comments/qsbtnp/20211112_cool_query_friday_tagging_and_tracking/) — by Andrew-CS (CrowdStrike) — 2021-11-12
+
+Welcome to our thirty-first installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk though of each step (3) application in the wild.
+
+## Query 1
+```cql
+| inputlookup aid_master
+| table aid ComputerName *Tags
+```
+
+## Query 2
+```cql
+[...]
+| lookup local=true aid_master aid OUTPUT FalconGroupingTags
+```
+
+## Query 3
+```cql
+[...]
+| search FalconGroupingTags!="none" AND FalconGroupingTags!="-"
+| makemv delim=";" FalconGroupingTags
+| search FalconGroupingTags="FalconGroupingTags\Group2"
+```
+
+## Query 4
+```cql
+index=main sourcetype=AgentConnect* event_simpleName=AgentConnect 
+| lookup local=true aid_master aid OUTPUT FalconGroupingTags 
+| search FalconGroupingTags!="none" AND FalconGroupingTags!="-" 
+| makemv delim=";" FalconGroupingTags 
+| search FalconGroupingTags="FalconGroupingTags/Group2"
+| fields aid, aip, ComputerName, ConnectTime_decimal, FalconGroupingTags
+```
+
+## Query 5
+```cql
+[...]
+| iplocation aip
+```
+
+## Query 6
+```cql
+[...]
+| stats count(aid) as totalConnections, earliest(ConnectTime_decimal) as firstConnect, latest(ConnectTime_decimal) as lastConnect by aid, ComputerName, aip, City, Region, Country
+| convert ctime(firstConnect) ctime(lastConnect)
+```
+
+## Query 7
+```cql
+[...]
+| sort +ComputerName, +firstConnect
+| rename aid as "Falcon Agent ID", ComputerName as "Lost System", aip as "External IP", totalConnections as "Connections from IP", firstConnect as "First Connection", lastConnect as "Last Connection"
+```

--- a/Queries-Only/Cool-Query-Friday/2021-12-03 - Cool Query Friday - Auditing SSH Connections in Linux.md
+++ b/Queries-Only/Cool-Query-Friday/2021-12-03 - Cool Query Friday - Auditing SSH Connections in Linux.md
@@ -101,3 +101,55 @@ event_platform=lin event_simpleName=CriticalEnvironmentVariableChanged, Environm
 [...]
 | search NOT clientIP IN (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 127.0.0.1)
 ```
+
+## Community & Staff Additions
+*Harvested from this post's [r/CrowdStrike](https://www.reddit.com/r/crowdstrike/) comment thread — not part of the original CQF post. **[CS]** = CrowdStrike staff · **[Community]** = other r/CrowdStrike users. Upvote scores shown for context.*
+
+### Query variants
+
+```cql
+event_platfrom=lin event_simpleName=ProcessRollup2 FileName IN (scp, sftp)
+| table _time ComputerName FileName CommandLine
+```
+— [CS] Andrew-CS · comment score 1
+
+```cql
+event_platform=lin event_simpleName=CriticalEnvironmentVariableChanged, EnvironmentVariableName IN (SSH_CONNECTION, USER) 
+| stats values(EnvironmentVariableName) as EnvironmentVariableName,values(EnvironmentVariableValue) as EnvironmentVariableValue by aid, ContextProcessId_decimal, ContextTimeStamp_decimal
+| eval tempData=mvzip(EnvironmentVariableName,EnvironmentVariableValue,":")
+| rex field=tempData "SSH_CONNECTION\:((?<clientIP>\d+\.\d+\.\d+\.\d+)\s+(?<rPort>\d+)\s+(?<serverIP>\d+\.\d+\.\d+\.\d+)\s+(?<lPort>\d+))"
+| rex field=tempData "USER\:(?<userName>.*)"
+| where isnotnull(clientIP)
+| iplocation clientIP
+| lookup local=true aid_master aid OUTPUT ComputerName as ComputerName, Version as osVersion, Country as sshServerCountry
+| fillnull City, Country, Region value="-"
+| table ContextTimeStamp_decimal aid ComputerName sshServerCountry osVersion serverIP lPort userName clientIP rPort City Region Country
+| where isnotnull(userName)
+| convert ctime(ContextTimeStamp_decimal)
+| sort +ComputerName, +ContextTimeStamp_decimal
+```
+— [CS] Andrew-CS · comment score 3
+
+```cql
+cat /var/log/auth.log | grep "Failed password"
+```
+— [CS] Andrew-CS · comment score 2
+
+### Operational caveats
+
+> Hi there. If you specify the `index` and `sourcetype` you're using in your Splunk instance does performance improve?
+— [CS] Andrew-CS · score 2
+
+### Q&A
+
+**Q — [Community] brandeded:** How can scp usage and sftp subsystem usage be identified?
+
+**A — [CS] Andrew-CS:** Hi there. Since those are both programs, you would look for `ProcessRollup2` events. event_platfrom=lin event_simpleName=ProcessRollup2 FileName IN (scp, sftp) | table _time ComputerName FileName CommandLine That will show you those events.
+
+**Q — [Community] brandeded:** Meaning, if I run 'pscp' on my Windows client, it invokes `scp` on the server?
+
+**A — [CS] Andrew-CS:** If Falcon is on both systems, you should see a `ProcessRollup2` event for `pscp` on your Windows system and an SSH Login on the server system assuming the server is Linux.
+
+**Q — [Community] brandeded:** Yes. To confirm, this means that `scp` usage can't be observed server side with crowdstrike, but could be observed on-the-wire. Crowdstrike can not observe packets inbound?
+
+**A — [CS] Andrew-CS:** Correct, because from a process execution standpoint scp isn't running on the server. If you were to have SSL interception/inspection you might be able to determine SCP, but again on the surface it will look like SSH from the packet generics.

--- a/Queries-Only/Cool-Query-Friday/2021-12-03 - Cool Query Friday - Auditing SSH Connections in Linux.md
+++ b/Queries-Only/Cool-Query-Friday/2021-12-03 - Cool Query Friday - Auditing SSH Connections in Linux.md
@@ -1,0 +1,103 @@
+---
+title: "Auditing SSH Connections in Linux"
+date: 2021-12-03
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/r80usb/20211203_cool_query_friday_auditing_ssh/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Auditing SSH Connections in Linux
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/r80usb/20211203_cool_query_friday_auditing_ssh/](https://www.reddit.com/r/crowdstrike/comments/r80usb/20211203_cool_query_friday_auditing_ssh/) — by Andrew-CS (CrowdStrike) — 2021-12-03
+
+Welcome to our thirty-first installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk though of each step (3) application in the wild.
+
+## Query 1
+```cql
+event_platform=lin event_simpleName=CriticalEnvironmentVariableChanged, EnvironmentVariableName IN (SSH_CONNECTION, USER) 
+| eventstats list(EnvironmentVariableName) as EnvironmentVariableName,list(EnvironmentVariableValue) as EnvironmentVariableValue by aid, ContextProcessId_decimal
+```
+
+## Query 2
+```cql
+event_platform=lin event_simpleName=CriticalEnvironmentVariableChanged, EnvironmentVariableName IN (SSH_CONNECTION, USER) 
+| eventstats list(EnvironmentVariableName) as EnvironmentVariableName,list(EnvironmentVariableValue) as EnvironmentVariableValue by aid, ContextProcessId_decimal
+| eval tempData=mvzip(EnvironmentVariableName,EnvironmentVariableValue,":")
+```
+
+## Query 3
+```cql
+event_platform=lin event_simpleName=CriticalEnvironmentVariableChanged, EnvironmentVariableName IN (SSH_CONNECTION, USER) 
+| eventstats list(EnvironmentVariableName) as EnvironmentVariableName,list(EnvironmentVariableValue) as EnvironmentVariableValue by aid, ContextProcessId_decimal
+| eval tempData=mvzip(EnvironmentVariableName,EnvironmentVariableValue,":") 
+| table ComputerName tempData
+```
+
+## Query 4
+```cql
+[...]
+| rex field=tempData "SSH_CONNECTION\:((?<clientIP>\d+\.\d+\.\d+\.\d+)\s+(?<rPort>\d+)\s+(?<serverIP>\d+\.\d+\.\d+\.\d+)\s+(?<lPort>\d+))"
+| rex field=tempData "USER\:(?<userName>.*)"
+```
+
+## Query 5
+```cql
+event_platform=lin event_simpleName=CriticalEnvironmentVariableChanged, EnvironmentVariableName IN (SSH_CONNECTION, USER) 
+| eventstats list(EnvironmentVariableName) as EnvironmentVariableName,list(EnvironmentVariableValue) as EnvironmentVariableValue by aid, ContextProcessId_decimal
+| eval tempData=mvzip(EnvironmentVariableName,EnvironmentVariableValue,":")
+| rex field=tempData "SSH_CONNECTION\:((?<clientIP>\d+\.\d+\.\d+\.\d+)\s+(?<rPort>\d+)\s+(?<serverIP>\d+\.\d+\.\d+\.\d+)\s+(?<lPort>\d+))"
+| rex field=tempData "USER\:(?<userName>.*)"
+| where isnotnull(clientIP)
+| table ComputerName userName serverIP lPort clientIP rPort
+```
+
+## Query 6
+```cql
+[...]
+| iplocation clientIP
+| lookup local=true aid_master aid OUTPUT Version as osVersion, Country as sshServerCountry
+| fillnull City, Country, Region value="-"
+```
+
+## Query 7
+```cql
+[...]
+| table _time aid ComputerName sshServerCountry osVersion serverIP lPort userName clientIP rPort City Region Country
+| where isnotnull(userName)
+| sort +ComputerName, +_time
+```
+
+## Query 8
+```cql
+event_platform=lin event_simpleName=CriticalEnvironmentVariableChanged, EnvironmentVariableName IN (SSH_CONNECTION, USER) 
+| eventstats list(EnvironmentVariableName) as EnvironmentVariableName,list(EnvironmentVariableValue) as EnvironmentVariableValue by aid, ContextProcessId_decimal
+| eval tempData=mvzip(EnvironmentVariableName,EnvironmentVariableValue,":")
+| rex field=tempData "SSH_CONNECTION\:((?<clientIP>\d+\.\d+\.\d+\.\d+)\s+(?<rPort>\d+)\s+(?<serverIP>\d+\.\d+\.\d+\.\d+)\s+(?<lPort>\d+))"
+| rex field=tempData "USER\:(?<userName>.*)"
+| where isnotnull(clientIP)
+| iplocation clientIP
+| lookup local=true aid_master aid OUTPUT Version as osVersion, Country as sshServerCountry
+| fillnull City, Country, Region value="-"
+| table _time aid ComputerName sshServerCountry osVersion serverIP lPort userName clientIP rPort City Region Country
+| where isnotnull(userName)
+| sort +ComputerName, +_time
+```
+
+## Query 9
+```cql
+[...]
+| search NOT Country IN ("-", "United States")
+```
+
+## Query 10
+```cql
+[...]
+| search userName=root
+```
+
+## Query 11
+```cql
+[...]
+| search NOT clientIP IN (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 127.0.0.1)
+```

--- a/Queries-Only/Cool-Query-Friday/2021-12-10 - Cool Query Friday - Hunting Apache Log4j CVE-2021-44228 (Log4Shell).md
+++ b/Queries-Only/Cool-Query-Friday/2021-12-10 - Cool Query Friday - Hunting Apache Log4j CVE-2021-44228 (Log4Shell).md
@@ -1,0 +1,37 @@
+---
+title: "Hunting Apache Log4j CVE-2021-44228 (Log4Shell)"
+date: 2021-12-10
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/rda0ls/20211210_cool_query_friday_hunting_apache_log4j/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Hunting Apache Log4j CVE-2021-44228 (Log4Shell)
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/rda0ls/20211210_cool_query_friday_hunting_apache_log4j/](https://www.reddit.com/r/crowdstrike/comments/rda0ls/20211210_cool_query_friday_hunting_apache_log4j/) — by Andrew-CS (CrowdStrike) — 2021-12-10
+
+Welcome to our thirty-second\* installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk though of each step (3) application in the wild.
+
+## Query 1
+```cql
+event_simpleName IN (ProcessRollup2, SyntheticProcessRollup2, JarFileWritten, NewExecutableWritten, PeFileWritten, ElfFileWritten)
+| search log4j
+| eval falconEvents=case(event_simpleName="ProcessRollup2", "Process Execution", event_simpleName="SyntheticProcessRollup2", "Process Execution", event_simpleName="JarFileWritten", "JAR File Write", event_simpleName="NewExecutableWritten", "EXE File Write", event_simpleName="PeFileWritten", "EXE File Write", event_simpleName=ElfFileWritten, "ELF File Write")
+| fillnull value="-"
+| stats dc(falconEvents) as totalEvents, values(falconEvents) as falconEvents, values(ImageFileName) as fileName, values(CommandLine) as cmdLine by aid, ProductType
+| eval productType=case(ProductType = "1","Workstation", ProductType = "2","Domain Controller", ProductType = "3","Server", event_platform = "Mac", "Workstation") 
+| lookup local=true aid_master aid OUTPUT Version, ComputerName, AgentVersion
+| table aid, ComputerName, productType, Version, AgentVersion, totalEvents, falconEvents, fileName, cmdLine
+| sort +productType, +ComputerName
+```
+
+## Query 2
+```cql
+event_simpleName IN (ProcessRollup2, SyntheticProcessRollup2) 
+| fields ProcessStartTime_decimal ComputerName  FileName CommandLine
+| search CommandLine="*jndi:ldap:*" OR CommandLine="*jndi:rmi:*" OR CommandLine="*jndi:ldaps:*" OR CommandLine="*jndi:dns:*" 
+| rex field=CommandLine ".*(?<stringOfInterest>\$\{jndi\:(ldap|rmi|ldaps|dns)\:.*\}).*"
+| table ProcessStartTime_decimal ComputerName FileName stringOfInterest CommandLine
+| convert ctime(ProcessStartTime_decimal)
+```

--- a/Queries-Only/Cool-Query-Friday/2021-12-10 - Cool Query Friday - Hunting Apache Log4j CVE-2021-44228 (Log4Shell).md
+++ b/Queries-Only/Cool-Query-Friday/2021-12-10 - Cool Query Friday - Hunting Apache Log4j CVE-2021-44228 (Log4Shell).md
@@ -35,3 +35,83 @@ event_simpleName IN (ProcessRollup2, SyntheticProcessRollup2)
 | table ProcessStartTime_decimal ComputerName FileName stringOfInterest CommandLine
 | convert ctime(ProcessStartTime_decimal)
 ```
+
+## Community & Staff Additions
+*Harvested from this post's [r/CrowdStrike](https://www.reddit.com/r/crowdstrike/) comment thread — not part of the original CQF post. **[CS]** = CrowdStrike staff · **[Community]** = other r/CrowdStrike users. Upvote scores shown for context.*
+
+### Query variants
+
+```cql
+aid=PUTaidHERE (event_simpleName=JarFileWritten AND FileName=PUTfilenameHERE) OR (event_simpleName=ProcessRollup2)
+| eval falconPID=coalesce(TargetProcessId_decimal, ContextProcessId_decimal)
+| stats dc(event_simpleName) as eventCount, values(FileName) as fileNames, values(CommandLine) as commandLine by aid, ComputerName, falconPID
+| where eventCount>1
+```
+— [CS] Andrew-CS · comment score 3
+
+```cql
+| rex field=CommandLine = ".*(?<log4jver>log4j[^;: ]*).*"
+```
+— [Community] theredmoose33 · comment score 2
+
+```cql
+| search log4j
+| eval falconEvents=case(event_simpleName="ProcessRollup2", "Process Execution", event_simpleName="SyntheticProcessRollup2", "Process Execution", event_simpleName="JarFileWritten", "JAR File Write", event_simpleName="NewExecutableWritten", "EXE File Write", event_simpleName="PeFileWritten", "EXE File Write", event_simpleName=ElfFileWritten, "ELF File Write")
+| fillnull value="-"
+| stats dc(falconEvents) as totalEvents, values(falconEvents) as falconEvents, values(ImageFileName) as fileName, values(CommandLine) as cmdLine by cid, company, aid, ProductType
+| eval productType=case(ProductType = "1","Workstation", ProductType = "2","Domain Controller", ProductType = "3","Server", event_platform = "Mac", "Workstation") 
+| lookup local=true aid_master aid OUTPUT Version, ComputerName, AgentVersion
+| table cid, company, aid, ComputerName, productType, Version, AgentVersion, totalEvents, falconEvents, fileName, cmdLine
+| sort +productType, +ComputerName
+```
+— [CS] Andrew-CS · comment score 2
+
+```cql
+| inputlookup aid_master
+```
+— [CS] Andrew-CS · comment score 1
+
+### Operational caveats
+
+> That's definitely a good strategy. In a pinned comment above, there is also a dashboard you can use that will try to identify the Log4j version running so you don't have to. I hope that helps.
+— [CS] Andrew-CS · score 2
+
+> HI there. Log4j is bundled with thousands of different pieces of software. As such, there is no one standardized way to find every iteration of it. Ideally what would happen is every software vendor that bundles/includes it with their offering would issue a separate CVE instead of just piggybacking on 44228. That way, vuln. management solutions could process each CVE and provide the steps required to mitigate. Unfortunately, that isn't what's really happening so we have to get creative with ways to look for where Log4j may/may not be. When bundled, we're noticing that Log4j quite often will be invoked via a command line argument that we can hunt against and parse. I hope that helps a bit.
+— [CS] Andrew-CS · score 4
+
+> It's where Log4j is being executed from so you can investigate if the version running is vulnerable (since Log4j is bundled with thousands of software packages). If there are exploit attempts you should have detections in your Falcon UI.
+— [CS] Andrew-CS · score 2
+
+### Q&A
+
+**Q — [Community] mrmpls:** Is the event query for identifying POC usage already part of the detection coverage CrowdStrike mentioned, or would we need to create a custom IOA? Do 'Process Creation' custom IOAs with the same jndi/ldap info in the command line function identically to Event Search, or does Event Search see someth …
+
+**A — [CS] Andrew-CS:** What you see in a Process Creation IOA is parsing the same data that is in a ProcessRollup2 and the CommandLine field within that event.
+
+**Q — [Community] jotin_:** > would we need to create a custom IOA? Did you get any feedback on this?
+
+**A — [CS] Andrew-CS:** What you see in a Process Creation IOA is parsing the same data that is in a ProcessRollup2 and the CommandLine field within that event.
+
+**Q — [Community] ljapa:** Yep. I’m aware that the internal systems are going to need patching. Running the query you provided, I see some Jar File Write events on workstations but no details on commandLine/path. Any way to dig into that?
+
+**A — [CS] Andrew-CS:** Of course! Try this... aid=PUTaidHERE (event_simpleName=JarFileWritten AND FileName=PUTfilenameHERE) OR (event_simpleName=ProcessRollup2) | eval falconPID=coalesce(TargetProcessId_decimal, ContextProcessId_decimal) | stats dc(event_simpleName) as eventCount, values(FileName) as fileNames, values(CommandLine) as commandLine by aid, ComputerName, falconPID | where eventCount>1
+
+**Q — [Community] theredmoose33:** Ugh very true. However, does it not allow us to at least identify some log4j versions that are vulnerable? As long as you don't make the assumption that you are capturing all occurrences. I am getting a fair amount of hits. If I then narrow down the systems that are running known vulnerable versions …
+
+**A — [CS] Andrew-CS:** That's definitely a good strategy. In a pinned comment above, there is also a dashboard you can use that will try to identify the Log4j version running so you don't have to. I hope that helps.
+
+**Q — [Community] Nobodyknowswhereitgo:** Its been very helpful. Regarding the Updated Query, can you provide a brief explanation of its action - would that bring up any unpatched log4j modules? Thank you.
+
+**A — [CS] Andrew-CS:** Hi there. The updated query at the bottom is looking for the signs of someone trying to exploit the CVE. Typically you will see a command line that looks like this: ${jndi:ldap://x.x.x.x:x/Basic/Command/Base64/<base64 string>} The updated query is looking for `jndi:<protocol>` so you can audit those to make sure they are legitimate.
+
+**Q — [Community] Sam8131:** I know this is probably an easy answer, how can I include the company attribute on the first query, we have a multi CID environment and need to differentiate between CIDs
+
+**A — [CS] Andrew-CS:** event_simpleName IN (ProcessRollup2, SyntheticProcessRollup2, JarFileWritten, NewExecutableWritten, PeFileWritten, ElfFileWritten) | search log4j | eval falconEvents=case(event_simpleName="ProcessRollup2", "Process Execution", event_simpleName="SyntheticProcessRollup2", "Process Execution", event_simpleName="JarFileWritten", "JAR File Write", event_simpleName="NewExecutableWritten", "EXE File Write", event_simpleName="PeFileWritten", "EXE File Write", event_simpleName=ElfFileWritten, "ELF File W …
+
+**Q — [Community] AUserWithUsername:** can you explain for what "aid\_master" stands for in query? Where we can find info about that? `| lookup local=true aid_master`
+
+**A — [CS] Andrew-CS:** It's short-hand for "Agent ID Master." When a system connects to Falcon it places some of its metrics that don't really change in a lookup table. If you are in Event Search, run this to see everything in `aid_master` | inputlookup aid_master The `lookup` command just merges data in. Keeps the query speedy when you're dealing with massive datasets.
+
+**Q — [Community] sarathdrake:** [https://www.elastic.co/blog/detecting-log4j2-with-elastic-security](https://www.elastic.co/blog/detecting-log4j2-with-elastic-security) any thoughts on this?
+
+**A — [CS] Andrew-CS:** I question the utility of this query, but here it is anyway... (index=main sourcetype=ProcessRollup* event_simpleName=ProcessRollup2 ParentBaseFileName IN (java) FileName IN (sh, bash, dash, ksh, tcsh, zsh, curl, perl*, python*, ruby*, php*, wget)) OR (index=main sourcetype=NetworkConnectIP4* event_simplename=NetworkConnectIP4 RemotePort_decimal IN (1389, 389, 1099, 53, 5353)) | eval falconPID=mvappend(TargetProcessId_decimal,ContextProcessId_decimal) | stats dc(event_simpleName) as eventCount, …

--- a/Queries-Only/Cool-Query-Friday/2021-12-22 - Cool Query Friday - (ish) - Continuing to Obsess Over Log4Shell.md
+++ b/Queries-Only/Cool-Query-Friday/2021-12-22 - Cool Query Friday - (ish) - Continuing to Obsess Over Log4Shell.md
@@ -1,0 +1,45 @@
+---
+title: "(ish) - Continuing to Obsess Over Log4Shell"
+date: 2021-12-22
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/rmgjli/20211222_cool_query_fridayish_continuing_to/"
+mitre: []
+series: Cool Query Friday
+---
+
+# (ish) - Continuing to Obsess Over Log4Shell
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/rmgjli/20211222_cool_query_fridayish_continuing_to/](https://www.reddit.com/r/crowdstrike/comments/rmgjli/20211222_cool_query_fridayish_continuing_to/) — by Andrew-CS (CrowdStrike) — 2021-12-22
+
+Welcome to our thirty-third installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk though of each step (3) application in the wild.
+
+## Query 1
+```cql
+index=main sourcetype=ProcessRollup2* event_simpleName=ProcessRollup2
+| search ComputerName IN (*), ParentBaseFileName IN (java, java.exe)
+| stats dc(aid) as uniqueEndpoints, count(aid) as executionCount by event_platform, ParentBaseFileName, FileName
+| sort +event_platform, -executionCount
+```
+
+## Query 2
+```cql
+[...]
+| search event_platform IN (Mac), ComputerName IN (MD-*), ParentBaseFileName IN (java, java.exe)
+[...]
+```
+
+## Query 3
+```cql
+index=main sourcetype=ProcessRollup2* event_simpleName=ProcessRollup2
+| search event_platform IN (Mac), ComputerName IN (MD-*), ParentBaseFileName IN (java, java.exe)
+| stats dc(aid) as uniqueEndpoints, count(aid) as executionCount by event_platform, ParentBaseFileName, FileName
+| search NOT FileName IN (jspawnhelper, who, users)
+| sort +event_platform, -executionCount
+```
+
+## Query 4
+```cql
+event_simpleName=CustomIOABasicProcessDetectionInfoEvent TemplateInstanceId_decimal=26 
+|  stats dc(aid) as endpointCount count(aid) as alertCount by ParentImageFileName, ImageFileName, CommandLine
+| sort - alertCount
+```

--- a/Queries-Only/Cool-Query-Friday/2021-12-22 - Cool Query Friday - (ish) - Continuing to Obsess Over Log4Shell.md
+++ b/Queries-Only/Cool-Query-Friday/2021-12-22 - Cool Query Friday - (ish) - Continuing to Obsess Over Log4Shell.md
@@ -43,3 +43,12 @@ event_simpleName=CustomIOABasicProcessDetectionInfoEvent TemplateInstanceId_deci
 |  stats dc(aid) as endpointCount count(aid) as alertCount by ParentImageFileName, ImageFileName, CommandLine
 | sort - alertCount
 ```
+
+## Community & Staff Additions
+*Harvested from this post's [r/CrowdStrike](https://www.reddit.com/r/crowdstrike/) comment thread — not part of the original CQF post. **[CS]** = CrowdStrike staff · **[Community]** = other r/CrowdStrike users. Upvote scores shown for context.*
+
+### Q&A
+
+**Q — [Community] jmcybersec:** The github log4j scanning script references a cast.exe file, but there is a 404 when i attempt to download and it doesn't show up anywhere on there? Any ideas what happened to this?
+
+**A — [CS] Andrew-CS:** Hi there. If you download this file from Git and decompress it you'll get `cast.exe`: https://github.com/CrowdStrike/CAST/releases/download/v0.6.0/cast\_0.6.0\_Windows\_amd64.tar.gz

--- a/Queries-Only/Cool-Query-Friday/2022-01-07 - Cool Query Friday - Adding Process Explorer and RTR Links to Scheduled Queries.md
+++ b/Queries-Only/Cool-Query-Friday/2022-01-07 - Cool Query Friday - Adding Process Explorer and RTR Links to Scheduled Queries.md
@@ -58,3 +58,58 @@ index=main sourcetype=ProcessRollup* event_platform=win event_simpleName=Process
 | eval processExplorer="https://falcon.crowdstrike.com/investigate/process-explorer/" .aid. "/" . latestFalconPID
 | eval startRTR="https://falcon.crowdstrike.com/activity/real-time-response/console/?start=hosts&aid=".aid
 ```
+
+## Community & Staff Additions
+*Harvested from this post's [r/CrowdStrike](https://www.reddit.com/r/crowdstrike/) comment thread — not part of the original CQF post. **[CS]** = CrowdStrike staff · **[Community]** = other r/CrowdStrike users. Upvote scores shown for context.*
+
+### Query variants
+
+```cql
+// Specify data source and simpleName (index)
+#type = FDR "#event_simpleName" = ProcessRollup2
+
+// search for net.exe and net1.exe (including path, hence the wildcard)
+| ImageFileName =~ in(values=["*\\net.exe", "*\\net1.exe"])
+
+// search commandline (case insenitive) 
+| CommandLine =~ regex(".*group\s+.*admin.*", flags="i")
+
+// group data and summarize
+| groupBy(["#cid", "aid", "UserSid", "ImageFileName", "CommandLine"], function=[count(as=executionCount), selectLast(["TargetProcessId"])])
+
+// enrich sid -> username and aid -> ComputerName, not in the ProcessRollup event when through FDR
+| join({#type = FDR #event_simpleName = "UserIdentity" | groupBy(["#cid", "aid", "UserSid"], function=selectLast(["UserName"]))}, include="UserName", field=["#cid", "aid", "UserSid"])
+| join({#type = FDR #event_simpleName!=* EventType != "Event_ExternalApiEvent" | groupBy(["#cid", "aid"], function=selectLast(["ComputerName"]))}, include="ComputerName", field=["#cid", "aid"])
+
+// Create RTR and PE links, Humio supports markdown!
+| RTR := format("[RTR](https://falcon.eu-1.crowdstrike.com/activity/real-time-response/console/?start=hosts&aid=%s)",field=["aid"])
+| "Process Explorer" := format("[Explore](https://falcon.eu-1.crowdstrike.com/investigate/process-explorer/%s/%s)", field=["aid", "TargetProcessId"])
+
+// Split string to only get filename
+| FileName := splitString(field="ImageFileName", by="\\\\", index="-1")
+
+// Table the output!
+| table(["aid", "ComputerName", "UserName", "FileName", "UserSid", "CommandLine", "executionCount", "TargetProcessId", "RTR", "Process Explorer"])
+```
+— [Community] ts-kra · comment score 3
+
+```cql
+"Process Explorer.region" := ?region
+| "Process Explorer.region" := upper("Process Explorer.region")
+| case {
+    "Process Explorer.region" =  "US-1" | "Process Explorer" := format("[Process Explorer](https://falcon.crowdstrike.com/investigate/process-explorer/%s/%s)", field=["aid", "TargetProcessId"]);
+    "Process Explorer.region" = "US-2" | "Process Explorer" := format("[Process Explorer](https://falcon.us-2.crowdstrike.com/investigate/process-explorer/%s/%s)", field=["aid", "TargetProcessId"]);
+    "Process Explorer.region" = "EU" | "Process Explorer" := format("[Process Explorer](https://falcon.eu-1.crowdstrike.com/investigate/process-explorer/%s/%s)", field=["aid", "TargetProcessId"]);
+    "Process Explorer.region" = "GOV" | "Process Explorer" := format("[Process Explorer](https://falcon.laggar.gcw.crowdstrike.com/investigate/process-explorer/%s/%s)", field=["aid", "TargetProcessId"]);
+    @function.error := "Invalid region selected!"
+}
+```
+— [Community] ts-kra · comment score 3
+
+```cql
+[...]
+| eval CommandLine=lower(CommandLine)
+| regex CommandLine=".*group\s+.*admin.*" 
+[...]
+```
+— [CS] Andrew-CS · comment score 3

--- a/Queries-Only/Cool-Query-Friday/2022-01-07 - Cool Query Friday - Adding Process Explorer and RTR Links to Scheduled Queries.md
+++ b/Queries-Only/Cool-Query-Friday/2022-01-07 - Cool Query Friday - Adding Process Explorer and RTR Links to Scheduled Queries.md
@@ -1,0 +1,60 @@
+---
+title: "Adding Process Explorer and RTR Links to Scheduled Queries"
+date: 2022-01-07
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/ry6ma0/20220107_cool_query_friday_adding_process/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Adding Process Explorer and RTR Links to Scheduled Queries
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/ry6ma0/20220107_cool_query_friday_adding_process/](https://www.reddit.com/r/crowdstrike/comments/ry6ma0/20220107_cool_query_friday_adding_process/) — by Andrew-CS (CrowdStrike) — 2022-01-07
+
+Welcome to our thirty-fourth installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk though of each step (3) application in the wild.
+
+## Query 1
+```cql
+[...]
+| eval CommandLine=lower(CommandLine)
+| regex CommandLine=".*group\s+.*admin.*"
+```
+
+## Query 2
+```cql
+[...]
+| stats count(aid) as executionCount, latest(TargetProcessId_decimal) as latestFalconPID by aid, ComputerName, UserName, UserSid_readable, FileName, CommandLine
+```
+
+## Query 3
+```cql
+index=main sourcetype=ProcessRollup* event_platform=win event_simpleName=ProcessRollup2 FileName IN (net.exe, net1.exe)
+| eval CommandLine=lower(CommandLine)
+| regex CommandLine=".*group\s+.*admin.*"
+| stats count(aid) as executionCount, latest(TargetProcessId_decimal) as latestFalconPID by aid, ComputerName, UserName, UserSid_readable, FileName, CommandLine
+| sort + executionCount
+```
+
+## Query 4
+```cql
+[...]
+| eval processExplorer="https://falcon.crowdstrike.com/investigate/process-explorer/" .aid. "/" . latestFalconPID
+```
+
+## Query 5
+```cql
+[...]
+| eval startRTR="https://falcon.crowdstrike.com/activity/real-time-response/console/?start=hosts&aid=".aid
+```
+
+## Query 6
+```cql
+index=main sourcetype=ProcessRollup* event_platform=win event_simpleName=ProcessRollup2 FileName IN (net.exe, net1.exe)
+| fields aid, TargetProcessId_decimal, ComputerName, UserName, UserSid_readable, FileName, CommandLine
+| eval CommandLine=lower(CommandLine)
+| regex CommandLine=".*group\s+.*admin.*"
+| stats count(aid) as executionCount, latest(TargetProcessId_decimal) as latestFalconPID by aid, ComputerName, UserName, UserSid_readable, FileName, CommandLine
+| sort + executionCount
+| eval processExplorer="https://falcon.crowdstrike.com/investigate/process-explorer/" .aid. "/" . latestFalconPID
+| eval startRTR="https://falcon.crowdstrike.com/activity/real-time-response/console/?start=hosts&aid=".aid
+```

--- a/Queries-Only/Cool-Query-Friday/2022-01-26 - Cool Query Friday - Hunting pwnkit Local Privilege Escalation in Linux (CVE-2021-4034).md
+++ b/Queries-Only/Cool-Query-Friday/2022-01-26 - Cool Query Friday - Hunting pwnkit Local Privilege Escalation in Linux (CVE-2021-4034).md
@@ -1,0 +1,48 @@
+---
+title: "Hunting pwnkit Local Privilege Escalation in Linux (CVE-2021-4034)"
+date: 2022-01-26
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/sdfeig/20220126_cool_query_friday_hunting_pwnkit_local/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Hunting pwnkit Local Privilege Escalation in Linux (CVE-2021-4034)
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/sdfeig/20220126_cool_query_friday_hunting_pwnkit_local/](https://www.reddit.com/r/crowdstrike/comments/sdfeig/20220126_cool_query_friday_hunting_pwnkit_local/) — by Andrew-CS (CrowdStrike) — 2022-01-26
+
+Welcome to our thirty-fifth installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk though of each step (3) application in the wild.
+
+## Query 1
+```cql
+index=main sourcetype=ProcessRollup2* event_simpleName=ProcessRollup2 event_platform=Lin 
+| search ParentBaseFileName=pkexec AND UID_decimal=0
+| stats values(CommandLine) as CommandLine, count(aid) as executionCount by aid, ComputerName, ParentBaseFileName, FileName, UID_decimal
+| sort + executionCount
+```
+
+## Query 2
+```cql
+index=main sourcetype=ProcessRollup2* event_simpleName=ProcessRollup2 event_platform=Lin 
+| search ParentBaseFileName=pkexec AND UID_decimal=0 AND CommandLine="/bin/sh -pi"
+| stats values(CommandLine) as CommandLine, count(aid) as executionCount by aid, ComputerName, ParentBaseFileName, FileName, UID_decimal
+| sort + executionCount
+```
+
+## Query 3
+```cql
+index=main sourcetype=ProcessRollup2* event_simpleName=ProcessRollup2 event_platform=Lin
+| search FileName=pkexec 
+| where isnull(CommandLine)
+| stats dc(aid) as totalEndpoints count(aid) as detectionCount, values(ComputerName) as endpointNames by ParentBaseFileName, FileName, UID_decimal
+| sort - detectionCount
+```
+
+## Query 4
+```cql
+index=main sourcetype=ProcessRollup2* event_simpleName=ProcessRollup2 event_platform=Lin
+| search FileName=pkexec AND RUID_decimal!=0 AND NOT ParentBaseFileName IN ("python*")
+| where isnull(CommandLine)
+| stats dc(aid) as totalEndpoints, count(aid) as detectionCount by cid, ParentBaseFileName, FileName
+| sort - detectionCount
+```

--- a/Queries-Only/Cool-Query-Friday/2022-01-26 - Cool Query Friday - Hunting pwnkit Local Privilege Escalation in Linux (CVE-2021-4034).md
+++ b/Queries-Only/Cool-Query-Friday/2022-01-26 - Cool Query Friday - Hunting pwnkit Local Privilege Escalation in Linux (CVE-2021-4034).md
@@ -46,3 +46,12 @@ index=main sourcetype=ProcessRollup2* event_simpleName=ProcessRollup2 event_plat
 | stats dc(aid) as totalEndpoints, count(aid) as detectionCount by cid, ParentBaseFileName, FileName
 | sort - detectionCount
 ```
+
+## Community & Staff Additions
+*Harvested from this post's [r/CrowdStrike](https://www.reddit.com/r/crowdstrike/) comment thread — not part of the original CQF post. **[CS]** = CrowdStrike staff · **[Community]** = other r/CrowdStrike users. Upvote scores shown for context.*
+
+### Q&A
+
+**Q — [Community] salanki:** As someone who only recently started looking into CS, would this CVE not be automatically detected by CS?
+
+**A — [CS] Andrew-CS:** Hi there. We have detection/prevention logic in place, but I try to publish these tutorials for those that want to fully understand the data and go on the offense with their own research.

--- a/Queries-Only/Cool-Query-Friday/2022-02-11 - Cool Query Friday - Time To Assign, Time To Resolve, and Time To Close.md
+++ b/Queries-Only/Cool-Query-Friday/2022-02-11 - Cool Query Friday - Time To Assign, Time To Resolve, and Time To Close.md
@@ -1,0 +1,86 @@
+---
+title: "Time To Assign, Time To Resolve, and Time To Close"
+date: 2022-02-11
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/spx5zu/20220211_cool_query_friday_time_to_assign_time_to/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Time To Assign, Time To Resolve, and Time To Close
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/spx5zu/20220211_cool_query_friday_time_to_assign_time_to/](https://www.reddit.com/r/crowdstrike/comments/spx5zu/20220211_cool_query_friday_time_to_assign_time_to/) — by Andrew-CS (CrowdStrike) — 2022-02-11
+
+Welcome to our thirty-sixth installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk through of each step (3) application in the wild.
+
+## Query 1
+```cql
+index=json ExternalApiType IN (*)
+| stats values(ExternalApiType)
+```
+
+## Query 2
+```cql
+[...]
+| eval detection_id=coalesce(DetectId, mvfilter(match('AuditKeyValues{}.ValueString', "ldt.*")))
+| eval response_time=if('AuditKeyValues{}.ValueString' IN ("true_positive", "false_positive"), _time, null())
+| eval assign_time=if('AuditKeyValues{}.Key'="assigned_to", _time, null())
+```
+
+## Query 3
+```cql
+[...]
+| stats values(ComputerName) as ComputerName, max(Severity) as Severity, values(Tactic) as Tactics, values(Technique) as Techniques, earliest(_time) as FirstDetect earliest(assign_time) as FirstAssign, earliest(response_time) as ResolvedTime by detection_id
+```
+
+## Query 4
+```cql
+[...]
+| eval MinutesToAssign=round((FirstAssign-FirstDetect)/60,0)
+| eval HoursFromAssignToClose=round((ResolvedTime-FirstAssign)/60/60,2)
+| eval DaysFromDetectToClose=round((ResolvedTime-FirstDetect)/60/60/24,2)
+```
+
+## Query 5
+```cql
+| where isnotnull(ComputerName)
+| eval Severity=case(Severity=1, "Informational", Severity=2, "Low", Severity=3, "Medium", Severity=4, "High", Severity=5, "Critical")
+| convert ctime(FirstDetect) ctime(FirstAssign) ctime(ResolvedTime)
+| fillnull value="-" FirstAssign, ResolvedTime, MinutesToAssign, HoursFromAssignToClose, DaysFromDetectToClose 
+| table ComputerName, Severity, Tactics, Techniques, FirstDetect, FirstAssign, MinutesToAssign, ResolvedTime, HoursFromAssignToClose, DaysFromDetectToClose, detection_id 
+| sort + FirstDetect
+```
+
+## Query 6
+```cql
+index=json ExternalApiType=Event_DetectionSummaryEvent OR (ExternalApiType=Event_UserActivityAuditEvent AND OperationName=detection_update (AuditKeyValues{}.ValueString IN ("true_positive", "false_positive","new_detection") OR AuditKeyValues{}.Key="assigned_to"))
+| eval detection_id=coalesce(DetectId, mvfilter(match('AuditKeyValues{}.ValueString', "ldt.*")))
+| eval response_time=if('AuditKeyValues{}.ValueString' IN ("true_positive", "false_positive"), _time, null())
+| eval assign_time=if('AuditKeyValues{}.Key'="assigned_to", _time, null())
+| stats values(ComputerName) as ComputerName, max(Severity) as Severity, values(Tactic) as Tactics, values(Technique) as Techniques, earliest(_time) as FirstDetect earliest(assign_time) as FirstAssign, earliest(response_time) as ResolvedTime by detection_id
+| eval MinutesToAssign=round((FirstAssign-FirstDetect)/60,0)
+| eval HoursFromAssignToClose=round((ResolvedTime-FirstAssign)/60/60,2)
+| eval DaysFromDetectToClose=round((ResolvedTime-FirstDetect)/60/60/24,2)
+| where isnotnull(ComputerName)
+| eval Severity=case(Severity=1, "Informational", Severity=2, "Low", Severity=3, "Medium", Severity=4, "High", Severity=5, "Critical")
+| convert ctime(FirstDetect) ctime(FirstAssign) ctime(ResolvedTime)
+| fillnull value="-" FirstAssign, ResolvedTime, MinutesToAssign, HoursFromAssignToClose, DaysFromDetectToClose 
+| table ComputerName, Severity, Tactics, Techniques, FirstDetect, FirstAssign, MinutesToAssign, ResolvedTime, HoursFromAssignToClose, DaysFromDetectToClose, detection_id 
+| sort + FirstDetect
+```
+
+## Query 7
+```cql
+[...]
+| stats avg(DaysFromDetectToClose) as DaysFromDetectToClose by Severity
+| eval DaysFromDetectToClose=round(DaysFromDetectToClose,2)
+```
+
+## Query 8
+```cql
+[...]
+| stats avg(DaysFromDetectToClose) as DaysFromDetectToClose, avg(HoursFromAssignToClose) as HoursFromAssignToClose, avg(MinutesToAssign) as MinutesToAssign by Severity
+| eval DaysFromDetectToClose=round(DaysFromDetectToClose,2)
+| eval HoursFromAssignToClose=round(HoursFromAssignToClose,2)
+| eval MinutesToAssign=round(MinutesToAssign,2)
+```

--- a/Queries-Only/Cool-Query-Friday/2022-02-18 - Cool Query Friday - New Office File Written Events.md
+++ b/Queries-Only/Cool-Query-Friday/2022-02-18 - Cool Query Friday - New Office File Written Events.md
@@ -1,0 +1,100 @@
+---
+title: "New Office File Written Events"
+date: 2022-02-18
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/svf8y7/20220218_cool_query_friday_new_office_file/"
+mitre: []
+series: Cool Query Friday
+---
+
+# New Office File Written Events
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/svf8y7/20220218_cool_query_friday_new_office_file/](https://www.reddit.com/r/crowdstrike/comments/svf8y7/20220218_cool_query_friday_new_office_file/) — by Andrew-CS (CrowdStrike) — 2022-02-18
+
+Welcome to our thirty-seventh installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk through of each step (3) application in the wild.
+
+## Query 1
+```cql
+event_simpleName IN (MSDocxFileWritten, MSPptxFileWritten, MSVsdxFileWritten, MSXlsxFileWritten)
+| eval falconPID=coalesce(ContextProcessId_decimal, TargetProcessId_decimal)
+```
+
+## Query 2
+```cql
+[...]
+| eval MSOfficeSubType=case(MSOfficeSubType_decimal=0, "Unknown", MSOfficeSubType_decimal=1, "Legacy Binary", MSOfficeSubType_decimal=2, "OOXML")
+```
+
+## Query 3
+```cql
+[...]
+| eval isInOutlookTemp=if(match(TargetFileName, ".*\\\Content\.Outlook\\\.*"),"Yes", "No")
+| eval isInDownloads=if(match(TargetFileName, ".*\\\Downloads\\\.*"),"Yes", "No")
+```
+
+## Query 4
+```cql
+[...]
+| eval isOnRemoveableDrive=case(IsOnRemovableDisk_decimal=1, "Yes", IsOnRemovableDisk_decimal=0, "No")
+| eval isOnNetworkDrive=case(IsOnNetwork_decimal=1, "Yes", IsOnNetwork_decimal=0, "No")
+```
+
+## Query 5
+```cql
+[...]
+| rex field=FileName ".*\.(?<fileExtension>.*)"
+| eval fileExtension=lower(fileExtension)
+```
+
+## Query 6
+```cql
+[...]
+| rex mode=sed field=FilePath "s/\\\Device\\\HarddiskVolume\d+//g"
+```
+
+## Query 7
+```cql
+[...]
+| rex mode=sed field=FilePath "s/\\\Device\\\HarddiskVolume\d+/C:/g"
+```
+
+## Query 8
+```cql
+[...]
+| eval ProcExplorer=case(falconPID!="","https://falcon.crowdstrike.com/investigate/process-explorer/" .aid. "/" . falconPID)
+```
+
+## Query 9
+```cql
+[...]
+| rename FileOperatorSid_readable AS UserSid_readable
+| lookup local=true userinfo.csv UserSid_readable OUTPUT UserName, AccountType, LocalAdminAccess
+```
+
+## Query 10
+```cql
+[...]
+| table aid, ComputerName, UserSid_readable, UserName, AccountType, LocalAdminAccess, ContextTimeStamp_decimal, fileExtension, MSOfficeSubType, FileName, FilePath, isIn*, isOn*, ProcExplorer 
+| convert ctime(ContextTimeStamp_decimal)
+| rename aid as "Falcon AID", ComputerName as "Endpoint", UserSid_readable as "User SID", UserName as "User", AccountType as "Account Type", LocalAdminAccess as "Local Admin?", ContextTimeStamp_decimal as "File Written Time", fileExtension as "Extension", MSOfficeSubType as "Office Type", isInDownloads as "Downloads Folder?", isInOutlookTemp as "Outlook Temp?", isOnNetworkDrive as "Network Drive?", isOnRemoveableDrive as "Removable Drive?", ProcExplorer as "Process Explorer Link"
+```
+
+## Query 11
+```cql
+event_simpleName IN (MSDocxFileWritten, MSPptxFileWritten, MSVsdxFileWritten, MSXlsxFileWritten)
+| eval falconPID=coalesce(ContextProcessId_decimal, TargetProcessId_decimal)
+| eval MSOfficeSubType=case(MSOfficeSubType_decimal=0, "Unknown", MSOfficeSubType_decimal=1, "Legacy Binary", MSOfficeSubType_decimal=2, "OOXML") 
+| eval isInOutlookTemp=if(match(TargetFileName, ".*\\\Content\.Outlook\\\.*"),"Yes", "No")
+| eval isInDownloads=if(match(TargetFileName, ".*\\\Downloads\\\.*"),"Yes", "No")
+| eval isOnRemoveableDrive=case(IsOnRemovableDisk_decimal=1, "Yes", IsOnRemovableDisk_decimal=0, "No")
+| eval isOnNetworkDrive=case(IsOnNetwork_decimal=1, "Yes", IsOnNetwork_decimal=0, "No")
+| rex field=FileName ".*\.(?<fileExtension>.*)"
+| eval fileExtension=lower(fileExtension)
+| rex mode=sed field=FilePath "s/\\\Device\\\HarddiskVolume\d+/C:/g"
+| eval ProcExplorer=case(falconPID!="","https://falcon.crowdstrike.com/investigate/process-explorer/" .aid. "/" . falconPID)
+| rename FileOperatorSid_readable AS UserSid_readable
+| lookup local=true userinfo.csv UserSid_readable OUTPUT UserName, AccountType, LocalAdminAccess
+| table aid, ComputerName, UserSid_readable, UserName, AccountType, LocalAdminAccess, ContextTimeStamp_decimal, fileExtension, MSOfficeSubType, FileName, FilePath, isIn*, isOn*, ProcExplorer 
+| convert ctime(ContextTimeStamp_decimal)
+| rename aid as "Falcon AID", ComputerName as "Endpoint", UserSid_readable as "User SID", UserName as "User", AccountType as "Account Type", LocalAdminAccess as "Local Admin?", ContextTimeStamp_decimal as "File Written Time", fileExtension as "Extension", MSOfficeSubType as "Office Type", isInDownloads as "Downloads Folder?", isInOutlookTemp as "Outlook Temp?", isOnNetworkDrive as "Network Drive?", isOnRemoveableDrive as "Removable Drive?", ProcExplorer as "Process Explorer Link"
+```

--- a/Queries-Only/Cool-Query-Friday/2022-02-18 - Cool Query Friday - New Office File Written Events.md
+++ b/Queries-Only/Cool-Query-Friday/2022-02-18 - Cool Query Friday - New Office File Written Events.md
@@ -98,3 +98,13 @@ event_simpleName IN (MSDocxFileWritten, MSPptxFileWritten, MSVsdxFileWritten, MS
 | convert ctime(ContextTimeStamp_decimal)
 | rename aid as "Falcon AID", ComputerName as "Endpoint", UserSid_readable as "User SID", UserName as "User", AccountType as "Account Type", LocalAdminAccess as "Local Admin?", ContextTimeStamp_decimal as "File Written Time", fileExtension as "Extension", MSOfficeSubType as "Office Type", isInDownloads as "Downloads Folder?", isInOutlookTemp as "Outlook Temp?", isOnNetworkDrive as "Network Drive?", isOnRemoveableDrive as "Removable Drive?", ProcExplorer as "Process Explorer Link"
 ```
+
+## Community & Staff Additions
+*Harvested from this post's [r/CrowdStrike](https://www.reddit.com/r/crowdstrike/) comment thread — not part of the original CQF post. **[CS]** = CrowdStrike staff · **[Community]** = other r/CrowdStrike users. Upvote scores shown for context.*
+
+### Query variants
+
+```cql
+| lookup local=true userinfo.csv UserSid_readable OUTPUT UserName, AccountType, LocalAdminAccess
+```
+— [CS] Andrew-CS · comment score 1

--- a/Queries-Only/Cool-Query-Friday/2022-02-25 - Cool Query Friday - Situational Awareness  DriveSlayer Wiper.md
+++ b/Queries-Only/Cool-Query-Friday/2022-02-25 - Cool Query Friday - Situational Awareness  DriveSlayer Wiper.md
@@ -1,0 +1,48 @@
+---
+title: "Situational Awareness \\\\ DriveSlayer Wiper"
+date: 2022-02-25
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/t0vhe6/20220225_cool_query_friday_situational_awareness/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Situational Awareness \\ DriveSlayer Wiper
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/t0vhe6/20220225_cool_query_friday_situational_awareness/](https://www.reddit.com/r/crowdstrike/comments/t0vhe6/20220225_cool_query_friday_situational_awareness/) — by Andrew-CS (CrowdStrike) — 2022-02-25
+
+Welcome to our thirty-eighth installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk through of each step (3) application in the wild.
+
+## Query 1
+```cql
+event_platform=win event_simpleName IN (PeFileWritten) AND FileName="*.sys" AND FilePath="*\\Windows\\System32\\drivers\\"
+| rex field=FileName "(?<fileNameNoExtension>.*)\..*"
+| eval fileNameLength=len(fileNameNoExtension)
+| search fileNameLength=4 
+| eval endpointTime=coalesce(ContextTimeStamp_decimal, ProcessStartTime_decimal)
+| eval falconPID=coalesce(TargetProcessId_decimal, ContextProcessId_decimal)
+| table endpointTime, aid, ComputerName, event_simpleName, falconPID, FileName, FilePath, fileNameNoExtension, fileNameLength, SHA256HashData
+| sort + endpointTime
+| convert ctime(endpointTime)
+```
+
+## Query 2
+```cql
+event_platform=win event_simpleName IN (Asep*) 
+| search RegStringValue="*\\Windows\\system32\\Drivers\\*.sys"
+| rex field=RegObjectName ".*\\\(?<regObjNameNoExtension>.*)" 
+| eval regObjNameNoExtensionLength=len(regObjNameNoExtension)
+| search regObjNameNoExtensionLength=4
+| table ContextTimeStamp_decimal, aid, ComputerName, UserName, RegObjectName, regObjNameNoExtension, regObjNameNoExtensionLength, RegStringValue
+| convert ctime(ContextTimeStamp_decimal)
+| rename ContextTimeStamp_decimal as registryModifiedTime
+```
+
+## Query 3
+```cql
+event_platform=win event_simpleName=DriverLoad CertificateThumbprint=696b5cb5d85721807d3942c73b317a062e22cf2a 
+| rex field=FileName "(?<baseFileName>.*)\.sys" 
+| eval baseFileLength=len(baseFileName) 
+| search baseFileLength=4 
+| table _time, aid, ComputerName, FileName, baseFileName, baseFileLength, FilePath, SHA256HashData, CertificateThumbprint
+```

--- a/Queries-Only/Cool-Query-Friday/2022-02-25 - Cool Query Friday - Situational Awareness  DriveSlayer Wiper.md
+++ b/Queries-Only/Cool-Query-Friday/2022-02-25 - Cool Query Friday - Situational Awareness  DriveSlayer Wiper.md
@@ -46,3 +46,12 @@ event_platform=win event_simpleName=DriverLoad CertificateThumbprint=696b5cb5d85
 | search baseFileLength=4 
 | table _time, aid, ComputerName, FileName, baseFileName, baseFileLength, FilePath, SHA256HashData, CertificateThumbprint
 ```
+
+## Community & Staff Additions
+*Harvested from this post's [r/CrowdStrike](https://www.reddit.com/r/crowdstrike/) comment thread — not part of the original CQF post. **[CS]** = CrowdStrike staff · **[Community]** = other r/CrowdStrike users. Upvote scores shown for context.*
+
+### Q&A
+
+**Q — [Community] jarks_20:** Andrew...is there any goodies :) that you can share in regards with whispergate?
+
+**A — [CS] Andrew-CS:** Hi there, for Falcon Intelligence customers there is a very detailed report here: CSA-220189. We track this activity cluster to the threat actor [EMBER BEAR](https://falcon.crowdstrike.com/intelligence-v2/actors/ember-bear/summary).

--- a/Queries-Only/Cool-Query-Friday/2022-03-06 - Cool Query Friday - SITUATIONAL AWARENESS  Hunting for NVIDIA Certificates.md
+++ b/Queries-Only/Cool-Query-Friday/2022-03-06 - Cool Query Friday - SITUATIONAL AWARENESS  Hunting for NVIDIA Certificates.md
@@ -71,3 +71,23 @@ INSERT SHA256 LIST HERE
 | rex field=FilePath ".*\\HarddiskVolume\d+(?<trimmedPath>.*)"
 | stats values(FileName) as fileName, dc(aid) as endpointCount, count(aid) as runCount, values(trimmedPath) as filePaths, values(event_simpleName) as eventType by SHA256HashData
 ```
+
+## Community & Staff Additions
+*Harvested from this post's [r/CrowdStrike](https://www.reddit.com/r/crowdstrike/) comment thread — not part of the original CQF post. **[CS]** = CrowdStrike staff · **[Community]** = other r/CrowdStrike users. Upvote scores shown for context.*
+
+### Query variants
+
+```cql
+| inputlookup lookuptable
+```
+— [CS] Andrew-CS · comment score 2
+
+### Q&A
+
+**Q — [Community] cs-del:** Quick question, why did you search through JSON logs rather the main index. If you can give a little insight between both indexing on?
+
+**A — [CS] Andrew-CS:** Hi there. You don't have to specify, but it will make things quicker. The JSON index is basically what will be output by the SIEM connector or ingested by our SIEM integrations. It includes alerts, audit events, etc.
+
+**Q — [Community] MSP-IT-Simplified:** Quick question. In you first query you reference file appinfo.csv, where is that file located?
+
+**A — [CS] Andrew-CS:** Hi there. It's a lookup table similar to `aid_master`. I have a list of the ones I use [here](https://www.reddit.com/r/crowdstrike/comments/oz9oow/comment/h7z7wy8/?utm_source=reddit&utm_medium=web2x&context=3). If you want to view the file by itself, you use the following: | inputlookup lookuptable

--- a/Queries-Only/Cool-Query-Friday/2022-03-06 - Cool Query Friday - SITUATIONAL AWARENESS  Hunting for NVIDIA Certificates.md
+++ b/Queries-Only/Cool-Query-Friday/2022-03-06 - Cool Query Friday - SITUATIONAL AWARENESS  Hunting for NVIDIA Certificates.md
@@ -1,0 +1,73 @@
+---
+title: "SITUATIONAL AWARENESS \\\\ Hunting for NVIDIA Certificates"
+date: 2022-03-06
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/t81heu/20220306_cool_query_friday_situational_awareness/"
+mitre: []
+series: Cool Query Friday
+---
+
+# SITUATIONAL AWARENESS \\ Hunting for NVIDIA Certificates
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/t81heu/20220306_cool_query_friday_situational_awareness/](https://www.reddit.com/r/crowdstrike/comments/t81heu/20220306_cool_query_friday_situational_awareness/) — by Andrew-CS (CrowdStrike) — 2022-03-06
+
+Welcome to our thirty-ninth installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk through of each step (3) application in the wild.
+
+## Query 1
+```cql
+index=json ExternalApiType=Event_ModuleSummaryInfoEvent 
+| search SubjectCN IN ("NVIDIA Corporation") 
+| lookup local=true appinfo.csv SHA256HashData OUTPUT FileName, ProductName, ProductVersion , FileDescription , FileVersion , CompanyName 
+| fillnull value="Unknown" FileName, ProductName, ProductVersion , FileDescription , FileVersion , CompanyName
+| stats values(SubjectDN) as SubjectDN, values(SHA256HashData) as sha256 by IssuerCN, FileName, ProductName, ProductVersion , FileDescription , FileVersion , CompanyName
+| sort + FileName
+```
+
+## Query 2
+```cql
+index=json ExternalApiType=Event_ModuleSummaryInfoEvent 
+| search SubjectSerialNumber IN (43bb437d609866286dd839e1d00309f5, 14781bc862e8dc503a559346f5dcc518) 
+| lookup local=true appinfo.csv SHA256HashData OUTPUT FileName, ProductName, ProductVersion , FileDescription , FileVersion , CompanyName 
+| fillnull value="Unknown" FileName, ProductName, ProductVersion , FileDescription , FileVersion , CompanyName
+| stats values(SHA256HashData) as sha256 by IssuerCN, SubjectCN, SubjectDN, FileName, ProductName, ProductVersion , FileDescription , FileVersion , CompanyName
+```
+
+## Query 3
+```cql
+index=main sourcetype IN (ProcessRollup*, ImageHash*, PeFileWritten*, DriverLoad*) event_platform=win event_simpleName IN (ProcessRollup2, ImageHash, PeFileWritten, DriverLoad)
+| search SHA256HashData IN (
+17d22cf02b4121efd4526f30b16371a084f5f41b8746f9359bad4c29d7deb715
+31f87d4188f210be2df99b0a88fb437628a9864a3bffea4c5238cbc7dcb14df8
+31fef1519f5dd7b74d21a19b453ace2c677922b8060fea11d6f53bf8f73bd99c
+4d4e71840e5802b9ab790bae15bcadb0a31b3285009189be50573e313db07fe2
+6b02469349125bf474ae29303d81e84ad2f073ee6b6c619015bf7b9fea371ce6
+6bf1d0b94f4097f65fd611ea570b10aff7c5141d76736b0cb001a5de60fb778b
+9fac39999d2d87e0b60eedb4126fa5a25d142c52d5e5ddcd8bdb6bf2a836abb9
+a86a788e4823caa25f6eb3f6c5d7e59de225f121af6ed24077e118ba324e4e19
+b4226ed448e07357f216c193ca8f4ec74268e41fa369196b6de54cf058f622d1
+b4bd732e766e7de094378d2dec07264e16eb6b75e9c3fa35c2219dfe3726cc27
+b7c21ee31c8dea07cc5ccc9736e4aac31428f073ae14ad430dc8bdf999ab0813
+cbf74c0c0f5f05a501c53ab8f96c716522096cf60f545ecadd3100b578b62900
+d4210f400bcf3bc2553fc7c62493e96554c1b3b82d346db8adc84c75cea124d6
+db22f4465ed5bb82e8b9322291cafc554ded1dc8ecd7d7f2b1b14784617a0f5a
+ed5728d26a7856886faec9e3340ce7dbafbf8daa4c36aad79a8e7106b998d76a
+f39ce105207842154e69cedd3e332b2bfefad82cdd40832245cc991dad5b8f7c
+fce84e34a971e1bf8420639689c8ecc6170357354deb775c02f6d70a28723680
+ff3935ba15be2d74a810b695bdc6529103ddd81df302425db2f2cafcbaf10040
+)
+| eval falconPID=coalesce(ContextProcessId_decimal, TargetProcessId_decimal)
+| eval ProcExplorer=case(falconPID!="","https://falcon.crowdstrike.com/investigate/process-explorer/" .aid. "/" . falconPID)
+| stats values(FileName) as fileName, dc(aid) as endpointCount, count(aid) as runCount, values(FilePath) as filePaths, values(event_simpleName) as eventType by SHA256HashData, ProcExplorer
+```
+
+## Query 4
+```cql
+index=main sourcetype IN (ProcessRollup*, ImageHash*, PeFileWritten*, DriverLoad*) event_platform=win event_simpleName IN (ProcessRollup2, ImageHash, PeFileWritten, DriverLoad)
+| search SHA256HashData IN (
+INSERT SHA256 LIST HERE
+)
+| eval falconPID=coalesce(ContextProcessId_decimal, TargetProcessId_decimal)
+| eval ProcExplorer=case(falconPID!="","https://falcon.crowdstrike.com/investigate/process-explorer/" .aid. "/" . falconPID)
+| rex field=FilePath ".*\\HarddiskVolume\d+(?<trimmedPath>.*)"
+| stats values(FileName) as fileName, dc(aid) as endpointCount, count(aid) as runCount, values(trimmedPath) as filePaths, values(event_simpleName) as eventType by SHA256HashData
+```

--- a/Queries-Only/Cool-Query-Friday/2022-03-18 - Cool Query Friday - Revisiting User Added To Group Events.md
+++ b/Queries-Only/Cool-Query-Friday/2022-03-18 - Cool Query Friday - Revisiting User Added To Group Events.md
@@ -1,0 +1,94 @@
+---
+title: "Revisiting User Added To Group Events"
+date: 2022-03-18
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/th06gy/20220318_cool_query_friday_revisiting_user_added/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Revisiting User Added To Group Events
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/th06gy/20220318_cool_query_friday_revisiting_user_added/](https://www.reddit.com/r/crowdstrike/comments/th06gy/20220318_cool_query_friday_revisiting_user_added/) — by Andrew-CS (CrowdStrike) — 2022-03-18
+
+Welcome to our fortieth(!!) installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk through of each step (3) application in the wild.
+
+## Query 1
+```cql
+[...]
+| eval falconPID=coalesce(TargetProcessId_decimal, RpcClientProcessId_decimal)
+This takes the value of TargetProcessId_decimal, which exists in ProcessRollup2 events, and the value RpcClientProcessId_decimal, which exists in UserAccountAddedToGroup events, and makes a new variable named falconPID.
+```
+
+## Query 2
+```cql
+[...]
+| rename UserName as responsibleUserName
+| rename UserSid_readable as responsibleUserSID
+```
+
+## Query 3
+```cql
+[...]
+| eval GroupRid_dec=tonumber(ltrim(tostring(GroupRid), "0"), 16)
+| eval UserRid_dec=tonumber(ltrim(tostring(UserRid), "0"), 16)
+| eval UserSid_readable=DomainSid. "-" .UserRid_dec
+```
+
+## Query 4
+```cql
+[...]
+| lookup local=true userinfo.csv UserSid_readable OUTPUT UserName
+| lookup local=true grouprid_wingroup.csv GroupRid_dec OUTPUT WinGroup
+| fillnull value="-" UserName responsibleUserName
+```
+
+## Query 5
+```cql
+[...]
+| stats dc(event_simpleName) as eventCount, values(ProcessStartTime_decimal) as processStartTime, values(FileName) as responsibleFile, values(CommandLine) as responsibleCmdLine, values(responsibleUserSID) as responsibleUserSID, values(responsibleUserName) as responsibleUserName, values(WinGroup) as windowsGroupName, values(GroupRid_dec) as windowsGroupRID, values(UserName) as addedUserName, values(UserSid_readable) as addedUserSID by aid, falconPID
+| where eventCount>1
+```
+
+## Query 6
+```cql
+(index=main sourcetype=UserAccountAddedToGroup* event_platform=win event_simpleName=UserAccountAddedToGroup) OR (index=main sourcetype=ProcessRollup2* event_platform=win event_simpleName=ProcessRollup2)
+| eval falconPID=coalesce(TargetProcessId_decimal, RpcClientProcessId_decimal)
+| rename UserName as responsibleUserName
+| rename UserSid_readable as responsibleUserSID
+| eval GroupRid_dec=tonumber(ltrim(tostring(GroupRid), "0"), 16)
+| eval UserRid_dec=tonumber(ltrim(tostring(UserRid), "0"), 16)
+| eval UserSid_readable=DomainSid. "-" .UserRid_dec
+| lookup local=true userinfo.csv UserSid_readable OUTPUT UserName
+| lookup local=true grouprid_wingroup.csv GroupRid_dec OUTPUT WinGroup
+| fillnull value="-" UserName responsibleUserName
+| stats dc(event_simpleName) as eventCount, values(ProcessStartTime_decimal) as processStartTime, values(FileName) as responsibleFile, values(CommandLine) as responsibleCmdLine, values(responsibleUserSID) as responsibleUserSID, values(responsibleUserName) as responsibleUserName, values(WinGroup) as windowsGroupName, values(GroupRid_dec) as windowsGroupRID, values(UserName) as addedUserName, values(UserSid_readable) as addedUserSID by aid, falconPID
+| where eventCount>1
+```
+
+## Query 7
+```cql
+[...]
+| eval ProcExplorer=case(falconPID!="","https://falcon.us-2.crowdstrike.com/investigate/process-explorer/" .aid. "/" . falconPID)
+| convert ctime(processStartTime)
+| table processStartTime, aid, responsibleUserSID, responsibleUserName, responsibleFile, responsibleCmdLine, addedUserSID, addedUserName, windowsGroupRID, windowsGroupName, ProcExplorer
+```
+
+## Query 8
+```cql
+(index=main sourcetype=UserAccountAddedToGroup* event_platform=win event_simpleName=UserAccountAddedToGroup) OR (index=main sourcetype=ProcessRollup2* event_platform=win event_simpleName=ProcessRollup2)
+| eval falconPID=coalesce(TargetProcessId_decimal, RpcClientProcessId_decimal)
+| rename UserName as responsibleUserName
+| rename UserSid_readable as responsibleUserSID
+| eval GroupRid_dec=tonumber(ltrim(tostring(GroupRid), "0"), 16)
+| eval UserRid_dec=tonumber(ltrim(tostring(UserRid), "0"), 16)
+| eval UserSid_readable=DomainSid. "-" .UserRid_dec
+| lookup local=true userinfo.csv UserSid_readable OUTPUT UserName
+| lookup local=true grouprid_wingroup.csv GroupRid_dec OUTPUT WinGroup
+| fillnull value="-" UserName responsibleUserName
+| stats dc(event_simpleName) as eventCount, values(ProcessStartTime_decimal) as processStartTime, values(FileName) as responsibleFile, values(CommandLine) as responsibleCmdLine, values(responsibleUserSID) as responsibleUserSID, values(responsibleUserName) as responsibleUserName, values(WinGroup) as windowsGroupName, values(GroupRid_dec) as windowsGroupRID, values(UserName) as addedUserName, values(UserSid_readable) as addedUserSID by aid, falconPID
+| where eventCount>1 
+| eval ProcExplorer=case(falconPID!="","https://falcon.us-2.crowdstrike.com/investigate/process-explorer/" .aid. "/" . falconPID)
+| convert ctime(processStartTime)
+| table processStartTime, aid, responsibleUserSID, responsibleUserName, responsibleFile, responsibleCmdLine, addedUserSID, addedUserName, windowsGroupRID, windowsGroupName, ProcExplorer
+```

--- a/Queries-Only/Cool-Query-Friday/2022-03-18 - Cool Query Friday - Revisiting User Added To Group Events.md
+++ b/Queries-Only/Cool-Query-Friday/2022-03-18 - Cool Query Friday - Revisiting User Added To Group Events.md
@@ -92,3 +92,28 @@ This takes the value of TargetProcessId_decimal, which exists in ProcessRollup2 
 | convert ctime(processStartTime)
 | table processStartTime, aid, responsibleUserSID, responsibleUserName, responsibleFile, responsibleCmdLine, addedUserSID, addedUserName, windowsGroupRID, windowsGroupName, ProcExplorer
 ```
+
+## Community & Staff Additions
+*Harvested from this post's [r/CrowdStrike](https://www.reddit.com/r/crowdstrike/) comment thread — not part of the original CQF post. **[CS]** = CrowdStrike staff · **[Community]** = other r/CrowdStrike users. Upvote scores shown for context.*
+
+### Operational caveats
+
+> Nice! For performance reasons, you may want to add the additional search parameters to the first line like this: (index=main sourcetype=UserAccountAddedToGroup* event_platform=win event_simpleName=UserAccountAddedToGroup) OR (index=main sourcetype=ProcessRollup2* event_platform=win event_simpleName=ProcessRollup2 ProductType=1 FileName!=VSFinalizer.exe) That will qualify out more results quicker :)
+— [CS] Andrew-CS · score 2
+
+> Not exactly sure. If you have a massive environment it maybe it's running for too long? What happens if you shorted the search period a bit?
+— [CS] Andrew-CS · score 1
+
+### Q&A
+
+**Q — [Community] amjcyb:** With this and the older one ([https://www.reddit.com/r/crowdstrike/comments/o2onsf/20210618\_cool\_query\_friday\_user\_added\_to\_group/](https://www.reddit.com/r/crowdstrike/comments/o2onsf/20210618_cool_query_friday_user_added_to_group/)) we get lots of "UserName: Unknown". We check the SID and t …
+
+**A — [CS] Andrew-CS:** The user was added then deleted. The user was added, but never logged in to that system (so you'll have SID, but the UserLogon event will never have occurred which helps populate UserName).
+
+**Q — [Community] yankeesfan01x:** The grand finale query threw back over 23,000 events for me in a 15 minutes time frame so I'm not sure what I'm doing wrong with this one?
+
+**A — [CS] Andrew-CS:** The number of events (if you're looking at the number value in the "Events" tab) will be very high as we're looking at all process executions. Are you saying the table has 23K user additions in it? That would be crazy.
+
+**Q — [Community] yankeesfan01x:** That's my bad. The high number is showing in the events tab but nothing is showing in the statistics tab. You might need to correct me if I'm wrong here but the statistics tab will actually show if a user account has been added to a user group on a Windows host? If I created a scheduled search to al …
+
+**A — [CS] Andrew-CS:** The "grand finale" is actually marrying the process that did the adding with the add itself. If you don't care about the process that did the adding, but care more about what was added, you can use the [older CQF](https://www.reddit.com/r/crowdstrike/comments/o2onsf/20210618_cool_query_friday_user_added_to_group/). That will be easier and the query will be faster.

--- a/Queries-Only/Cool-Query-Friday/2022-04-08 - Cool Query Friday - Scoring User Logon Events in Windows.md
+++ b/Queries-Only/Cool-Query-Friday/2022-04-08 - Cool Query Friday - Scoring User Logon Events in Windows.md
@@ -147,3 +147,19 @@ index=main sourcetype=UserLogon* event_simpleName=UserLogon event_platform=win
 | stats sum(weirdnessCoefficient) as weirdnessCoefficient, dc(aid) as uniqueEndpoints, count(aid) as totalLogons by UserSid_readable, UserName, AccountType 
 | sort - weirdnessCoefficient
 ```
+
+## Community & Staff Additions
+*Harvested from this post's [r/CrowdStrike](https://www.reddit.com/r/crowdstrike/) comment thread — not part of the original CQF post. **[CS]** = CrowdStrike staff · **[Community]** = other r/CrowdStrike users. Upvote scores shown for context.*
+
+### Query variants
+
+```cql
+| eval weirdnessCoefficient=ratingServiceAccountInteractive + ratingRdpToDc + ratingInteractiveServer + ratingexternalRDP + ratingPasswdAge + ratingDomainAdmin
+```
+— [CS] Andrew-CS · comment score 1
+
+### Q&A
+
+**Q — [Community] kevinelwell:** You can register for free here: [https://mitre.brandlive.com/mitre-attackcon-3/en](https://mitre.brandlive.com/mitre-attackcon-3/en) The presenter was Halee Mills **Tracking Noisy Behavior and Risk-Based Alerting with ATT&CK** Having ATT&CK to identify threats, prioritize data sources, and improve s …
+
+**A — [CS] Andrew-CS:** Oh yeah! Thanks. Fixed. It was counted twice in this line: | eval weirdnessCoefficient=ratingServiceAccountInteractive + ratingRdpToDc + ratingInteractiveServer + ratingexternalRDP + ratingPasswdAge + ratingDomainAdmin

--- a/Queries-Only/Cool-Query-Friday/2022-04-08 - Cool Query Friday - Scoring User Logon Events in Windows.md
+++ b/Queries-Only/Cool-Query-Friday/2022-04-08 - Cool Query Friday - Scoring User Logon Events in Windows.md
@@ -1,0 +1,149 @@
+---
+title: "Scoring User Logon Events in Windows"
+date: 2022-04-08
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/tz5obg/20220408_cool_query_friday_scoring_user_logon/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Scoring User Logon Events in Windows
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/tz5obg/20220408_cool_query_friday_scoring_user_logon/](https://www.reddit.com/r/crowdstrike/comments/tz5obg/20220408_cool_query_friday_scoring_user_logon/) — by Andrew-CS (CrowdStrike) — 2022-04-08
+
+Welcome to our forty-first installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk through of each step (3) application in the wild.
+
+## Query 1
+```cql
+index=main sourcetype=UserLogon* event_simpleName=UserLogon event_platform=win
+| search UserSid_readable=S-1-5-21-* AND LogonType_decimal!=7
+```
+
+## Query 2
+```cql
+[...]
+| lookup local=true userinfo.csv UserSid_readable OUTPUT AccountType, LocalAdminAccess
+```
+
+## Query 3
+```cql
+| inputlookup userinfo.csv
+```
+
+## Query 4
+```cql
+[...]
+| lookup local=true aid_master aid OUTPUT Version, AgentVersion
+```
+
+## Query 5
+```cql
+| inputlookup aid_master
+```
+
+## Query 6
+```cql
+[...]
+| eval passwordAgeDays=round((now()-PasswordLastSet_decimal)/60/60/24,0) 
+| fillnull passwordAgeDays value="NA"
+```
+
+## Query 7
+```cql
+[...]
+| iplocation RemoteAddressIP4
+```
+
+## Query 8
+```cql
+[...]
+| eval ratingRdpToDc=if(ProductType=2 AND LogonType_decimal=10,"10","0")
+```
+
+## Query 9
+```cql
+[...]
+| eval ratingServiceAccountInteractive=case(UserName LIKE "svc%" AND (LogonType_decimal=2 OR LogonType_decimal=10), "10")
+| fillnull ratingServiceAccountInteractive value=0
+```
+
+## Query 10
+```cql
+[...]
+| eval ratingInteractiveServer=if(ProductType=3 AND LogonType_decimal=2,"3","0")
+```
+
+## Query 11
+```cql
+[...]
+| eval ratingExternalRDP=if(isnotnull(Country) AND LogonType_decimal=10,"5","0")
+```
+
+## Query 12
+```cql
+[...]
+| eval ratingPasswdAge=if(passwordAgeDays > 180,"3","0")
+```
+
+## Query 13
+```cql
+[...]
+| eval ratingDomainAdmin=if(AccountType="Domain Administrators", "2", "0")
+```
+
+## Query 14
+```cql
+[...]
+| eval weirdnessCoefficient=ratingRdpToDc + ratingServiceAccountInteractive + ratingRdpToDc + ratingInteractiveServer + ratingexternalRDP + ratingPasswdAge + ratingDomainAdmin
+| table LogonTime_decimal, aid, ComputerName, Version, AgentVersion, UserName, UserSid_readable, LogonType_decimal, AccountType, LocalAdminAccess, ratingPasswdAge, weirdnessCoefficient 
+| sort -weirdnessCoefficient, +LogonTime_decimal 
+| convert ctime(LogonTime_decimal)
+| rename LogonTime_decimal as "Logon Time", aid as "Falcon AID", ComputerName as "Endpoint", Version as "OS", AgentVersion as "Falcon Version", UserName as "User", UserSid_readable as "User SID", LogonType_decimal as "Logon Type", AccountType as "Account Type", LocalAdminAccess as "Local Admin?", ratingPasswdAge as "Password Age (Days)", weirdnessCoefficient as "Rating"
+```
+
+## Query 15
+```cql
+index=main sourcetype=UserLogon* event_simpleName=UserLogon event_platform=win 
+| search UserSid_readable=S-1-5-21-* AND LogonType_decimal!=7
+| lookup local=true userinfo.csv UserSid_readable OUTPUT AccountType, LocalAdminAccess 
+| lookup local=true aid_master aid OUTPUT Version, AgentVersion 
+| eval passwordAgeDays=round((now()-PasswordLastSet_decimal)/60/60/24,0) 
+| fillnull passwordAgeDays value="NA" 
+| iplocation RemoteAddressIP4 
+| eval ratingRdpToDc=if(ProductType=2 AND LogonType_decimal=10,"10","0") 
+| eval ratingServiceAccountInteractive=case(UserName LIKE "svc%" AND (LogonType_decimal=2 OR LogonType_decimal=10), "10") 
+| fillnull ratingServiceAccountInteractive value=0 
+| eval ratingRdpToDc=if(ProductType=2 AND LogonType_decimal=10,"10","0") 
+| eval ratingInteractiveServer=if(ProductType=3 AND LogonType_decimal=2,"3","0") 
+| eval ratingexternalRDP=if(isnotnull(Country) AND LogonType_decimal=10,"5","0") 
+| eval ratingPasswdAge=if(passwordAgeDays > 180,"3","0") 
+| eval ratingDomainAdmin=if(AccountType="Domain Administrators", "2", "0")
+| eval weirdnessCoefficient=ratingServiceAccountInteractive + ratingRdpToDc + ratingInteractiveServer + ratingexternalRDP + ratingPasswdAge + ratingDomainAdmin
+| table LogonTime_decimal, aid, ComputerName, Version, AgentVersion, UserName, UserSid_readable, LogonType_decimal, AccountType, LocalAdminAccess, ratingPasswdAge, weirdnessCoefficient 
+| sort -weirdnessCoefficient, +LogonTime_decimal 
+| convert ctime(LogonTime_decimal)
+| rename LogonTime_decimal as "Logon Time", aid as "Falcon AID", ComputerName as "Endpoint", Version as "OS", AgentVersion as "Falcon Version", UserName as "User", UserSid_readable as "User SID", LogonType_decimal as "Logon Type", AccountType as "Account Type", LocalAdminAccess as "Local Admin?", ratingPasswdAge as "Password Age (Days)", weirdnessCoefficient as "Rating"
+```
+
+## Query 16
+```cql
+index=main sourcetype=UserLogon* event_simpleName=UserLogon event_platform=win 
+| search UserSid_readable=S-1-5-21-* AND LogonType_decimal!=7
+| lookup local=true userinfo.csv UserSid_readable OUTPUT AccountType, LocalAdminAccess 
+| lookup local=true aid_master aid OUTPUT Version, AgentVersion 
+| eval passwordAgeDays=round((now()-PasswordLastSet_decimal)/60/60/24,0) 
+| fillnull passwordAgeDays value="NA" 
+| iplocation RemoteAddressIP4 
+| eval ratingRdpToDc=if(ProductType=2 AND LogonType_decimal=10,"10","0") 
+| eval ratingServiceAccountInteractive=case(UserName LIKE "svc%" AND (LogonType_decimal=2 OR LogonType_decimal=10), "10") 
+| fillnull ratingServiceAccountInteractive value=0 
+| eval ratingRdpToDc=if(ProductType=2 AND LogonType_decimal=10,"10","0") 
+| eval ratingInteractiveServer=if(ProductType=3 AND LogonType_decimal=2,"3","0") 
+| eval ratingexternalRDP=if(isnotnull(Country) AND LogonType_decimal=10,"5","0") 
+| eval ratingPasswdAge=if(passwordAgeDays > 180,"3","0") 
+| eval ratingDomainAdmin=if(AccountType="Domain Administrators", "2", "0")
+| eval weirdnessCoefficient=ratingServiceAccountInteractive + ratingRdpToDc + ratingInteractiveServer + ratingexternalRDP + ratingPasswdAge + ratingDomainAdmin
+| table LogonTime_decimal, aid, ComputerName, Version, AgentVersion, UserName, UserSid_readable, LogonType_decimal, AccountType, LocalAdminAccess, ratingPasswdAge, weirdnessCoefficient 
+| stats sum(weirdnessCoefficient) as weirdnessCoefficient, dc(aid) as uniqueEndpoints, count(aid) as totalLogons by UserSid_readable, UserName, AccountType 
+| sort - weirdnessCoefficient
+```

--- a/Queries-Only/Cool-Query-Friday/2022-04-15 - Cool Query Friday - Hunting Tarrask and HAFNIUM.md
+++ b/Queries-Only/Cool-Query-Friday/2022-04-15 - Cool Query Friday - Hunting Tarrask and HAFNIUM.md
@@ -1,0 +1,80 @@
+---
+title: "Hunting Tarrask and HAFNIUM"
+date: 2022-04-15
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/u49jxq/20220415_cool_query_friday_hunting_tarrask_and/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Hunting Tarrask and HAFNIUM
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/u49jxq/20220415_cool_query_friday_hunting_tarrask_and/](https://www.reddit.com/r/crowdstrike/comments/u49jxq/20220415_cool_query_friday_hunting_tarrask_and/) — by Andrew-CS (CrowdStrike) — 2022-04-15
+
+Welcome to our forty-second installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk through of each step (3) application in the wild.
+
+## Query 1
+```cql
+[...]
+| search AuthenticationId_decimal=999
+```
+
+## Query 2
+```cql
+[...]
+| search RegObjectName="\\REGISTRY\\MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tree\\*"
+```
+
+## Query 3
+```cql
+[...]
+| search RegOperationType_decimal IN (2, 4) AND RegValueName="SD"
+```
+
+## Query 4
+```cql
+event_platform=win event_simpleName IN (AsepValueUpdate, RegGenericValueUpdate) 
+| search AuthenticationId_decimal=999
+| search RegObjectName="\\REGISTRY\\MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tree\\*"
+| search RegOperationType_decimal IN (2, 4) AND RegValueName="SD"
+```
+
+## Query 5
+```cql
+[...]
+| rename RegOperationType_decimal as RegOperationType, AsepClass_decimal as AsepClass
+| lookup local=true RegOperation.csv RegOperationType OUTPUT RegOperationName
+| lookup local=true AsepClass.csv AsepClass OUTPUT AsepClassName
+| eval ProcExplorer=case(ContextProcessId_decimal!="","https://falcon.crowdstrike.com/investigate/process-explorer/" .aid. "/" . ContextProcessId_decimal)
+```
+
+## Query 6
+```cql
+[...]
+| table aid, ComputerName, RegObjectName, RegValueName, AsepClassName, RegOperationName, ProcExplorer
+```
+
+## Query 7
+```cql
+event_platform=win event_simpleName IN (AsepValueUpdate, RegGenericValueUpdate) 
+| search AuthenticationId_decimal=999
+| search RegObjectName="\\REGISTRY\\MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tree\\*"
+| search RegOperationType_decimal IN (2, 4) AND RegValueName="SD"
+| rename RegOperationType_decimal as RegOperationType, AsepClass_decimal as AsepClass
+| lookup local=true RegOperation.csv RegOperationType OUTPUT RegOperationName
+| lookup local=true AsepClass.csv AsepClass OUTPUT AsepClassName
+| eval ProcExplorer=case(ContextProcessId_decimal!="","https://falcon.crowdstrike.com/investigate/process-explorer/" .aid. "/" . ContextProcessId_decimal)
+| table aid, ComputerName, RegObjectName, RegValueName, AsepClassName, RegOperationName, ProcExplorer
+```
+
+## Query 8
+```cql
+event_platform=win event_simpleName IN (AsepValueUpdate, RegGenericValueUpdate) 
+| search AuthenticationId_decimal=999
+| search RegOperationType_decimal IN (2, 4)
+| rename RegOperationType_decimal as RegOperationType, AsepClass_decimal as AsepClass
+| lookup local=true RegOperation.csv RegOperationType OUTPUT RegOperationName
+| lookup local=true AsepClass.csv AsepClass OUTPUT AsepClassName
+| eval ProcExplorer=case(ContextProcessId_decimal!="","https://falcon.crowdstrike.com/investigate/process-explorer/" .aid. "/" . ContextProcessId_decimal)
+| table aid, ComputerName, RegObjectName, RegValueName, AsepClassName, RegOperationName, ProcExplorer
+```

--- a/Queries-Only/Cool-Query-Friday/2022-04-22 - Cool Query Friday - macOS, HostInfo, and System Preferences.md
+++ b/Queries-Only/Cool-Query-Friday/2022-04-22 - Cool Query Friday - macOS, HostInfo, and System Preferences.md
@@ -1,0 +1,113 @@
+---
+title: "macOS, HostInfo, and System Preferences"
+date: 2022-04-22
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/u9f2z6/20220422_cool_query_friday_macos_hostinfo_and/"
+mitre: []
+series: Cool Query Friday
+---
+
+# macOS, HostInfo, and System Preferences
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/u9f2z6/20220422_cool_query_friday_macos_hostinfo_and/](https://www.reddit.com/r/crowdstrike/comments/u9f2z6/20220422_cool_query_friday_macos_hostinfo_and/) — by Andrew-CS (CrowdStrike) — 2022-04-22
+
+Welcome to our forty-third installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk through of each step (3) application in the wild.
+
+## Query 1
+```cql
+[...]
+| where isnotnull(AnalyticsAndImprovementsIsSet_decimal)
+| stats latest(AnalyticsAndImprovementsIsSet_decimal) as AnalyticsAndImprovementsIsSet, latest(ApplicationFirewallIsSet_decimal) as ApplicationFirewallIsSet, latest(AutoUpdate_decimal) as AutoUpdate, latest(FullDiskAccessForFalconIsSet_decimal) as FullDiskAccessForFalconIsSet, latest(FullDiskAccessForOthersIsSet_decimal) as FullDiskAccessForOthersIsSet, latest(GatekeeperIsSet_decimal) as GatekeeperIsSet, latest(InternetSharingIsSet_decimal) as InternetSharingIsSet, latest(PasswordRequiredIsSet_decimal) as PasswordRequiredIsSet, latest(RemoteLoginIsSet_decimal) as RemoteLoginIsSet, latest(SIPIsEnabled_decimal) as SIPIsEnabled, latest(StealthModeIsSet_decimal) as StealthModeIsSet by aid
+```
+
+## Query 2
+```cql
+[...]
+|  eval remediationAnalytic=case(AnalyticsAndImprovementsIsSet=1, "Disable Analytics and Improvements in macOS")
+```
+
+## Query 3
+```cql
+[...]
+|  eval remediationAnalytic=case(AnalyticsAndImprovementsIsSet=1, "Disable Analytics and Improvements in macOS")
+|  eval remediationFirewall=case(ApplicationFirewallIsSet=0, "Enable Application Firewall")
+|  eval remediationUpdate=case(AutoUpdate!=31, "Check macOS Update Settings")
+|  eval remediationFalcon=case(FullDiskAccessForFalconIsSet=0, "Enable Full Disk Access for Falcon")
+|  eval remediationGatekeeper=case(GatekeeperIsSet=0, "Enable macOS Gatekeeper")
+|  eval remediationInternet=case(InternetSharingIsSet=1, "Disable Internet Sharing")
+|  eval remediationPassword=case(PasswordRequiredIsSet=0, "Disable Automatic Logon")
+|  eval remediationSSH=case(RemoteLoginIsSet=1, "Disable Remote Logon")
+|  eval remediationSIP=case(SIPIsEnabled=0, "System Integrity Protection is disabled")
+|  eval remediationStealth=case(StealthModeIsSet=0, "Enable Stealth Mode")
+```
+
+## Query 4
+```cql
+event_platform=mac sourcetype=HostInfo* event_simpleName=HostInfo 
+| where isnotnull(AnalyticsAndImprovementsIsSet_decimal)
+| stats latest(AnalyticsAndImprovementsIsSet_decimal) as AnalyticsAndImprovementsIsSet, latest(ApplicationFirewallIsSet_decimal) as ApplicationFirewallIsSet, latest(AutoUpdate_decimal) as AutoUpdate, latest(FullDiskAccessForFalconIsSet_decimal) as FullDiskAccessForFalconIsSet, latest(FullDiskAccessForOthersIsSet_decimal) as FullDiskAccessForOthersIsSet, latest(GatekeeperIsSet_decimal) as GatekeeperIsSet, latest(InternetSharingIsSet_decimal) as InternetSharingIsSet, latest(PasswordRequiredIsSet_decimal) as PasswordRequiredIsSet, latest(RemoteLoginIsSet_decimal) as RemoteLoginIsSet, latest(SIPIsEnabled_decimal) as SIPIsEnabled, latest(StealthModeIsSet_decimal) as StealthModeIsSet by aid
+|  eval remediationAnalytic=case(AnalyticsAndImprovementsIsSet=1, "Disable Analytics and Improvements in macOS")
+|  eval remediationFirewall=case(ApplicationFirewallIsSet=0, "Enable Application Firewall")
+|  eval remediationUpdate=case(AutoUpdate!=31, "Check macOS Update Settings")
+|  eval remediationFalcon=case(FullDiskAccessForFalconIsSet=0, "Enable Full Disk Access for Falcon")
+|  eval remediationGatekeeper=case(GatekeeperIsSet=0, "Enable macOS Gatekeeper")
+|  eval remediationInternet=case(InternetSharingIsSet=1, "Disable Internet Sharing")
+|  eval remediationPassword=case(PasswordRequiredIsSet=0, "Disable Automatic Logon")
+|  eval remediationSSH=case(RemoteLoginIsSet=1, "Disable Remote Logon")
+|  eval remediationSIP=case(SIPIsEnabled=0, "System Integrity Protection is disabled")
+|  eval remediationStealth=case(StealthModeIsSet=0, "Enable Stealth Mode")
+```
+
+## Query 5
+```cql
+[...]
+|  eval macosRemediations=mvappend(remediationAnalytic, remediationFirewall, remediationUpdate, remediationFalcon, remediationGatekeeper, remediationInternet, remediationPassword, remediationSSH, remediationSIP, remediationStealth)
+```
+
+## Query 6
+```cql
+[...]
+| lookup local=true aid_master aid OUTPUT HostHiddenStatus, ComputerName, SystemManufacturer, SystemProductName, Version, Timezone, AgentVersion
+```
+
+## Query 7
+```cql
+[...]
+| search HostHiddenStatus=Visible
+```
+
+## Query 8
+```cql
+[...]
+| table aid, ComputerName, SystemManufacturer, SystemProductName, Version, Timezone, AgentVersion, macosRemediations
+```
+
+## Query 9
+```cql
+[...]
+| sort +ComputerName
+| rename aid as "Falcon Agent ID", ComputerName as "Endpoint", SystemManufacturer as "System Maker", SystemProductName as "Product Name", Version as "OS", AgentVersion as "Falcon Version", macosRemediations as "Configuration Issues"
+```
+
+## Query 10
+```cql
+event_platform=mac sourcetype=HostInfo* event_simpleName=HostInfo 
+| where isnotnull(AnalyticsAndImprovementsIsSet_decimal)
+| stats latest(AnalyticsAndImprovementsIsSet_decimal) as AnalyticsAndImprovementsIsSet, latest(ApplicationFirewallIsSet_decimal) as ApplicationFirewallIsSet, latest(AutoUpdate_decimal) as AutoUpdate, latest(FullDiskAccessForFalconIsSet_decimal) as FullDiskAccessForFalconIsSet, latest(FullDiskAccessForOthersIsSet_decimal) as FullDiskAccessForOthersIsSet, latest(GatekeeperIsSet_decimal) as GatekeeperIsSet, latest(InternetSharingIsSet_decimal) as InternetSharingIsSet, latest(PasswordRequiredIsSet_decimal) as PasswordRequiredIsSet, latest(RemoteLoginIsSet_decimal) as RemoteLoginIsSet, latest(SIPIsEnabled_decimal) as SIPIsEnabled, latest(StealthModeIsSet_decimal) as StealthModeIsSet by aid
+|  eval remediationAnalytic=case(AnalyticsAndImprovementsIsSet=1, "Disable Analytics and Improvements in macOS")
+|  eval remediationFirewall=case(ApplicationFirewallIsSet=0, "Enable Application Firewall")
+|  eval remediationUpdate=case(AutoUpdate!=31, "Check macOS Update Settings")
+|  eval remediationFalcon=case(FullDiskAccessForFalconIsSet=0, "Enable Full Disk Access for Falcon")
+|  eval remediationGatekeeper=case(GatekeeperIsSet=0, "Enable macOS Gatekeeper")
+|  eval remediationInternet=case(InternetSharingIsSet=1, "Disable Internet Sharing")
+|  eval remediationPassword=case(PasswordRequiredIsSet=0, "Disable Automatic Logon")
+|  eval remediationSSH=case(RemoteLoginIsSet=1, "Disable Remote Logon")
+|  eval remediationSIP=case(SIPIsEnabled=0, "System Integrity Protection is disabled")
+|  eval remediationStealth=case(StealthModeIsSet=0, "Enable Stealth Mode")
+|  eval macosRemediations=mvappend(remediationAnalytic, remediationFirewall, remediationUpdate, remediationFalcon, remediationGatekeeper, remediationInternet, remediationPassword, remediationSSH, remediationSIP, remediationStealth)
+| lookup local=true aid_master aid OUTPUT HostHiddenStatus, ComputerName, SystemManufacturer, SystemProductName, Version, Timezone, AgentVersion
+| search HostHiddenStatus=Visible
+| table aid, ComputerName, SystemManufacturer, SystemProductName, Version, Timezone, AgentVersion, macosRemediations 
+| sort +ComputerName
+| rename aid as "Falcon Agent ID", ComputerName as "Endpoint", SystemManufacturer as "System Maker", SystemProductName as "Product Name", Version as "OS", AgentVersion as "Falcon Version", macosRemediations as "Configuration Issues"
+```

--- a/Queries-Only/Cool-Query-Friday/2022-04-22 - Cool Query Friday - macOS, HostInfo, and System Preferences.md
+++ b/Queries-Only/Cool-Query-Friday/2022-04-22 - Cool Query Friday - macOS, HostInfo, and System Preferences.md
@@ -111,3 +111,16 @@ event_platform=mac sourcetype=HostInfo* event_simpleName=HostInfo
 | sort +ComputerName
 | rename aid as "Falcon Agent ID", ComputerName as "Endpoint", SystemManufacturer as "System Maker", SystemProductName as "Product Name", Version as "OS", AgentVersion as "Falcon Version", macosRemediations as "Configuration Issues"
 ```
+
+## Community & Staff Additions
+*Harvested from this post's [r/CrowdStrike](https://www.reddit.com/r/crowdstrike/) comment thread — not part of the original CQF post. **[CS]** = CrowdStrike staff · **[Community]** = other r/CrowdStrike users. Upvote scores shown for context.*
+
+### Q&A
+
+**Q — [Community] soroyaya:** I was just trying this, great stuff! Would you have any comments on below? 1) Can you explain what information `PasswordRequiredIsSet_decimal` captures? 2) System Preferences > Software Update (outside the advanced settings) has a tick-box for applying automatic updates. Is there a way to know if th …
+
+**A — [CS] Andrew-CS:** Thanks! Glad it's helpful. Here are the answers: 1. If auto-login for a single user is enabled via "Users and Groups," `PasswordRequiredIsSet_decimal` will be set to `0`. 2. Correct. If that main toggle is NOT enabled, the bitmask value would be `0`.
+
+**Q — [Community] felixguerrero12:** What would "Enabling Full Disk Access for Falcon" grant? What implications might it have not having it turned on?
+
+**A — [CS] Andrew-CS:** If you were to try and put, get, or list files using RTR that would not work as Falcon will not have access to the disk. Functions that require Falcon to read configurations (e.g. Spotlight) might also not work properly. The ability to hash files could also be impacted. FWIW, it's listed as a system requirement so my recommendation would be to allow it unless there is a strong technical reason not to.

--- a/Queries-Only/Cool-Query-Friday/2022-05-20 - Cool Query Friday - Hunting macOS Application Bundles.md
+++ b/Queries-Only/Cool-Query-Friday/2022-05-20 - Cool Query Friday - Hunting macOS Application Bundles.md
@@ -1,0 +1,62 @@
+---
+title: "Hunting macOS Application Bundles"
+date: 2022-05-20
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/utycmg/20220520_cool_query_friday_hunting_macos/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Hunting macOS Application Bundles
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/utycmg/20220520_cool_query_friday_hunting_macos/](https://www.reddit.com/r/crowdstrike/comments/utycmg/20220520_cool_query_friday_hunting_macos/) — by Andrew-CS (CrowdStrike) — 2022-05-20
+
+Welcome to our forty-fourth installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk through of each step (3) application in the wild.
+
+## Query 1
+```cql
+[...]
+| regex TargetFileName=".*\/.*\.app\/.*"
+```
+
+## Query 2
+```cql
+[...]
+| rex field=TargetFileName ".*\/(?<appName>.*\.app)\/.*" 
+| rex field=TargetFileName "(?<filePath>^\/.*\.app)\/.*"
+```
+
+## Query 3
+```cql
+[...]
+| eval fileLocale=case(match(TargetFileName,"^\/Applications\/"), "Applications Folder", match(TargetFileName,"^\/Users\/"), "User's Home Folder", match(TargetFileName,"^\/(System|Library|Developer)\/"), "macOS Core Folder")
+```
+
+## Query 4
+```cql
+[...]
+| rex field=TargetFileName "\/Users\/\w+\/(?<homeFolderLocale>\w+)\/.*"
+| eval homeFolderLocale = "~/".homeFolderLocale
+| fillnull value="-" homeFolderLocale
+```
+
+## Query 5
+```cql
+[...]
+| stats dc(aid) as endpointCount, dc(TargetFileName) as filesWritten, dc(SHA256HashData) as sha256Count by appName, filePath, fileLocale, homeFolderLocale
+| sort - endpointCount
+```
+
+## Query 6
+```cql
+event_platform=mac event_simpleName=MachOFileWritten 
+| regex TargetFileName=".*\/.*\.app\/.*" 
+| rex field=TargetFileName ".*\/(?<appName>.*\.app)\/.*" 
+| rex field=TargetFileName "(?<filePath>^\/.*\.app)\/.*" 
+| eval fileLocale=case(match(TargetFileName,"^\/Applications\/"), "Applications Folder", match(TargetFileName,"^\/Users\/"), "User's Home Folder", match(TargetFileName,"^\/(System|Library|Developer)\/"), "macOS Core Folder")
+| rex field=TargetFileName "\/Users\/\w+\/(?<homeFolderLocale>\w+)\/.*"
+| eval homeFolderLocale = "~/".homeFolderLocale
+| fillnull value="-" homeFolderLocale
+| stats dc(aid) as endpointCount, dc(TargetFileName) as filesWritten, dc(SHA256HashData) as sha256Count by appName, filePath, fileLocale, homeFolderLocale
+| sort - endpointCount
+```

--- a/Queries-Only/Cool-Query-Friday/2022-07-15 - Cool Query Friday - Hunting ISO Mounts with New Telemetry.md
+++ b/Queries-Only/Cool-Query-Friday/2022-07-15 - Cool Query Friday - Hunting ISO Mounts with New Telemetry.md
@@ -1,0 +1,56 @@
+---
+title: "Hunting ISO Mounts with New Telemetry"
+date: 2022-07-15
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/vzosj9/20220715_cool_query_friday_hunting_iso_mounts/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Hunting ISO Mounts with New Telemetry
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/vzosj9/20220715_cool_query_friday_hunting_iso_mounts/](https://www.reddit.com/r/crowdstrike/comments/vzosj9/20220715_cool_query_friday_hunting_iso_mounts/) — by Andrew-CS (CrowdStrike) — 2022-07-15
+
+Welcome to our forty-fifth installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk through of each step (3) application in the wild.
+
+## Query 1
+```cql
+| eval driveType=case(VirtualDriveFileType_decimal=1, "ISO", VirtualDriveFileType_decimal=2, "VHD", VirtualDriveFileType_decimal=3, "VHDX", VirtualDriveFileType_decimal=0, "Unknown")
+```
+
+## Query 2
+```cql
+[...]
+| rex field=VirtualDriveFileName ".*\\\(?<isoName>.*\.(img|iso))"
+```
+
+## Query 3
+```cql
+[...]
+| table ContextTimeStamp_decimal, aid, ComputerName, VolumeDriveLetter, VolumeName, isoName, VirtualDriveFileName
+| rename ContextTimeStamp_decimal as endpointSystemClock, aid as agentID, ComputerName as computerName, VolumeDriveLetter as driveLetter, VolumeName as volumeName, VirtualDriveFileName as fullPath
+| convert ctime(endpointSystemClock)
+```
+
+## Query 4
+```cql
+event_platform=win event_simpleName IN (FsVolumeMounted, RemovableMediaVolumeMounted, SnapshotVolumeMounted) VirtualDriveFileType_decimal=1 
+| rex field=VirtualDriveFileName ".*\\\(?<isoName>.*\.(img|iso))" 
+| table ContextTimeStamp_decimal, aid, ComputerName, VolumeDriveLetter, VolumeName, isoName, VirtualDriveFileName
+| rename ContextTimeStamp_decimal as endpointSystemClock, aid as agentID, ComputerName as computerName, VolumeDriveLetter as driveLetter, VolumeName as volumeName, VirtualDriveFileName as fullPath
+| convert ctime(endpointSystemClock)
+```
+
+## Query 5
+```cql
+event_platform=win event_simpleName IN (FsVolumeMounted, RemovableMediaVolumeMounted, SnapshotVolumeMounted) VirtualDriveFileType_decimal=1 
+| rex field=VirtualDriveFileName ".*\\\(?<isoName>.*\.(img|iso))" 
+| search isoName!="SW_DVD5_OFFICE_PROFESSIONAL_PLUS_64BIT_ENGLISH_-6_OFFICEONLINESVR_MLF_X21-90444.iso"
+```
+
+## Query 6
+```cql
+event_platform=win event_simpleName IN (FsVolumeMounted, RemovableMediaVolumeMounted, SnapshotVolumeMounted) VirtualDriveFileType_decimal=1 
+| rex field=VirtualDriveFileName ".*\\\(?<isoName>.*\.(img|iso))" 
+| regex isoName!="sw_dvd\d\_office\_professional\_plus\_(64|32)bit\_english\_\-\d\_officeonlinesvr_mlf_x\d+\-\d+\.iso"
+```

--- a/Queries-Only/Cool-Query-Friday/2022-07-15 - Cool Query Friday - Hunting ISO Mounts with New Telemetry.md
+++ b/Queries-Only/Cool-Query-Friday/2022-07-15 - Cool Query Friday - Hunting ISO Mounts with New Telemetry.md
@@ -54,3 +54,17 @@ event_platform=win event_simpleName IN (FsVolumeMounted, RemovableMediaVolumeMou
 | rex field=VirtualDriveFileName ".*\\\(?<isoName>.*\.(img|iso))" 
 | regex isoName!="sw_dvd\d\_office\_professional\_plus\_(64|32)bit\_english\_\-\d\_officeonlinesvr_mlf_x\d+\-\d+\.iso"
 ```
+
+## Community & Staff Additions
+*Harvested from this post's [r/CrowdStrike](https://www.reddit.com/r/crowdstrike/) comment thread — not part of the original CQF post. **[CS]** = CrowdStrike staff · **[Community]** = other r/CrowdStrike users. Upvote scores shown for context.*
+
+### Operational caveats
+
+> The ISO has to be mounted - via double clicking - and the Falcon sensor has to be at version 6.40+.
+— [CS] Andrew-CS · score 1
+
+### Q&A
+
+**Q — [Community] jarks_20:** In the case of legit .iso images, what would be the best approach to the detection? Adding exclusions on the search manually would make the week longer :) How to determine if this .iso is not one of ours or externally sent? Does this make sense?
+
+**A — [CS] Andrew-CS:** Any commonality to the ISOs that are yours? Naming conventions, computers interacting with them, location, etc.?

--- a/Queries-Only/Cool-Query-Friday/2022-08-15 - Cool Query Friday - Hunting Cluster Events by Process Lineage.md
+++ b/Queries-Only/Cool-Query-Friday/2022-08-15 - Cool Query Friday - Hunting Cluster Events by Process Lineage.md
@@ -1,0 +1,73 @@
+---
+title: "Hunting Cluster Events by Process Lineage"
+date: 2022-08-15
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/woz73a/20220815_cool_query_friday_hunting_cluster_events/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Hunting Cluster Events by Process Lineage
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/woz73a/20220815_cool_query_friday_hunting_cluster_events/](https://www.reddit.com/r/crowdstrike/comments/woz73a/20220815_cool_query_friday_hunting_cluster_events/) — by Andrew-CS (CrowdStrike) — 2022-08-15
+
+Welcome to our forty-sixth installment of[ Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk through of each step (3) application in the wild.
+
+## Query 1
+```cql
+[...]
+| stats dc(FileName) as fnameCount, earliest(ProcessStartTime_decimal) as firstRun, latest(ProcessStartTime_decimal) as lastRun, values(FileName) as filesRun, values(CommandLine) as cmdsRun by cid, aid, ComputerName, ParentBaseFileName, ParentProcessId_decimal
+```
+
+## Query 2
+```cql
+[...]
+| where fnameCount > 3
+```
+
+## Query 3
+```cql
+[...]
+| where fnameCount>=9
+```
+
+## Query 4
+```cql
+event_platform=win event_simpleName=ProcessRollup2 FileName IN (whoami.exe, arp.exe, cmd.exe, net.exe, net1.exe, ipconfig.exe, route.exe, netstat.exe, nslookup.exe)
+| stats dc(FileName) as fnameCount, earliest(ProcessStartTime_decimal) as firstRun, latest(ProcessStartTime_decimal) as lastRun, values(FileName) as filesRun, values(CommandLine) as cmdsRun by cid, aid, ComputerName, ParentBaseFileName, ParentProcessId_decimal
+| where fnameCount > 3
+```
+
+## Query 5
+```cql
+[...]
+| eval timeDelta=lastRun-firstRun
+| where timeDelta < 600
+```
+
+## Query 6
+```cql
+event_platform=win event_simpleName=ProcessRollup2 FileName IN (whoami.exe, arp.exe, cmd.exe, net.exe, net1.exe, ipconfig.exe, route.exe, netstat.exe, nslookup.exe)
+| stats dc(FileName) as fnameCount, earliest(ProcessStartTime_decimal) as firstRun, latest(ProcessStartTime_decimal) as lastRun, values(FileName) as filesRun, values(CommandLine) as cmdsRun by cid, aid, ComputerName, ParentBaseFileName, ParentProcessId_decimal
+| where fnameCount > 3
+| eval timeDelta=lastRun-firstRun
+| where timeDelta < 600
+```
+
+## Query 7
+```cql
+[...]
+| eval graphExplorer=case(ParentProcessId_decimal!="","https://falcon.crowdstrike.com/graphs/process-explorer/tree?id=pid:".aid.":".ParentProcessId_decimal)
+| table cid, aid, ComputerName, ParentBaseFileName, filesRun, cmdsRun, timeDelta, graphExplorer
+```
+
+## Query 8
+```cql
+event_platform=win event_simpleName=ProcessRollup2 FileName IN (whoami.exe, arp.exe, cmd.exe, net.exe, net1.exe, ipconfig.exe, route.exe, netstat.exe, nslookup.exe)
+| stats dc(FileName) as fnameCount, earliest(ProcessStartTime_decimal) as firstRun, latest(ProcessStartTime_decimal) as lastRun, values(FileName) as filesRun, values(CommandLine) as cmdsRun by cid, aid, ComputerName, ParentBaseFileName, ParentProcessId_decimal
+| where fnameCount > 3
+| eval timeDelta=lastRun-firstRun
+| where timeDelta < 600
+| eval graphExplorer=case(ParentProcessId_decimal!="","https://falcon.crowdstrike.com/graphs/process-explorer/tree?id=pid:".aid.":".ParentProcessId_decimal)
+| table cid, aid, ComputerName, ParentBaseFileName, filesRun, cmdsRun, timeDelta, graphExplorer
+```

--- a/Queries-Only/Cool-Query-Friday/2022-08-15 - Cool Query Friday - Hunting Cluster Events by Process Lineage.md
+++ b/Queries-Only/Cool-Query-Friday/2022-08-15 - Cool Query Friday - Hunting Cluster Events by Process Lineage.md
@@ -71,3 +71,16 @@ event_platform=win event_simpleName=ProcessRollup2 FileName IN (whoami.exe, arp.
 | eval graphExplorer=case(ParentProcessId_decimal!="","https://falcon.crowdstrike.com/graphs/process-explorer/tree?id=pid:".aid.":".ParentProcessId_decimal)
 | table cid, aid, ComputerName, ParentBaseFileName, filesRun, cmdsRun, timeDelta, graphExplorer
 ```
+
+## Community & Staff Additions
+*Harvested from this post's [r/CrowdStrike](https://www.reddit.com/r/crowdstrike/) comment thread — not part of the original CQF post. **[CS]** = CrowdStrike staff · **[Community]** = other r/CrowdStrike users. Upvote scores shown for context.*
+
+### Q&A
+
+**Q — [Community] animatedgoblin:** During general alert reviews we noticed that the above query has a bit of a problem we _think_ we understand, but would like some clarity. Let's say for sake of example, we have fNameCount set to >3, and a time delta of 600. Now, let's say that we have a PowerShell process that is created at 12:00 a …
+
+**A — [CS] Andrew-CS:** That does make sense and you are absolutely correct. The results will be affected by the `lastRun` time — which in your example puts `timeDelta` at 53 minutes. In the example article, we were working under the assumption that the tradecraft was programatic so we *should* be able to detect it with some time-boxing, however, if it where hands-on-keyboard and the timing were varied (because humans) we might want to make it time OR count. So something like "more than 5 of these things happen in my s …
+
+**Q — [Community] animatedgoblin:** >more than 5 of these things happen in my search window That's super simple logic I hadn't considered! How would one implement that? Would it be something as simple as ``` | eval timeDelta=lastRun-firstRun | where (fnameCount > 3 AND timeDelta < 600) OR fnameCount > 5 ``` ?
+
+**A — [CS] Andrew-CS:** Yup! Your idea to use `bucket` and then set your `span` to 10, 15, whatever minutes is also a good one as that will *chunck* up the rows in the given increments.

--- a/Queries-Only/Cool-Query-Friday/2022-08-20 - Cool Query Friday - Linux UserLogon and FailedUserLogon Event Updates.md
+++ b/Queries-Only/Cool-Query-Friday/2022-08-20 - Cool Query Friday - Linux UserLogon and FailedUserLogon Event Updates.md
@@ -1,0 +1,112 @@
+---
+title: "Linux UserLogon and FailedUserLogon Event Updates"
+date: 2022-08-20
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/wta83n/20220820_cool_query_friday_linux_userlogon_and/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Linux UserLogon and FailedUserLogon Event Updates
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/wta83n/20220820_cool_query_friday_linux_userlogon_and/](https://www.reddit.com/r/crowdstrike/comments/wta83n/20220820_cool_query_friday_linux_userlogon_and/) — by Andrew-CS (CrowdStrike) — 2022-08-20
+
+Welcome to our forty-seventh installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk through of each step (3) application in the wild.
+
+## Query 1
+```cql
+[...]
+| search NOT RemoteAddressIP4 IN (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 127.0.0.1)
+```
+
+## Query 2
+```cql
+[...]
+| iplocation RemoteAddressIP4
+```
+
+## Query 3
+```cql
+event_platform=Lin event_simpleName IN (UserLogon, UserLogonFailed2) LogonType_decimal=10
+| search NOT RemoteAddressIP4 IN (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 127.0.0.1)
+| iplocation RemoteAddressIP4
+| stats count(aid) as loginAttempts, dc(aid) as totalSystemsTargeted, values(ComputerName) as computersTargeted, values(UserName) as accountsTargeted by RemoteAddressIP4, Country, Region, City
+| sort - loginAttempts
+```
+
+## Query 4
+```cql
+event_platform=Lin event_simpleName IN (UserLogon, UserLogonFailed2) LogonType_decimal=10
+| search NOT RemoteAddressIP4 IN (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 127.0.0.1)
+| iplocation RemoteAddressIP4
+| stats count(aid) as loginAttempts, dc(aid) as totalSystemsTargeted, values(ComputerName) as computersTargeted by UserName, RemoteAddressIP4, Country, Region, City
+| sort - loginAttempts
+```
+
+## Query 5
+```cql
+event_platform=Lin event_simpleName IN (UserLogon, UserLogonFailed2) LogonType_decimal=10
+| search NOT RemoteAddressIP4 IN (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 127.0.0.1)
+| iplocation RemoteAddressIP4
+| stats count(aid) as loginAttempts, dc(aid) as totalSystemsTargeted, dc(RemoteAddressIP4) as remoteIPsInvolved, values(Country) as countriesInvolved, values(ComputerName) as computersTargeted by UserName
+| sort - loginAttempts
+```
+
+## Query 6
+```cql
+event_platform=Lin event_simpleName IN (UserLogon) 
+| iplocation RemoteAddressIP4
+| convert ctime(LogonTime_decimal) as LogonTime, ctime(PasswordLastSet_decimal) as PasswordLastSet
+| eval LogonType=case(LogonType_decimal=2, "Interactive", LogonType_decimal=10, "Remote Interactive/SSH")
+| eval UserIsAdmin=case(UserIsAdmin_decimal=1, "Admin", UserIsAdmin_decimal=0, "Non-Admin")
+| fillnull value="-" RemoteAddressIP4, Country, Region, City
+| table aid, ComputerName, UserName, UID_decimal, PasswordLastSet, UserIsAdmin, LogonType, LogonTime, RemoteAddressIP4, Country, Region, City 
+| sort 0 +ComputerName, LogonTime
+| rename aid as "Agent ID", ComputerName as "Endpoint", UserName as "User", UID_decimal as "User ID", PasswordLastSet as "Password Last Set", UserIsAdmin as "Admin?", LogonType as "Logon Type", LogonTime as "Logon Time", RemoteAddressIP4 as "Remote IP", Country as "GeoIP Country", City as "GeoIP City", Region as "GeoIP Region"
+```
+
+## Query 7
+```cql
+| convert ctime(LogonTime_decimal) as LogonTime, ctime(PasswordLastSet_decimal) as PasswordLastSet
+| eval LogonType=case(LogonType_decimal=2, "Interactive", LogonType_decimal=10, "Remote Interactive/SSH")
+| eval UserIsAdmin=case(UserIsAdmin_decimal=1, "Admin", UserIsAdmin_decimal=0, "Non-Admin")
+```
+
+## Query 8
+```cql
+event_simpleName=UserLogon NOT RemoteIP IN (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 127.0.0.1)
+| iplocation RemoteIP 
+| eval userID=coalesce(UserSid_readable, UID_decimal)
+| eval stream1=mvzip(mvzip(mvzip(mvzip(mvzip(LogonTime_decimal, lat, ":::"), lon, ":::"), Country, ":::"), Region, ":::"), City, ":::")
+| stats values(stream1) as stream2, dc(RemoteIP) as remoteIPCount by userID, UserName, event_platform
+| where remoteIPCount > 1 
+| fields userID UserName event_platform stream2
+| mvexpand stream2
+| eval stream1=split(stream2, ":::")
+| eval LogonTime=mvindex(stream1, 0)
+| eval lat=mvindex(stream1, 1)
+| eval lon=mvindex(stream1, 2)
+| eval country=mvindex(stream1, 3)
+| eval region=mvindex(stream1, 4)
+| eval city=mvindex(stream1, 5)
+| sort - userID + LogonTime
+| streamstats values(LogonTime) as previous_logon, values(lat) as previous_lat, values(lon) as previous_lon, values(country) as previous_country, values(region) as previous_region, values(city) as previous_city by userID UserName event_platform current=f window=1 reset_on_change=true
+| fillnull value="Initial"
+| eval timeDelta=round((LogonTime-previous_logon)/60/60,2)
+| eval rlat1 = pi()*previous_lat/180, rlat2=pi()*lat/180, rlat = pi()*(lat-previous_lat)/180, rlon= pi()*(lon-previous_lon)/180
+| eval a = sin(rlat/2) * sin(rlat/2) + cos(rlat1) * cos(rlat2) * sin(rlon/2) * sin(rlon/2) 
+| eval c = 2 * atan2(sqrt(a), sqrt(1-a)) 
+| eval distance = round((6371 * c),0)
+| eval speed=round((distance/timeDelta),2) 
+| fields - stream1 stream2 
+| where previous_logon!="Initial" AND speed > 1234
+| table event_platform UserName userID previous_logon previous_country previous_region previous_city LogonTime country region city distance timeDelta speed
+| sort - speed
+| convert ctime(previous_logon) ctime(LogonTime)
+| rename event_platform as "Platform", UserName AS "User", userID AS "User ID", previous_logon AS "Logon", previous_country AS Country, previous_region AS "Region", previous_city AS City, LogonTime AS "Next Logon", country AS "Next Country", region AS "Next Region", city AS "Next City", distance AS Distance, timeDelta AS "Time Delta", speed AS "Required Speed (km\h)"
+```
+
+## Query 9
+```cql
+| where previous_logon!="Initial" AND speed > 1234
+```

--- a/Queries-Only/Cool-Query-Friday/2022-09-07 - Cool Query Friday - Fields of Dreams Project.md
+++ b/Queries-Only/Cool-Query-Friday/2022-09-07 - Cool Query Friday - Fields of Dreams Project.md
@@ -1,0 +1,37 @@
+---
+title: "Fields of Dreams Project"
+date: 2022-09-07
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/x85ufw/20220907_cool_query_friday_fields_of_dreams/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Fields of Dreams Project
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/x85ufw/20220907_cool_query_friday_fields_of_dreams/](https://www.reddit.com/r/crowdstrike/comments/x85ufw/20220907_cool_query_friday_fields_of_dreams/) — by Andrew-CS (CrowdStrike) — 2022-09-07
+
+Welcome to our forty-eighth installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk through of each step (3) application in the wild.
+
+## Query 1
+```cql
+| eval LogonType=case(
+	LogonType_decimal="2",  "Interactive", 
+	LogonType_decimal="3",  "Network", 
+	LogonType_decimal="4",  "Batch", 
+	LogonType_decimal="5",  "Service", 
+	LogonType_decimal="6",  "Proxy", 
+	LogonType_decimal="7",  "Unlock", 
+	LogonType_decimal="8",  "Network Cleartext", 
+	LogonType_decimal="9",  "New Credentials", 
+	LogonType_decimal="10", "Remote Interactive", 
+	LogonType_decimal="11", "Cached Interactive", 
+	LogonType_decimal="12", "Cached Remote Interactive", 
+	LogonType_decimal="13", "Cached Unlock"
+	)
+```
+
+## Query 2
+```cql
+| eval LogonType=case(LogonType_decimal="2", "Interactive", LogonType_decimal="3",  "Network", LogonType_decimal="4", "Batch", LogonType_decimal="5", "Service", LogonType_decimal="6", "Proxy", LogonType_decimal="7", "Unlock", LogonType_decimal="8", "Network Cleartext", LogonType_decimal="9", "New Credentials", LogonType_decimal="10", "Remote Interactive", LogonType_decimal="11", "Cached Interactive", LogonType_decimal="12", "Cached Remote Interactive", LogonType_decimal="13", "Cached Unlock")
+```

--- a/Queries-Only/Cool-Query-Friday/2022-09-16 - Cool Query Friday - Microsoft Teams Credentials in the Clear.md
+++ b/Queries-Only/Cool-Query-Friday/2022-09-16 - Cool Query Friday - Microsoft Teams Credentials in the Clear.md
@@ -81,3 +81,60 @@ COMMAND LINE: .*\/\.config\/Microsoft\/Microsoft\sTeams\/(Cookies|Local\s+Storag
 | CommandLine=/Teams(\\|\/)(local\sstorage(\\|\/))?(?<teamsFile>(leveldb|cookies))/i
 | sankey(source="ImageFileName",target="teamsFile", weight=count(aid))
 ```
+
+## Community & Staff Additions
+*Harvested from this post's [r/CrowdStrike](https://www.reddit.com/r/crowdstrike/) comment thread — not part of the original CQF post. **[CS]** = CrowdStrike staff · **[Community]** = other r/CrowdStrike users. Upvote scores shown for context.*
+
+### Query variants
+
+```cql
+| CommandLine IN (cookies, leveldb)
+```
+— [CS] Andrew-CS · comment score 2
+
+```cql
+index=main event_simpleName IN ("SyntheticProcessRollup2", "ProcessRollup2") ((FilePath IN ("\\Device\\HarddiskVolume*\\Users\\*\\AppData\\*\\Microsoft\\Teams\\Cookies\\", "\\Device\\HarddiskVolume*\\Users\\*\\AppData\\*\\Microsoft\\Teams\\Local Storage\\leveldb\\") OR CommandLine IN ("*Microsoft\\Teams\\Cookies\\*", "*Microsoft\\Teams\\Local Storage\\leveldb\\*") ) FileName!="Teams.exe" event_platform=Win ) OR ((FilePath IN ("/*/Library/Application Support/Microsoft/Teams/Cookies", "/*/Library/Application Support/Microsoft/Teams/Local Storage/leveldb") OR CommandLine IN ("/*/Library/Application Support/Microsoft/Teams/Cookies/*", "/*/Library/Application Support/Microsoft/Teams/Local Storage/leveldb/*") event_platform=mac) OR ((FilePath IN ("/*/.config/Microsoft/Microsoft Teams/Cookies/", "/*/.config/Microsoft/Microsoft Teams/Local Storage/leveldb/") OR CommandLine IN ("/*/.config/Microsoft/Microsoft Teams/Cookies/*", "/*/.config/Microsoft/Microsoft Teams/Local Storage/leveldb/*") event_platform=lin)
+| fillnull value="Value not provided" 
+| stats values(FilePath) AS Path,
+    values(CommandLine) AS commands,
+    values(_time) AS Time
+    BY 
+    FileName,
+    ComputerName,
+    UserName,
+    aid,
+    company,
+    LocalAddressIP4 
+| eval Time = strftime(Time, "%m/%d/%Y %H:%M:%S")
+```
+— [Community] ChirsF · comment score 3
+
+```cql
+index=main sourcetype=ProcessRollup2* event_simpleName=ProcessRollup2 event_platform IN (win, mac, lin)
+| regex CommandLine="(?i).*(\\\\|\/)microsoft(\\\\|\/)(microsoft\s)?teams(\\\\|\/)(cookies|local\s+storage(\\\\|\/)leveldb).*"
+| stats dc(aid) as uniqueEndpoints, count(aid) as invocationCount, earliest(ProcessStartTime_decimal) as firstRun, latest(ProcessStartTime_decimal) as lastRun, values(CommandLine) as cmdLines by ParentBaseFileName, FileName
+| convert ctime(firstRun), ctime(lastRun)
+```
+— [CS] Andrew-CS · comment score 3
+
+### Operational caveats
+
+> Regex is scary to look at, but easy to learn if someone explains it. We did a short write-up on it [here](https://www.reddit.com/r/crowdstrike/comments/ppzp59/20210917_cool_query_friday_regular_expressions/). The general rule is: if you want to use a character that isn't a literal number \[0-9\] or letter \[A-Z\] you should "escape" it. Here is an example. Device\HarddiskVolume1\Program Files\Adobe Suite 4\Photoshop_v1234.exe so if you wanted to write regex to match that, you just go slowly from left to right and use pattern where you can. Device\\HarddiskVolume\d\\Program\sFiles\\Adobe\sSuite\s\d\\Photoshop\_v\d{4}\.exe If I were to put actual spaces between the regex so it's easier to read …
+— [CS] Andrew-CS · score 2
+
+> Confirmed working as expected here on macOS 12.6. [https://imgur.com/a/3XcH56z](https://imgur.com/a/3XcH56z) I would make sure: 1. Custom IOA logic is correct 2. Rule is enabled 3. Custom IOA Group is enabled 4. Custom IOA Group is assigned to the prevention policy your system is in 5. Sensor has Full Disk Access If that doesn't work, you can definitely open up a support ticket for assistance.
+— [CS] Andrew-CS · score 2
+
+### Q&A
+
+**Q — [Community] ChirsF:** From an spl perspective this is taking all events and then running the regex command on the data, versus doing CommandLine IN (“string”, “string2”) grabbing only the relevant events. Have you found this regex method to be more efficient in CS?
+
+**A — [CS] Andrew-CS:** HI there. I like regex because of the pattern matching and precision in this instance. If you use: | CommandLine IN (cookies, leveldb) there will likely be far more *hits* that don't necessarily have to do with Teams. But please do whatever works for you!
+
+**Q — [Community] TerribleSessions:** Is it possible to make the query bit lighter? On a large estate this never finish.
+
+**A — [CS] Andrew-CS:** Hi there. You may have to run this in smaller time chunks on larger estates as this query will run a regex over every single command line — this is, as you've seen, computationally expensive. I've added a little optimization here by specifying index and sourcetype, but I honestly don't think that will impact the expensive part of the query. index=main sourcetype=ProcessRollup2* event_simpleName=ProcessRollup2 event_platform IN (win, mac, lin) | regex CommandLine="(?i).*(\\\\|\/)microsoft(\\\\|\/ …
+
+**Q — [Community] Parking_Industry_761:** Is there a reason as to why we wouldn't want to exclude the teams.exe since Vectra stated that we should be looking for anything other process other than teams.exe accessing these files?
+
+**A — [CS] Andrew-CS:** Hi there. It’s a good question. What we’re hunting here are things invoking the files via command line which we would not expect Teams to do when reading them. I hope that helps.

--- a/Queries-Only/Cool-Query-Friday/2022-09-16 - Cool Query Friday - Microsoft Teams Credentials in the Clear.md
+++ b/Queries-Only/Cool-Query-Friday/2022-09-16 - Cool Query Friday - Microsoft Teams Credentials in the Clear.md
@@ -1,0 +1,83 @@
+---
+title: "Microsoft Teams Credentials in the Clear"
+date: 2022-09-16
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/xfqtyb/20220916_cool_query_friday_microsoft_teams/"
+mitre: [T1552.001]
+series: Cool Query Friday
+---
+
+# Microsoft Teams Credentials in the Clear
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/xfqtyb/20220916_cool_query_friday_microsoft_teams/](https://www.reddit.com/r/crowdstrike/comments/xfqtyb/20220916_cool_query_friday_microsoft_teams/) — by Andrew-CS (CrowdStrike) — 2022-09-16
+
+Welcome to our forty-ninth installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk through of each step (3) application in the wild.
+
+## Query 1
+```cql
+event_platform IN (win, mac, lin) event_simpleName=ProcessRollup2
+| regex CommandLine="(?i).*(\\\\|\/)microsoft(\\\\|\/)(microsoft\s)?teams(\\\\|\/)(cookies|local\s+storage(\\\\|\/)leveldb).*"
+```
+
+## Query 2
+```cql
+event_platform IN (win, mac, lin) event_simpleName=ProcessRollup2
+| regex CommandLine="(?i).*(\\\\|\/)microsoft(\\\\|\/)(microsoft\s)?teams(\\\\|\/)(cookies|local\s+storage(\\\\|\/)leveldb).*"
+| stats dc(aid) as uniqueEndpoints, count(aid) as invocationCount, earliest(ProcessStartTime_decimal) as firstRun, latest(ProcessStartTime_decimal) as lastRun, values(CommandLine) as cmdLines by ParentBaseFileName, FileName
+| convert ctime(firstRun), ctime(lastRun)
+```
+
+## Query 3
+```cql
+Rule Type: Process Creation
+Action To Take: <choose>
+Severity: <choose>
+GRANDPARENT IMAGE FILENAME: .*
+GRANDPARENT COMMAND LINE: .*
+PARENT IMAGE FILENAME: .*
+PARENT COMMAND LINE: .*
+IMAGE FILENAME: .*
+COMMAND LINE: .*\\Microsoft\\Teams\\(Cookies|Local\s+Storage\\leveldb).*
+```
+
+## Query 4
+```cql
+Rule Type: Process Creation
+Action To Take: <choose>
+Severity: <choose>
+GRANDPARENT IMAGE FILENAME: .*
+GRANDPARENT COMMAND LINE: .*
+PARENT IMAGE FILENAME: .*
+PARENT COMMAND LINE: .*
+IMAGE FILENAME: .*
+COMMAND LINE: .*\/Library\/Application\s+Support\/Microsoft\/Teams\/(Cookies|Local\s+Storage\/leveldb).*
+```
+
+## Query 5
+```cql
+Rule Type: Process Creation
+Action To Take: <choose>
+Severity: <choose>
+GRANDPARENT IMAGE FILENAME: .*
+GRANDPARENT COMMAND LINE: .*
+PARENT IMAGE FILENAME: .*
+PARENT COMMAND LINE: .*
+IMAGE FILENAME: .*
+COMMAND LINE: .*\/\.config\/Microsoft\/Microsoft\sTeams\/(Cookies|Local\s+Storage\/leveldb).*
+```
+
+## Query 6
+```cql
+#event_simpleName=ProcessRollup2
+| CommandLine=/(\/|\\)Microsoft(\/|\\)(Microsoft\s)?Teams(\/|\\)(Cookies|Local\s+Storage(\/|\\)leveldb)/i
+| CommandLine=/Teams(\\|\/)(local\sstorage(\\|\/))?(?<teamsFile>(leveldb|cookies))/i
+| groupBy([ParentBaseFileName, ImageFileName, teamsFile, CommandLine])
+```
+
+## Query 7
+```cql
+#event_simpleName=ProcessRollup2
+| CommandLine=/(\/|\\)Microsoft(\/|\\)(Microsoft\s)?Teams(\/|\\)(Cookies|Local\s+Storage(\/|\\)leveldb)/i
+| CommandLine=/Teams(\\|\/)(local\sstorage(\\|\/))?(?<teamsFile>(leveldb|cookies))/i
+| sankey(source="ImageFileName",target="teamsFile", weight=count(aid))
+```

--- a/Queries-Only/Cool-Query-Friday/2022-09-23 - Cool Query Friday - LogScale += Humio - Decoding PowerShell Base64 and Entropy.md
+++ b/Queries-Only/Cool-Query-Friday/2022-09-23 - Cool Query Friday - LogScale += Humio - Decoding PowerShell Base64 and Entropy.md
@@ -1,0 +1,129 @@
+---
+title: "LogScale += Humio - Decoding PowerShell Base64 and Entropy"
+date: 2022-09-23
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/xm7lsn/20220923_cool_query_friday_logscale_humio/"
+mitre: []
+series: Cool Query Friday
+---
+
+# LogScale += Humio - Decoding PowerShell Base64 and Entropy
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/xm7lsn/20220923_cool_query_friday_logscale_humio/](https://www.reddit.com/r/crowdstrike/comments/xm7lsn/20220923_cool_query_friday_logscale_humio/) — by Andrew-CS (CrowdStrike) — 2022-09-23
+
+Welcome to our fiftieth (50, baby!) installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk through of each step (3) application in the wild.
+
+## Query 1
+```cql
+//Look for command line flags that indicate an encoded command
+| CommandLine=/\s+\-(e\s|enc|encodedcommand|encode)\s+/i
+```
+
+## Query 2
+```cql
+//Group by command frequency
+| groupby([ParentBaseFileName, CommandLine], function=stats([count(aid, distinct=true, as="uniqueEndpointCount"), count(aid, as="executionCount")]), limit=max)
+```
+
+## Query 3
+```cql
+//Grab all PowerShell execution events
+#event_simpleName=ProcessRollup2 event_platform=Win ImageFileName=/\\powershell(_ise)?\.exe/i
+//Look for command line flags that indicate an encoded command
+| CommandLine=/\s+\-(e\s|enc|encodedcommand|encode)\s+/i
+//Group by command frequency
+| groupby([ParentBaseFileName, CommandLine], function=stats([count(aid, distinct=true, as="uniqueEndpointCount"), count(aid, as="executionCount")]), limit=max)
+//Organizing fields
+| table([uniqueEndpointCount, executionCount, ParentBaseFileName, CommandLine])
+//Sorting by unique endpoints
+| sort(field=uniqueEndpointCount, order=desc)
+```
+
+## Query 4
+```cql
+//Setting prevalence threshold
+| uniqueEndpointCount < 3
+```
+
+## Query 5
+```cql
+//Calculating the length of the encrypted command line
+| cmdLength := length("CommandLine")
+```
+
+## Query 6
+```cql
+//Isolate Base64 String
+| CommandLine=/\s+\-(e\s|enc|encodedcommand|encode)\s+(?<base64String>\S+)/i
+```
+
+## Query 7
+```cql
+//Get Entropy of Base64 String
+| b64Entroy := shannonEntropy("base64String")
+```
+
+## Query 8
+```cql
+//Setting entropy threshold
+| b64Entroy > 3.5
+```
+
+## Query 9
+```cql
+//Decode encoded command blob
+| decodedCommand := base64Decode(base64String, charset="UTF-16LE")
+```
+
+## Query 10
+```cql
+//Grab all PowerShell execution events
+#event_simpleName=ProcessRollup2 event_platform=Win ImageFileName=/\\powershell(_ise)?\.exe/i
+//Look for command line flags that indicate an encoded command
+| CommandLine=/\s+\-(e\s|enc|encodedcommand|encode)\s+/i
+//Group by command frequency
+| groupby([ParentBaseFileName, CommandLine], function=stats([count(aid, distinct=true, as="uniqueEndpointCount"), count(aid, as="executionCount")]), limit=max)
+//Setting prevalence threshold
+| uniqueEndpointCount < 3
+//Calculating the length of the encrypted command line
+| cmdLength := length("CommandLine")
+//Isolate Base64 String
+| CommandLine=/\s+\-(e\s|enc|encodedcommand|encode)\s+(?<base64String>\S+)/i
+//Get Entropy of Base64 String
+| b64Entroy := shannonEntropy("base64String")
+//Decode encoded command blob
+| decodedCommand := base64Decode(base64String, charset="UTF-16LE")
+| table([ParentBaseFileName, uniqueEndpointCount, executionCount, cmdLength,  b64Entroy, decodedCommand])
+```
+
+## Query 11
+```cql
+//Search for http or https in command line
+| decodedCommand=/https?/i
+```
+
+## Query 12
+```cql
+//Grab all PowerShell execution events
+#event_simpleName=ProcessRollup2 event_platform=Win ImageFileName=/\\powershell(_ise)?\.exe/i
+//Look for command line flags that indicate an encoded command
+| CommandLine=/\s+\-(e\s|enc|encodedcommand|encode)\s+/i
+//Group by command frequency
+| groupby([ParentBaseFileName, CommandLine], function=stats([count(aid, distinct=true, as="uniqueEndpointCount"), count(aid, as="executionCount")]), limit=max)
+//Setting prevalence threshold
+| uniqueEndpointCount < 3
+//Calculating the length of the encrypted command line
+| cmdLength := length("CommandLine")
+//Isolate Base64 String
+| CommandLine=/\s+\-(e\s|enc|encodedcommand|encode)\s+(?<base64String>\S+)/i
+//Get Entropy of Base64 String
+| b64Entroy := shannonEntropy("base64String")
+//Setting entropy threshold
+| b64Entroy > 3.5
+//Decode encoded command blob
+| decodedCommand := base64Decode(base64String, charset="UTF-16LE")
+//Outputting to table
+| table([ParentBaseFileName, uniqueEndpointCount, executionCount, cmdLength,  b64Entroy, decodedCommand])
+//Search for http or https in command line
+| decodedCommand=/https?/i
+```

--- a/Queries-Only/Cool-Query-Friday/2022-09-23 - Cool Query Friday - LogScale += Humio - Decoding PowerShell Base64 and Entropy.md
+++ b/Queries-Only/Cool-Query-Friday/2022-09-23 - Cool Query Friday - LogScale += Humio - Decoding PowerShell Base64 and Entropy.md
@@ -127,3 +127,11 @@ Welcome to our fiftieth (50, baby!) installment of [Cool Query Friday](https://w
 //Search for http or https in command line
 | decodedCommand=/https?/i
 ```
+
+## Community & Staff Additions
+*Harvested from this post's [r/CrowdStrike](https://www.reddit.com/r/crowdstrike/) comment thread — not part of the original CQF post. **[CS]** = CrowdStrike staff · **[Community]** = other r/CrowdStrike users. Upvote scores shown for context.*
+
+### Operational caveats
+
+> Splunk was never “the back end”, that’s Threat, Intel or Asset Graph depending on module. What you’re seeing in the GUI is a highly customized version of the Splunk UI that can access this data and facilitates capabilities for raw searching. I’m not going to spoil our future but we have big things planned, be sure to attend the quarterly roadmap calls for more information!
+— [CS] BradW-CS · score 3

--- a/Queries-Only/Cool-Query-Friday/2022-10-14 - Cool Query Friday - Dealing with Security Articles.md
+++ b/Queries-Only/Cool-Query-Friday/2022-10-14 - Cool Query Friday - Dealing with Security Articles.md
@@ -46,3 +46,16 @@ FILE PATH: .*\\ManageEngine\\ADSelfService\s+Plus\\webapps\\adssp\\help\\admin\-
 
 FILE TYPE: ZIP, SCRIPT, OTHER
 ```
+
+## Community & Staff Additions
+*Harvested from this post's [r/CrowdStrike](https://www.reddit.com/r/crowdstrike/) comment thread — not part of the original CQF post. **[CS]** = CrowdStrike staff · **[Community]** = other r/CrowdStrike users. Upvote scores shown for context.*
+
+### Q&A
+
+**Q — [Community] jashley92:** How do you get crowdscrape to work with us-2? That's been an issue for me.
+
+**A — [CS] Andrew-CS:** Sorry, u/jashley92! I missed your initial question. Working with the developer to make sure cloud is included. I thought it was, but not sure if it was published to the Chrome store.
+
+**Q — [Community] jashley92:** any thoughts here? Is us-2 support perhaps a miss in crowdscrape?
+
+**A — [CS] Andrew-CS:** Sorry, u/jashley92! I missed your initial question. Working with the developer to make sure cloud is included. I thought it was, but not sure if it was published to the Chrome store.

--- a/Queries-Only/Cool-Query-Friday/2022-10-14 - Cool Query Friday - Dealing with Security Articles.md
+++ b/Queries-Only/Cool-Query-Friday/2022-10-14 - Cool Query Friday - Dealing with Security Articles.md
@@ -1,0 +1,48 @@
+---
+title: "Dealing with Security Articles"
+date: 2022-10-14
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/y3w8bt/20221014_cool_query_friday_dealing_with_security/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Dealing with Security Articles
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/y3w8bt/20221014_cool_query_friday_dealing_with_security/](https://www.reddit.com/r/crowdstrike/comments/y3w8bt/20221014_cool_query_friday_dealing_with_security/) — by Andrew-CS (CrowdStrike) — 2022-10-14
+
+Welcome to our fifty-first installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk through of each step (3) application in the wild.
+
+## Query 1
+```cql
+event_platform=win event_simpleName=ProcessRollup2 "ADSelfService" "ManageEngine"
+| stats values(aid) as aids, values(FileName) as fileNames, values(FilePath) as filePaths by cid
+```
+
+## Query 2
+```cql
+event_platform=win event_simpleName IN (NewScriptWritten, ZipFileWritten) "ADSelfService" "ManageEngine"
+| stats dc(aid) as endpointCount, count(aid) as writeCount by TargetFileName
+```
+
+## Query 3
+```cql
+event_platform=win event_simpleName IN (NewScriptWritten, ZipFileWritten) "ADSelfService" "ManageEngine"
+| regex TargetFileName=".*\\\\webapps\\\\adssp\\\\help\\\\admin-guide\\\\reports\\\\.*"
+| stats dc(aid) as endpointCount, count(aid) as writeCount by TargetFileName
+```
+
+## Query 4
+```cql
+RULE TYPE: File Creation
+
+ACTION TO TAKE: Detect
+
+SEVERITY: <choose>
+
+RULE NAME: <choose>
+
+FILE PATH: .*\\ManageEngine\\ADSelfService\s+Plus\\webapps\\adssp\\help\\admin\-guide\\reports\\.+\.(jsp|zip)
+
+FILE TYPE: ZIP, SCRIPT, OTHER
+```

--- a/Queries-Only/Cool-Query-Friday/2022-11-03 - Cool Query Friday - PSFalcon, Bulk RTR Queuing, and STDOUT Redirection to LogScale.md
+++ b/Queries-Only/Cool-Query-Friday/2022-11-03 - Cool Query Friday - PSFalcon, Bulk RTR Queuing, and STDOUT Redirection to LogScale.md
@@ -1,0 +1,30 @@
+---
+title: "PSFalcon, Bulk RTR Queuing, and STDOUT Redirection to LogScale"
+date: 2022-11-03
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/yl8hv8/20221103_cool_query_friday_psfalcon_bulk_rtr/"
+mitre: []
+series: Cool Query Friday
+---
+
+# PSFalcon, Bulk RTR Queuing, and STDOUT Redirection to LogScale
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/yl8hv8/20221103_cool_query_friday_psfalcon_bulk_rtr/](https://www.reddit.com/r/crowdstrike/comments/yl8hv8/20221103_cool_query_friday_psfalcon_bulk_rtr/) — by Andrew-CS (CrowdStrike) — 2022-11-03
+
+Welcome to our fifty-second installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk through of each step (3) application in the wild.
+
+## Query 1
+```cql
+Get-FalconHost -Filter "platform_name:'Windows'" -All | Invoke-FalconRtr -Command runscript -Argument "-CloudFile='list-browser-extensions'" -QueueOffline $true
+```
+
+## Query 2
+```cql
+| format(format="%s | %s | %s", field=[Name,  Version, Id], as="pluginDetails")
+| groupBy([aid, host, Browser], function=stats(collect([pluginDetails])))
+```
+
+## Query 3
+```cql
+Get-FalconHost -Limit 100 -Detailed | Send-FalconEvent
+```

--- a/Queries-Only/Cool-Query-Friday/2022-11-03 - Cool Query Friday - PSFalcon, Bulk RTR Queuing, and STDOUT Redirection to LogScale.md
+++ b/Queries-Only/Cool-Query-Friday/2022-11-03 - Cool Query Friday - PSFalcon, Bulk RTR Queuing, and STDOUT Redirection to LogScale.md
@@ -28,3 +28,16 @@ Get-FalconHost -Filter "platform_name:'Windows'" -All | Invoke-FalconRtr -Comman
 ```cql
 Get-FalconHost -Limit 100 -Detailed | Send-FalconEvent
 ```
+
+## Community & Staff Additions
+*Harvested from this post's [r/CrowdStrike](https://www.reddit.com/r/crowdstrike/) comment thread — not part of the original CQF post. **[CS]** = CrowdStrike staff · **[Community]** = other r/CrowdStrike users. Upvote scores shown for context.*
+
+### Q&A
+
+**Q — [Community] netsec_:** How do you get the results from this if you don't?
+
+**A — [CS] Andrew-CS:** You can always issue bulk RTR commands using PSFalcon and then invoke `Get-FalconQueue` to view the results.
+
+**Q — [Community] big_mic_energy:** How does this setup differ if Falcon and LogScale are products we already own? Keeping in mind I am an admin for both products and Falcon has been collecting data for years now.
+
+**A — [CS] Andrew-CS:** You can just have Falcon redirect the RTR output to the LogScale instance you have running. You just have to make sure your URL is correct as is outlined in this section: >Copy the URL under “Ingest host name” as well. You can just follow my lead if you’re using Community Edition, however, if you’re a full LogScale customer this URL will be different so please make note of it.

--- a/Queries-Only/Cool-Query-Friday/2022-12-09 - Cool Query Friday - Custom Weighting and Time-Bounding Events.md
+++ b/Queries-Only/Cool-Query-Friday/2022-12-09 - Cool Query Friday - Custom Weighting and Time-Bounding Events.md
@@ -1,0 +1,171 @@
+---
+title: "Custom Weighting and Time-Bounding Events"
+date: 2022-12-09
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/zh7k5a/20221209_cool_query_friday_custom_weighting_and/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Custom Weighting and Time-Bounding Events
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/zh7k5a/20221209_cool_query_friday_custom_weighting_and/](https://www.reddit.com/r/crowdstrike/comments/zh7k5a/20221209_cool_query_friday_custom_weighting_and/) — by Andrew-CS (CrowdStrike) — 2022-12-09
+
+Welcome to our fifty-third installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk through of each step (3) application in the wild.
+
+## Query 1
+```cql
+// Get all Windows ProcessRollup2 Events
+#event_simpleName=ProcessRollup2 event_platform=Win
+// Narrow to processes of interest and create FileName variable
+| ImageFileName=/\\(?<FileName>(whoami|net1?|systeminfo|ping|nltest|sc|hostname|ipconfig)\.exe)/i
+```
+
+## Query 2
+```cql
+// Get timestamp value with date and hour value
+| ProcessStartTime := ProcessStartTime*1000
+| dayBucket := formatTime("%Y-%m-%d %H", field=ProcessStartTime, locale=en_US, timezone=Z)
+// Force CommandLine and FileName into lower case
+| CommandLine := lower(CommandLine)
+| FileName := lower(FileName)
+```
+
+## Query 3
+```cql
+// Parse flag used in "net" and "sc" command
+| regex("(sc|net1?)\s+(?<netFlag>\S+)\s+", field=CommandLine, strict=false)
+// Force netFlag to lower case
+| netFlag := lower(netFlag)
+```
+
+## Query 4
+```cql
+/ Create evaluation criteria and weighting for process usage; modified behaviorWeight integer as desired
+| case {
+        FileName=/net1?\.exe/ AND netFlag="start" | behaviorWeight := "4" ;
+        FileName=/net1?\.exe/ AND netFlag="stop" | behaviorWeight := "4" ;
+        FileName=/net1?\.exe/ AND netFlag="stop" AND CommandLine=/falcon/i | behaviorWeight := "25" ;
+        FileName=/sc\.exe/ AND netFlag="start" | behaviorWeight := "4" ;
+        FileName=/sc\.exe/ AND netFlag="stop" | behaviorWeight := "4" ;
+        FileName=/sc\.exe/ AND netFlag=/(query|stop)/i AND CommandLine=/csagent/i | behaviorWeight := "25" ;
+        FileName=/net1?\.exe/ AND netFlag="share" | behaviorWeight := "2" ;
+        FileName=/net1?\.exe/ AND netFlag="user" AND CommandLine=/\/delete/i | behaviorWeight := "10" ;
+        FileName=/net1?\.exe/ AND netFlag="user" AND CommandLine=/\/add/i | behaviorWeight := "10" ;
+        FileName=/net1?\.exe/ AND netFlag="group" AND CommandLine=/\/domain\s+/i | behaviorWeight := "5" ;
+        FileName=/net1?\.exe/ AND netFlag="group" AND CommandLine=/admin/i | behaviorWeight := "5" ;
+        FileName=/net1?\.exe/ AND netFlag="localgroup" AND CommandLine=/\/add/i | behaviorWeight := "10" ;
+        FileName=/net1?\.exe/ AND netFlag="localgroup" AND CommandLine=/\/delete/i | behaviorWeight := "10" ;
+        FileName=/nltest\.exe/ | behaviorWeight := "3" ;
+        FileName=/systeminfo\.exe/ | behaviorWeight := "3" ;
+        FileName=/whoami\.exe/ | behaviorWeight := "3" ;
+        FileName=/ping\.exe/ | behaviorWeight := "3" ;
+        FileName=/ipconfig\.exe/ | behaviorWeight := "3" ;
+        FileName=/hostname\.exe/ | behaviorWeight := "3" ;
+  * }
+| default(field=behaviorWeight, value=0)
+```
+
+## Query 5
+```cql
+// Create FileName and CommandLine one-liner
+| format(format="(Score: %s) %s • %s", field=[behaviorWeight, FileName, CommandLine], as="executionDetails")
+// Group and organize output
+| groupby([cid,aid, dayBucket], function=[count(FileName, distinct=true, as="fileCount"), sum(behaviorWeight, as="behaviorWeight"), collect(executionDetails)], limit=max)
+```
+
+## Query 6
+```cql
+| dayBucket := formatTime("%Y-%m-%d, field=ProcessStartTime, locale=en_US, timezone=Z)
+```
+
+## Query 7
+```cql
+// Set thresholds 
+| fileCount >= 5 OR behaviorWeight > 30
+// Add Host Search link
+| format("[Host Search](https://falcon.crowdstrike.com/investigate/events/en-us/app/eam2/investigate__computer?earliest=-24h&latest=now&computer=*&aid_tok=%s&customer_tok=*)", field=["aid"], as="Host Search")
+// Sort descending by behavior weighting 
+| sort(behaviorWeight)
+```
+
+## Query 8
+```cql
+// Get all Windows ProcessRollup2 Events
+#event_simpleName=ProcessRollup2 event_platform=Win
+// Narrow to processes of interest and create FileName variable
+| ImageFileName=/\\(?<FileName>(whoami|net1?|systeminfo|ping|nltest|sc|hostname|ipconfig)\.exe)/i
+// Get timestamp value with date and hour value
+| ProcessStartTime := ProcessStartTime*1000
+| dayBucket := formatTime("%Y-%m-%d %H", field=ProcessStartTime, locale=en_US, timezone=Z)
+// Force CommandLine and FileName into lower case
+| CommandLine := lower(CommandLine)
+| FileName := lower(FileName)
+// Parse flag used in "net" command
+| regex("(sc|net1?)\s+(?<netFlag>\S+)\s+", field=CommandLine, strict=false)
+// Force netFlag to lower case
+| netFlag := lower(netFlag)
+// Create evaulation criteria and weighting for process usage; modified behaviorWeight integer as desired
+| case {
+       FileName=/net1?\.exe/ AND netFlag="start" | behaviorWeight := "4" ;
+       FileName=/net1?\.exe/ AND netFlag="stop" | behaviorWeight := "4" ;
+       FileName=/net1?\.exe/ AND netFlag="stop" AND CommandLine=/falcon/i | behaviorWeight := "25" ;
+       FileName=/sc\.exe/ AND netFlag="start" | behaviorWeight := "4" ;
+       FileName=/sc\.exe/ AND netFlag="stop" | behaviorWeight := "4" ;
+       FileName=/sc\.exe/ AND netFlag=/(query|stop)/i AND CommandLine=/csagent/i | behaviorWeight := "25" ;
+       FileName=/net1?\.exe/ AND netFlag="share" | behaviorWeight := "2" ;
+       FileName=/net1?\.exe/ AND netFlag="user" AND CommandLine=/\/delete/i | behaviorWeight := "10" ;
+       FileName=/net1?\.exe/ AND netFlag="user" AND CommandLine=/\/add/i | behaviorWeight := "10" ;
+       FileName=/net1?\.exe/ AND netFlag="group" AND CommandLine=/\/domain\s+/i | behaviorWeight := "5" ;
+       FileName=/net1?\.exe/ AND netFlag="group" AND CommandLine=/admin/i | behaviorWeight := "5" ;
+       FileName=/net1?\.exe/ AND netFlag="localgroup" AND CommandLine=/\/add/i | behaviorWeight := "10" ;
+       FileName=/net1?\.exe/ AND netFlag="localgroup" AND CommandLine=/\/delete/i | behaviorWeight := "10" ;
+       FileName=/nltest\.exe/ | behaviorWeight := "3" ;
+       FileName=/systeminfo\.exe/ | behaviorWeight := "3" ;
+       FileName=/whoami\.exe/ | behaviorWeight := "3" ;
+       FileName=/ping\.exe/ | behaviorWeight := "3" ;
+       FileName=/hostname\.exe/ | behaviorWeight := "3" ;
+       FileName=/ipconfig\.exe/ | behaviorWeight := "3" ;
+ * }
+| default(field=behaviorWeight, value=0)
+// Create FileName and CommandLine one-liner
+| format(format="(Score: %s) %s • %s", field=[behaviorWeight, FileName, CommandLine], as="executionDetails")
+// Group and organize output
+| groupby([cid,aid, dayBucket], function=[count(FileName, distinct=true, as="fileCount"), sum(behaviorWeight, as="behaviorWeight"), collect(executionDetails)], limit=max)
+// Set thresholds
+| fileCount >= 5 OR behaviorWeight > 30
+// Add Host Search link
+| format("[Host Search](https://falcon.crowdstrike.com/investigate/events/en-us/app/eam2/investigate__computer?earliest=-24h&latest=now&computer=*&aid_tok=%s&customer_tok=*)", field=["aid"], as="Host Search")
+// Sort descending by behavior weighting
+| sort(behaviorWeight)
+```
+
+## Query 9
+```cql
+event_platform=win event_simpleName=ProcessRollup2 FileName IN (net.exe, net1.exe, whoami.exe, ping.exe, nltest.exe,sc.exe, hostname.exe)
+| rex field=CommandLine "(sc|net)\s+(?<netFlag>\S+)\s+.*"
+| eval netFlag=lower(netFlag), CommandLine=lower(CommandLine), FileName=lower(FileName)
+| eval behaviorWeight=case(
+  (FileName == "net.exe" OR FileName == "net1.exe") AND netFlag=="start",  "2",
+  (FileName == "net.exe" OR FileName == "net1.exe") AND netFlag=="stop",  "4",
+  (FileName == "net.exe" OR FileName == "net1.exe") AND netFlag=="share",  "4",
+  (FileName == "net.exe" OR FileName == "net1.exe") AND (netFlag=="user"  AND CommandLine LIKE "%delete%"),  "10",
+  (FileName == "net.exe" OR FileName == "net1.exe") AND (netFlag=="user"  AND CommandLine LIKE "%add%"),  "10",
+  (FileName == "net.exe" OR FileName == "net1.exe") AND (netFlag=="group" AND CommandLine LIKE "%domain%"),  "5",
+  (FileName == "net.exe" OR FileName == "net1.exe") AND (netFlag=="group" AND CommandLine LIKE "%admin%"),  "5",
+  (FileName == "net.exe" OR FileName == "net1.exe") AND (netFlag=="localgroup" AND CommandLine LIKE "%add%"),  "10",
+  (FileName == "net.exe" OR FileName == "net1.exe") AND (netFlag=="localgroup" AND CommandLine LIKE "%delete%"),  "10",
+  (FileName == "sc.exe") AND (netFlag=="stop" AND CommandLine LIKE "%csagent%"),  "4",
+  FileName == "whoami.exe",  "3",
+  FileName == "ping.exe",  "3",
+  FileName == "nltest.exe",  "3",
+  FileName == "systeminfo.exe",  "3",
+  FileName == "hostname.exe",  "3",
+  true(),null()) 
+  | bucket ProcessStartTime_decimal as timeBucket span=1h
+  | stats dc(FileName) as fileCount, sum(behaviorWeight) as behaviorWeight, values(FileName) as filesSeen, values(CommandLine) as commandLines by timeBucket, aid, ComputerName
+  | where fileCount >= 5 
+  | eval hostSearch=case(aid!="","https://falcon.crowdstrike.com/investigate/events/en-us/app/eam2/investigate__computer?earliest=".timeBucket."&latest=now&computer=*&aid_tok=".aid)
+  | sort -behaviorWeight, -fileCount
+  | convert ctime(timeBucket)
+```

--- a/Queries-Only/Cool-Query-Friday/2022-12-09 - Cool Query Friday - Custom Weighting and Time-Bounding Events.md
+++ b/Queries-Only/Cool-Query-Friday/2022-12-09 - Cool Query Friday - Custom Weighting and Time-Bounding Events.md
@@ -169,3 +169,17 @@ event_platform=win event_simpleName=ProcessRollup2 FileName IN (net.exe, net1.ex
   | sort -behaviorWeight, -fileCount
   | convert ctime(timeBucket)
 ```
+
+## Community & Staff Additions
+*Harvested from this post's [r/CrowdStrike](https://www.reddit.com/r/crowdstrike/) comment thread — not part of the original CQF post. **[CS]** = CrowdStrike staff · **[Community]** = other r/CrowdStrike users. Upvote scores shown for context.*
+
+### Operational caveats
+
+> >What is the purpose of true(),null() in the case statement? This basically says, "if you do not match any of the case statements, set that value of the field `behaviorWeight` to null" (so it will be blank). >In the Event Search version, should 'OR behaviorWeight > 30' be added to the fourth line from the end '| where fileCount > 5'? Yup! You can add conditions for matching if you'd like!
+— [CS] Andrew-CS · score 2
+
+### Q&A
+
+**Q — [Community] Qbert513:** Two questions: 1. What is the purpose of true(),null() in the case statement? 2. In the Event Search version, should 'OR behaviorWeight > 30' be added to the fourth line from the end '| where fileCount > 5'?
+
+**A — [CS] Andrew-CS:** >What is the purpose of true(),null() in the case statement? This basically says, "if you do not match any of the case statements, set that value of the field `behaviorWeight` to null" (so it will be blank). >In the Event Search version, should 'OR behaviorWeight > 30' be added to the fourth line from the end '| where fileCount > 5'? Yup! You can add conditions for matching if you'd like!

--- a/Queries-Only/Cool-Query-Friday/2023-01-06 - Cool Query Friday - Hunting PE Language ID Prevalence in PeVersionInfo.md
+++ b/Queries-Only/Cool-Query-Friday/2023-01-06 - Cool Query Friday - Hunting PE Language ID Prevalence in PeVersionInfo.md
@@ -1,0 +1,119 @@
+---
+title: "Hunting PE Language ID Prevalence in PeVersionInfo"
+date: 2023-01-06
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/104y1wr/20230106_cool_query_friday_hunting_pe_language_id/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Hunting PE Language ID Prevalence in PeVersionInfo
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/104y1wr/20230106_cool_query_friday_hunting_pe_language_id/](https://www.reddit.com/r/crowdstrike/comments/104y1wr/20230106_cool_query_friday_hunting_pe_language_id/) — by Andrew-CS (CrowdStrike) — 2023-01-06
+
+Happy New Year and welcome to our fifty-fourth installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk through of each step (3) application in the wild.
+
+## Query 1
+```cql
+event_simpleName=PeVersionInfo event_platform=win
+| stats dc(aid) as uniqueEndpoints by LanguageId_decimal
+| sort 0 -uniqueEndpoints
+```
+
+## Query 2
+```cql
+#event_simpleName=PeVersionInfo event_platform=Win
+| groupBy("LanguageId")
+| sort(_count, order=desc, limit=100)
+```
+
+## Query 3
+```cql
+#event_simpleName=PeVersionInfo event_platform=Win 
+| !in(LanguageId, values=[0, 1033])
+```
+
+## Query 4
+```cql
+event_simpleName=PeVersionInfo event_platform=win NOT LanguageId_decimal IN (1033, 0)
+| rex field=FilePath "(\\\\Device\\\\HarddiskVolume\d+)?(?<trimmedFilePath>.*)"
+| stats count(aid) as uniqueEndpoints, values(FileName) as fileNames, values(trimmedFilePath) as filePaths by SHA256HashData, LanguageId_decimal
+| sort 0 -occurrences
+```
+
+## Query 5
+```cql
+#event_simpleName=PeVersionInfo event_platform=Win 
+| !in(LanguageId, values=[0, 1033])
+| ImageFileName=/(\\Device\\HarddiskVolume\d+)?(?<filePath>\\.*)\\(?<fileName>.+\.\w+)$/i
+| groupBy([SHA256HashData, LanguageId], function=([count(aid, distinct=true, as=uniqueEndpoints), collect([fileName, filePath])]))
+| sort(uniqueEndpoints, order=desc, limit=500)
+```
+
+## Query 6
+```cql
+event_simpleName=PeVersionInfo event_platform=win NOT LanguageId_decimal IN (1033, 0)
+| rex field=FilePath "(\\\\Device\\\\HarddiskVolume\d+)?(?<trimmedFilePath>.*)"
+| search "Users"
+| regex trimmedFilePath!=".*\\\(Google|boot\\efi)\\\.*"
+| regex FileName!=".*\.LocalizedResources\..*"
+| stats count(aid) as uniqueEndpoints, values(FileName) as fileNames, values(trimmedFilePath) as filePaths by SHA256HashData, LanguageId_decimal
+| sort -occurrences
+```
+
+## Query 7
+```cql
+#event_simpleName=PeVersionInfo event_platform=Win 
+| !in(LanguageId, values=[0, 1033])
+| ImageFileName=/(\\Device\\HarddiskVolume\d+)?(?<filePath>\\.*)\\(?<fileName>.+\.\w+)$/i
+| filePath=/\\Users\\/i
+| filePath!=/\\(Google|\\boot\\efi|OneDrive)\\/i
+| groupBy([SHA256HashData, LanguageId], function=([count(aid, distinct=true, as=uniqueEndpoints), collect([fileName, filePath])]))
+| sort(uniqueEndpoints, order=desc, limit=500)
+```
+
+## Query 8
+```cql
+[...]
+| where uniqueEndpoints < 10
+```
+
+## Query 9
+```cql
+[...]
+| test(uniqueEndpoints < 10)
+```
+
+## Query 10
+```cql
+event_simpleName=PeVersionInfo event_platform=win NOT LanguageId_decimal IN (1033, 0)
+| rex field=FilePath "(\\\\Device\\\\HarddiskVolume\d+)?(?<trimmedFilePath>.*)"
+| search "Users"
+| regex trimmedFilePath!=".*\\\(Google|boot\\efi)\\\.*"
+| regex FileName!=".*\.LocalizedResources\..*"
+| stats count(aid) as uniqueEndpoints, values(FileName) as fileNames, values(OriginalFilename) as originalFileNames, values(trimmedFilePath) as filePaths by SHA256HashData, LanguageId_decimal
+| sort -occurrences 
+| lookup local=true LanguageId.csv LanguageId_decimal OUTPUT lcid_lang, lcid_string
+| table SHA256HashData, fileNames, originalFileNames, filePaths, uniqueEndpoints, LanguageId_decimal, lcid_lang, lcid_string
+| rename SHA256HashData as SHA256, fileNames as "File Names", originalFileNames as "Original FileNames", filePaths as "File Paths", uniqueEndpoints as "Endpoints", LanguageId_decimal as "Language ID", lcid_lang as "LCID Code", lcid_string as "LCID String"
+```
+
+## Query 11
+```cql
+#event_simpleName=PeVersionInfo event_platform=Win 
+| !in(LanguageId, values=[0, 1033])
+| ImageFileName=/(\\Device\\HarddiskVolume\d+)?(?<filePath>\\.*)\\(?<fileName>.+\.\w+)$/i
+| filePath=/\\Users\\/i
+| filePath!=/\\(Google|\\boot\\efi|OneDrive)\\/i
+| groupBy([SHA256HashData, LanguageId], function=([count(aid, distinct=true, as=uniqueEndpoints), collect([fileName, OriginalFilename, filePath])]))
+| sort(uniqueEndpoints, order=desc, limit=500)
+| match(file="LanguageId.csv", field=LanguageId, ignoreCase=true, strict=false)
+| select([SHA256HashData, fileName, OriginalFilename, filePath, uniqueEndpoints, LanguageId, lcid_lang, lcid_string])
+| rename("SHA256HashData",as="SHA256")
+| rename("fileName",as="File Names")
+| rename("OriginalFilename",as="Original File Names")
+| rename("filePath",as="Paths")
+| rename("LanguageId",as="Language ID")
+| rename("lcid_lang",as="LCID Code")
+| rename("lcid_string",as="LCID String")
+```

--- a/Queries-Only/Cool-Query-Friday/2023-03-23 - Cool Query Friday - LogScale The Basics Part I.md
+++ b/Queries-Only/Cool-Query-Friday/2023-03-23 - Cool Query Friday - LogScale The Basics Part I.md
@@ -244,3 +244,27 @@ EventType="Event_ExternalApiEvent" ExternalApiType="Event_DetectionSummaryEvent"
 ```cql
 | format("%,.100s", field=CommandLine, as=CommandLine)
 ```
+
+## Community & Staff Additions
+*Harvested from this post's [r/CrowdStrike](https://www.reddit.com/r/crowdstrike/) comment thread — not part of the original CQF post. **[CS]** = CrowdStrike staff · **[Community]** = other r/CrowdStrike users. Upvote scores shown for context.*
+
+### Query variants
+
+```cql
+| match(file="lookup-file.csv", column=aid, field=aid, include=[Version, AgentVersion])
+```
+— [CS] Andrew-CS · comment score 2
+
+### Q&A
+
+**Q — [Community] mattdufrene:** in LogScale, is it possible to reference multiple fields/columns in a lookup table?
+
+**A — [CS] Andrew-CS:** Like all languages, you need a single key field to specify a "row" but you can output multiple "columns" related to that key field. Example: | match(file="lookup-file.csv", column=aid, field=aid, include=[Version, AgentVersion]) Documentation is [here](https://library.humio.com/falcon-logscale/functions-match.html#functions-match-examples).
+
+**Q — [Community] mattdufrene:** We're currently a Splunk shop, but recently pulled the trigger to migrate to LogScale. We are in the process of migrating searches and are working out the best way to leverage our lookup tables. In Splunk, you could match against values from multiple columns. For example: `| search [ inputlookup loo …
+
+**A — [CS] Andrew-CS:** Hey! Thanks for choosing LogScale! I don't know the exact answer to this question, so I'm going to tag in u/AHogan-CS to see if he knows.
+
+**Q — [Community] BigOwlCriesForLogs:** LogScale looks like an amazing product. Is there a way to try it out and play with it on my own?
+
+**A — [CS] Andrew-CS:** >If you want to mess around with LogScale on your own, there is a free Community Edition available. If you want to mess around with LogScale on your own, there is a [free Community Edition available](http://cloud.community.humio.com/).

--- a/Queries-Only/Cool-Query-Friday/2023-03-23 - Cool Query Friday - LogScale The Basics Part I.md
+++ b/Queries-Only/Cool-Query-Friday/2023-03-23 - Cool Query Friday - LogScale The Basics Part I.md
@@ -1,0 +1,246 @@
+---
+title: "LogScale: The Basics Part I"
+date: 2023-03-23
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/11zojds/20230323_cool_query_friday_logscale_the_basics/"
+mitre: []
+series: Cool Query Friday
+---
+
+# LogScale: The Basics Part I
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/11zojds/20230323_cool_query_friday_logscale_the_basics/](https://www.reddit.com/r/crowdstrike/comments/11zojds/20230323_cool_query_friday_logscale_the_basics/) — by Andrew-CS (CrowdStrike) — 2023-03-23
+
+Welcome to our fifty-sixth installment of Cool Query Friday. The format will be: (1) description of what we're doing (2) walk through of each step (3) application in the wild.
+
+## Query 1
+```cql
+// Get all ProcessRollup2 events
+#event_simpleName=ProcessRollup2
+// Search for system User SID
+| UserSid="S-1-5-18"
+// Count total executions
+| count(aid, as=totalExecutions)
+```
+
+## Query 2
+```cql
+// Account for microseconds or remove decimal point in timestamp
+| myTimeStamp := myTimeStamp * 1000
+```
+
+## Query 3
+```cql
+#event_simpleName=ProcessRollup2
+// Convert ProcessStartTime to proper epoch format
+| ProcessStartTime := ProcessStartTime * 1000
+// Convert epoch Time to Human Time
+| HumanTime := formatTime("%Y-%m-%d %H:%M:%S.%L", field=ProcessStartTime, locale=en_US, timezone=Z)
+| select([ProcessStartTime, HumanTime, aid, ImageFileName])
+```
+
+## Query 4
+```cql
+| timeDelta := now() - (ProcessStartTime*1000)
+```
+
+## Query 5
+```cql
+#event_simpleName=ProcessRollup2 event_platform=Win ImageFileName=/\\(System32|SysWow64)\\/i
+```
+
+## Query 6
+```cql
+#event_simpleName=ProcessRollup2 event_platform=Win ImageFileName=/\\(?<systemFolder>(System32|SysWow64))\\/i
+| groupBy([systemFolder, ImageFileName])
+```
+
+## Query 7
+```cql
+| case {
+UserIsAdmin=1 | UserIsAdmin := "True" ;
+UserIsAdmin=0 | UserIsAdmin := "False" ;
+* }
+```
+
+## Query 8
+```cql
+| case {
+UserIsAdmin=1 | UserIsAdmin_Readable := "True" ;
+UserIsAdmin=0 | UserIsAdmin_Readable := "False" ;
+* }
+```
+
+## Query 9
+```cql
+#event_simpleName=UserLogon
+| $UserIsAdmin()
+| select([aid, UserName, UserSid, UserIsAdmin, UserIsAdmin_Readable])
+```
+
+## Query 10
+```cql
+// Get all user logon events for User SID S-1-5-21-*
+#event_simpleName=UserLogon event_platform=Win UserSid="S-1-5-21-*"
+// Invoke saved query to enrich UserIsAdmin field
+| $ConvertUserIsAdmin()
+// Use select to output in tabular format
+| select([@timestamp, aid, ClientComputerName, UserName, LogonType, UserIsAdmin_Readable])
+```
+
+## Query 11
+```cql
+#event_simpleName=ProcessRollup2 event_platform=Win ImageFileName=/\\powershell\.exe/i
+| groupBy(SHA256HashData, function=([count(aid, distinct=true, as=uniqueEndpoints), count(aid, as=totalExecutions), collect(CommandLine)]))
+```
+
+## Query 12
+```cql
+| groupBy(SHA256HashData, function=([count(aid, distinct=true, as=uniqueEndpoints), count(aid, as=totalExecutions), collect(CommandLine)]))
+```
+
+## Query 13
+```cql
+| groupBy([SHA256HashData, FileName], function=([count(aid, distinct=true, as=uniqueEndpoints), count(aid, as=totalExecutions), collect(CommandLine)]))
+```
+
+## Query 14
+```cql
+| groupBy([SHA256HashData, FileName], function=([count(aid, distinct=true, as=uniqueEndpoints), count(aid, as=totalExecutions), collect([CommandLine, UserSid])]))
+```
+
+## Query 15
+```cql
+// Get all DNS Request events
+#event_simpleName=DnsRequest
+// Use regex to determine top level domain
+| DomainName=/\.?(?<topLevelDomain>\w+\.\w+$)/i
+// Create search box for top level domain
+| topLevelDomain=?topLevelDomain
+// Count number of domain variations by top level domain
+| groupBy(topLevelDomain, function=(count(DomainName, distinct=true, as=domainVariations)))
+```
+
+## Query 16
+```cql
+#event_simpleName=OsVersionInfo
+| groupBy("ProductName")
+```
+
+## Query 17
+```cql
+EventType = "Event_ExternalApiEvent" ExternalApiType = "Event_DetectionSummaryEvent"
+| sankey(source="Tactic",target="Technique", weight=count(AgentIdString))
+```
+
+## Query 18
+```cql
+EventType="Event_ExternalApiEvent" ExternalApiType="Event_DetectionSummaryEvent"
+| groupBy(Severity)
+```
+
+## Query 19
+```cql
+#event_simpleName=UserLogon event_platform=Lin
+| UserIsAdmin match {
+    1 => UserIsAdmin := "True" ;
+    0 => UserIsAdmin := "False" ;
+}
+| select([@timestamp, UserName, UID, LogonType, UserIsAdmin])
+```
+
+## Query 20
+```cql
+| targetField match {
+    value1 => targetField := "substitution1" ;
+    value2 => targetField := "substitution2" ;
+}
+```
+
+## Query 21
+```cql
+// Get InstalledApplication events for Google Chrome
+#event_simpleName=InstalledApplication AppName="Google Chrome"
+// Get latest AppVersion for each system
+| groupBy(aid, function=([selectLast([AppVendor, AppName, AppVersion, InstallDate])]))
+// Use regex to break AppVersion field into components
+| AppVersion = /(?<majorVersion>\d+)\.(?<minorVersion>\d+)\.(?<buildNumber>\d+)\.(?<subBuildNumber>\d+)$/i
+// Evaluate builds that need to be patched
+| case {
+    majorVersion>=110 | needsPatch := "No" ;
+    majorVersion>=109 AND buildNumber >= 5414 | needsPatch := "No" ;
+    majorVersion<=109 AND buildNumber < 5414 | needsPatch := "Yes" ;
+    majorVersion<=108 | needsPatch := "Yes" ;
+* }
+// Check for needed update  and Organize Output
+| needsPatch = "Yes"
+| select([aid, InstallDate, needsPatch, AppVendor, AppName, AppVersion, InstallDate])
+// Convert timestamp
+| InstallDate := InstallDate *1000
+| InstallDate := formatTime("%Y-%m-%d", field=InstallDate, locale=en_US, timezone=Z)
+```
+
+## Query 22
+```cql
+#event_simpleName=ProcessRollup2 ImageFileName=/\\(?<fileName>\w+\.\w+$)/i
+| regex("(?<fourLetterFileName>^\w{4})\.exe", field=fileName, strict=false)
+| groupBy([fileName, fourLetterFileName])
+```
+
+## Query 23
+```cql
+#event_simpleName=ProcessRollup2 event_platform=Win
+| ImageFileName=/\\powershell(_ise)?\.exe/i
+| CommandLine=/\-e(nc|ncodedcommand|ncoded)?\s+/i
+```
+
+## Query 24
+```cql
+#event_simpleName=ProcessRollup2 event_platform=Win
+| ImageFileName=/\\powershell(_ise)?\.exe/i
+| CommandLine=/\-(?<encodedFlagUsed>e(nc|ncodedcommand|ncoded)?)\s+/i
+```
+
+## Query 25
+```cql
+#event_simpleName=ProcessRollup2 event_platform=Win
+| ImageFileName=/\\powershell(_ise)?\.exe/i
+| CommandLine=/\-(?<encodedFlagUsed>e(nc|ncodedcommand|ncoded)?)\s+/i
+| UserSid="S-1-5-18"
+```
+
+## Query 26
+```cql
+#event_simpleName=ProcessRollup2 event_platform=Win
+| ImageFileName=/\\powershell(_ise)?\.exe/i
+| CommandLine=/\-(?<encodedFlagUsed>e(nc|ncodedcommand|ncoded)?)\s+/i
+| UserSid="S-1-5-18"
+| groupBy([encodedFlagUsed, CommandLine], function=(count(aid, as=executionCount)))
+| sort(executionCount, order=asc)
+```
+
+## Query 27
+```cql
+#event_simpleName=ProcessRollup2 event_platform=Win
+| ImageFileName=/\\powershell(_ise)?\.exe/i
+| CommandLine=/\-(?<encodedFlagUsed>e(nc|ncodedcommand|ncoded)?)\s+/i
+// | UserSid="S-1-5-18"
+| groupBy([encodedFlagUsed, CommandLine], function=(count(aid, as=executionCount)))
+| sort(executionCount, order=asc)
+```
+
+## Query 28
+```cql
+#event_simpleName=ProcessRollup2 event_platform=Win
+| ImageFileName=/\\powershell(_ise)?\.exe/i
+| CommandLine=/\-(?<encodedFlagUsed>e(nc|ncodedcommand|ncoded)?)\s+/i
+//| UserSid="S-1-5-18"
+| groupBy([encodedFlagUsed, CommandLine], function=(count(aid, as=executionCount)))
+| test(executionCount < 10)
+| sort(executionCount, order=asc)
+```
+
+## Query 29
+```cql
+| format("%,.100s", field=CommandLine, as=CommandLine)
+```

--- a/Queries-Only/Cool-Query-Friday/2023-04-07 - Cool Query Friday - Windows T1087.001 - When You're Bored, Go Overboard.md
+++ b/Queries-Only/Cool-Query-Friday/2023-04-07 - Cool Query Friday - Windows T1087.001 - When You're Bored, Go Overboard.md
@@ -1,0 +1,98 @@
+---
+title: "Windows T1087.001 - When You're Bored, Go Overboard"
+date: 2023-04-07
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/12enf8y/20230407_cool_query_friday_windows_t1087001_when/"
+mitre: [T1087, T1087.001]
+series: Cool Query Friday
+---
+
+# Windows T1087.001 - When You're Bored, Go Overboard
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/12enf8y/20230407_cool_query_friday_windows_t1087001_when/](https://www.reddit.com/r/crowdstrike/comments/12enf8y/20230407_cool_query_friday_windows_t1087001_when/) — by Andrew-CS (CrowdStrike) — 2023-04-07
+
+Welcome to our fifty-sixth installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk through of each step (3) application in the wild.
+
+## Query 1
+```cql
+| CommandLine=/\s+(?<netCommand>(accounts|computer|config|continue|file|group|help|helpmsg|localgroup|name|pause|print|send|session|share|start|statistics|stop|time|use|user|view))\s+(?<netArguments>.+)/i
+```
+
+## Query 2
+```cql
+#event_simpleName=ProcessRollup2 event_platform=Win ImageFileName=/\\net1?\.exe/i
+| CommandLine=/\s+(?<netCommand>(accounts|computer|config|continue|file|group|help|helpmsg|localgroup|name|pause|print|send|session|share|start|statistics|stop|time|use|user|view))\s+(?<netArguments>.+)/i
+| select([netCommand, netArguments])
+```
+
+## Query 3
+```cql
+| regex("(?<netFlag>\/\w+)(\s+|\:|$)", field=netArguments, strict=false, repeat=true)
+```
+
+## Query 4
+```cql
+| CommandLine=/\s+(?<netCommand>(accounts|computer|config|continue|file|group|help|helpmsg|localgroup|name|pause|print|send|session|share|start|statistics|stop|time|use|user|view))\s+(?<netArguments>.+)/i
+| regex("(?<netFlag>\/\w+)(\s+|\:|$)", field=netArguments, strict=false, repeat=true)
+| default(value="none", field=[netFlag])
+| select([netCommand, netFlag, netArguments])
+```
+
+## Query 5
+```cql
+#event_simpleName=ProcessRollup2 event_platform=Win ImageFileName=/\\(?<FileName>net1?\.exe)/i
+| CommandLine=/\s+(?<netCommand>(accounts|computer|config|continue|file|group|help|helpmsg|localgroup|name|pause|print|send|session|share|start|statistics|stop|time|use|user|view))\s+(?<netArguments>.+)/i
+| regex("(?<netFlag>\/\w+)(\s+|\:|$)", field=netArguments, strict=false, repeat=true)
+| default(value="none", field=[netFlag])
+| netCommand=?netCommand netFlag=?netFlag
+| rootURL := "https://falcon.crowdstrike.com/"
+| format("[Process Explorer](%sinvestigate/process-explorer/%s/%s)", field=["rootURL", "aid", "TargetProcessId"], as="Process Explorer")
+| groupBy([ProcessStartTime, aid, FileName, netCommand, netArguments], function=collect([netFlag, "Process Explorer"]))
+| select([ProcessStartTime, aid, FileName, netCommand, netFlag, netArguments, "Process Explorer"])
+| ProcessStartTime := ProcessStartTime*1000 | formatTime(format="%F %T.%L", field="ProcessStartTime", as="ProcessStartTime")
+```
+
+## Query 6
+```cql
+| netCommand=?netCommand netFlag=?netFlag
+```
+
+## Query 7
+```cql
+#event_simpleName=ProcessRollup2 event_platform=Win ImageFileName=/\\net1?\.exe/i
+| CommandLine=/\s+(?<netCommand>(accounts|computer|config|continue|file|group|help|helpmsg|localgroup|name|pause|print|send|session|share|start|statistics|stop|time|use|user|view))\s+(?<netArguments>.+)/i
+| lower("netArguments") | lower("netCommand")
+| regex("(?<netFlag>\/\w+)(\s+|\:|$)", field=netArguments, strict=false, repeat=true)
+| lower("netFlag") 
+| groupBy([netFlag])
+```
+
+## Query 8
+```cql
+#event_simpleName=ProcessRollup2 event_platform=Win ImageFileName=/\\(?<FileName>net1?\.exe)/i
+| CommandLine=/\s+(?<netCommand>(accounts|computer|config|continue|file|group|help|helpmsg|localgroup|name|pause|print|send|session|share|start|statistics|stop|time|use|user|view))\s+(?<netArguments>.+)/i
+| regex("(?<netFlag>\/\w+)(\s+|\:|$)", field=netArguments, strict=false, repeat=true)
+| default(value="none", field=[netFlag])
+| netCommand=?netCommand netFlag=?netFlag
+| sankey(source="netCommand", target="netFlag", weight=count(aid))
+```
+
+## Query 9
+```cql
+#event_simpleName=ProcessRollup2 event_platform=Win ImageFileName=/\\(?<FileName>net1?\.exe)/i
+| CommandLine=/\s+(?<netCommand>(accounts|computer|config|continue|file|group|help|helpmsg|localgroup|name|pause|print|send|session|share|start|statistics|stop|time|use|user|view))\s+(?<netArguments>.+)/i
+| regex("(?<netFlag>\/\w+)(\s+|\:|$)", field=netArguments, strict=false, repeat=true)
+| default(value="none", field=[netFlag])
+| netCommand=?netCommand netFlag=?netFlag
+| groupBy([netCommand])
+```
+
+## Query 10
+```cql
+#event_simpleName=ProcessRollup2 event_platform=Win ImageFileName=/\\(?<FileName>net1?\.exe)/i
+| CommandLine=/\s+(?<netCommand>(accounts|computer|config|continue|file|group|help|helpmsg|localgroup|name|pause|print|send|session|share|start|statistics|stop|time|use|user|view))\s+(?<netArguments>.+)/i
+| regex("(?<netFlag>\/\w+)(\s+|\:|$)", field=netArguments, strict=false, repeat=true)
+| default(value="none", field=[netFlag])
+| netCommand=?netCommand netFlag=?netFlag
+| timeChart(netCommand, span=1d)
+```

--- a/Queries-Only/Cool-Query-Friday/2023-06-08 - Cool Query Friday - [T1562.009] Defense Evasion - Impair Defenses - Windows Safe Mode.md
+++ b/Queries-Only/Cool-Query-Friday/2023-06-08 - Cool Query Friday - [T1562.009] Defense Evasion - Impair Defenses - Windows Safe Mode.md
@@ -1,0 +1,97 @@
+---
+title: "[T1562.009] Defense Evasion - Impair Defenses - Windows Safe Mode"
+date: 2023-06-08
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/144f19i/20230608_cool_query_friday_t1562009_defense/"
+mitre: [T1562, T1562.009]
+series: Cool Query Friday
+---
+
+# [T1562.009] Defense Evasion - Impair Defenses - Windows Safe Mode
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/144f19i/20230608_cool_query_friday_t1562009_defense/](https://www.reddit.com/r/crowdstrike/comments/144f19i/20230608_cool_query_friday_t1562009_defense/) — by Andrew-CS (CrowdStrike) — 2023-06-08
+
+Welcome to our fifty-seventh installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk through of each step (3) application in the wild.
+
+## Query 1
+```cql
+#event_simpleName=ProcessRollup2 event_platform=Win CommandLine=/safeboot/i  
+| ImageFileName=/\\(?<FileName>\w+\.exe)$/i
+| default(value="N/A", field=[GrandParentBaseFileName])
+| groupBy([GrandParentBaseFileName, ParentBaseFileName, FileName], function=([count(aid, distinct=true, as=uniqueEndpoints), count(aid, as=executionCount), collect([CommandLine])]))
+```
+
+## Query 2
+```cql
+event_platform=Win event_simpleName=ProcessRollup2 "bcdedit" "safeboot"
+| fillnull value="-" GrandParentBaseFileName
+| stats dc(aid) as uniqueEndpoints, count(aid) as executionCount, values(CommandLine) as CommandLine by GrandParentBaseFileName, ParentBaseFileName, FileName
+```
+
+## Query 3
+```cql
+#event_simpleName=ProcessRollup2 event_platform=Win (ImageFileName=/\\bcdedit\.exe/i OR CommandLine=/bcdedit/i)
+| ImageFileName=/\\(?<FileName>\w+\.exe)$/i
+| default(value="N/A", field=[GrandParentBaseFileName])
+| groupBy([GrandParentBaseFileName, ParentBaseFileName, FileName], function=([count(aid, distinct=true, as=uniqueEndpoints), count(aid, as=executionCount), collect([CommandLine])]))
+```
+
+## Query 4
+```cql
+event_platform=Win event_simpleName=ProcessRollup2 "bcdedit" 
+| fillnull value="-" GrandParentBaseFileName
+| stats dc(aid) as uniqueEndpoints, count(aid) as executionCount, values(CommandLine) as CommandLine by GrandParentBaseFileName, ParentBaseFileName, FileName
+```
+
+## Query 5
+```cql
+#event_simpleName=ProcessRollup2 event_platform=Win (ImageFileName=/\\bcdedit\.exe/i OR CommandLine=/bcdedit/i)
+| ImageFileName=/\\(?<FileName>\w+\.exe)$/i
+// Begin scoring. Adjust searches and values as desired.
+| case{
+   CommandLine=/\/set/i | scoreSet := 5;
+   *;
+   }
+| case {
+   CommandLine=/\/delete/i | scoreDelete := 5;
+   *;
+   }
+| case {
+   CommandLine=/safeboot/i | scoreSafeBoot := 10;
+   *;
+   }
+| case {
+   CommandLine=/network/i | scoreNetwork := 20;
+   *;
+   }
+| case {
+   CommandLine=/\{[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[\}]/ | scoreGUID := 9;
+   *;
+}
+| case {
+   ParentBaseFileName=/^(powershell|cmd)\.exe$/i | scoreParent := "7";
+   *;
+   }
+// End scoring
+| default(value="N/A", field=[GrandParentBaseFileName])
+| default(value=0, field=[scoreSet, scoreDelete, scoreSafeBoot, scoreNetwork, scoreGUID, scoreParent])
+| totalScore := scoreSet + scoreDelete + scoreSafeBoot + scoreNetwork + scoreGUID + scoreParent
+| groupBy([GrandParentBaseFileName, ParentBaseFileName, FileName, CommandLine], function=([collect(totalScore), count(aid, distinct=true, as=uniqueEndpoints), count(aid, as=executionCount)]))
+| select([GrandParentBaseFileName, ParentBaseFileName, FileName, totalScore, uniqueEndpoints, executionCount, CommandLine])
+| sort(totalScore, order=desc, limit=1000)
+```
+
+## Query 6
+```cql
+event_platform=Win event_simpleName=ProcessRollup2 "bcdedit" 
+| fillnull value="-" GrandParentBaseFileName
+| eval scoreSet=if(match(CommandLine,"\/set"),"5","0") 
+| eval scoreDelete=if(match(CommandLine,"\/delete"),"5","0") 
+| eval scoreSafeBoot=if(match(CommandLine,"safeboot"),"10","0") 
+| eval scoreNetwork=if(match(CommandLine,"network"),"20","0") 
+| eval scoreGUID=if(match(CommandLine,"{[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]"),"9","0") 
+| eval scoreParent=if(match(ParentBaseFileName,"^(powershell|cmd)\.exe"),"7","0") 
+| eval totalScore=scoreSet+scoreDelete+scoreSafeBoot+scoreNetwork+scoreGUID+scoreParent
+| stats dc(aid) as uniqueEndpoints, count(aid) as executionCount, values(CommandLine) as CommandLine by GrandParentBaseFileName, ParentBaseFileName, FileName, totalScore
+| sort 0 - totalScore
+```

--- a/Queries-Only/Cool-Query-Friday/2023-07-27 - Cool Query Friday - Adding Falcon Intelligence Data to LogScale and LTR Query Output.md
+++ b/Queries-Only/Cool-Query-Friday/2023-07-27 - Cool Query Friday - Adding Falcon Intelligence Data to LogScale and LTR Query Output.md
@@ -1,0 +1,116 @@
+---
+title: "Adding Falcon Intelligence Data to LogScale and LTR Query Output"
+date: 2023-07-27
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/15b3nyu/20230727_cool_query_friday_adding_falcon/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Adding Falcon Intelligence Data to LogScale and LTR Query Output
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/15b3nyu/20230727_cool_query_friday_adding_falcon/](https://www.reddit.com/r/crowdstrike/comments/15b3nyu/20230727_cool_query_friday_adding_falcon/) — by Andrew-CS (CrowdStrike) — 2023-07-27
+
+Welcome to our fifty-ninth installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk through of each step (3) application in the wild.
+
+## Query 1
+```cql
+| falconPID:=TargetProcessId | falconPID:=ContextProcessId
+```
+
+## Query 2
+```cql
+| falconPID:=concat([TargetProcessId,ContextProcessId])
+```
+
+## Query 3
+```cql
+| case { 
+    #event_simpleName=ProcessRollup2| ImageFileName=/(\\Device\\HarddiskVolume\d+|\/)?(?<FilePath>(\\|\/).+(\\|\/))(?<FileName>.+)$/i | FileName:=lower("FileName");
+    #event_simpleName=DnsRequest | ioc:lookup(field=[DomainName], type="domain");
+    *;
+    }
+```
+
+## Query 4
+```cql
+| selfJoinFilter(field=[aid, falconPID], where=[{#event_simpleName=ProcessRollup2 FileName=?FileName}, {#event_simpleName=DnsRequest ioc.detected=true}])
+```
+
+## Query 5
+```cql
+| groupBy([aid, falconPID], function=([count(#event_simpleName, distinct=true, as=eventCount), collect([ContextTimeStamp, DomainName, ioc[0].labels, UserSid, FileName, FilePath, CommandLine])]))
+| eventCount>1
+```
+
+## Query 6
+```cql
+(#event_simpleName=ProcessRollup2 aid=?aid) OR (#event_simpleName=DnsRequest DomainName=?DomainName)
+| falconPID:=TargetProcessId | falconPID:=ContextProcessId
+| case {
+    #event_simpleName=ProcessRollup2| ImageFileName=/(\\Device\\HarddiskVolume\d+|\/)?(?<FilePath>(\\|\/).+(\\|\/))(?<FileName>.+)$/i | FileName:=lower("FileName");
+    #event_simpleName=DnsRequest | ioc:lookup(field=[DomainName], type="domain");
+    *;
+    }
+| selfJoinFilter(field=[aid, falconPID], where=[{#event_simpleName=ProcessRollup2 FileName=?FileName}, {#event_simpleName=DnsRequest ioc.detected=true}])
+| groupBy([aid, falconPID], function=([count(#event_simpleName, distinct=true, as=eventCount), collect([ContextTimeStamp, DomainName, ioc[0].labels, UserSid, FileName, FilePath, CommandLine])]))
+| eventCount>1
+```
+
+## Query 7
+```cql
+| falcon_intel:=replace(field="ioc[0].labels", regex="\,", with="\n")
+| falcon_intel:=replace(field="falcon_intel", regex="\/", with=": ")
+```
+
+## Query 8
+```cql
+| ContextTimeStamp:=ContextTimeStamp*1000 | ContextTimeStamp:=formatTime(format="%F %T.%L", field="ContextTimeStamp")
+| Details:=format(format="\tTime:\t%s\nAgent ID:\t%s\nUser SID:\t%s\n\tFile:\t%s\n\tPath:\t%s\nCmd Line:\t%s\n\n", field=[ContextTimeStamp, aid, UserSid, FileName, FilePath, CommandLine])
+```
+
+## Query 9
+```cql
+// Un-comment one rootURL value
+| rootURL := "https://falcon.crowdstrike.com/" /* US-1 */
+//| rootURL := "https://falcon.us-2.crowdstrike.com/" /* US-2 */
+//| rootURL := "https://falcon.laggar.gcw.crowdstrike.com/" /* Gov */
+//| rootURL := "https://falcon.eu-1.crowdstrike.com/" /* EU */
+| format("[Graph Explorer](%sgraphs/process-explorer/graph?id=pid:%s:%s)", field=["rootURL", "aid", "falconPID"], as="Graph Explorer")
+```
+
+## Query 10
+```cql
+| rename(field="Details", as="Execution Details")
+| rename(field="DomainName", as="IOC")
+| rename(field="falcon_intel", as="Falcon Intelligence")
+| select([IOC, "Falcon Intelligence", "Execution Details", "Graph Explorer"])
+```
+
+## Query 11
+```cql
+(#event_simpleName=ProcessRollup2 aid=?aid) OR (#event_simpleName=DnsRequest DomainName=?DomainName)
+| falconPID:=TargetProcessId | falconPID:=ContextProcessId
+| case{ 
+    #event_simpleName=ProcessRollup2| ImageFileName=/(\\Device\\HarddiskVolume\d+|\/)?(?<FilePath>(\\|\/).+(\\|\/))(?<FileName>.+)$/i | FileName:=lower("FileName");
+    #event_simpleName=DnsRequest | ioc:lookup(field=[DomainName], type="domain");
+    *;
+    }
+| selfJoinFilter(field=[aid, falconPID], where=[{#event_simpleName=ProcessRollup2 FileName=?FileName}, {#event_simpleName=DnsRequest ioc.detected=true}])
+| groupBy([aid, falconPID], function=([count(#event_simpleName, distinct=true, as=eventCount), collect([ContextTimeStamp, DomainName, ioc[0].labels, UserSid, FileName, FilePath, CommandLine])]))
+| eventCount>1
+| falcon_intel:=replace(field="ioc[0].labels", regex="\,", with="\n")
+| falcon_intel:=replace(field="falcon_intel", regex="\/", with=": ")
+| ContextTimeStamp:=ContextTimeStamp*1000 | ContextTimeStamp:=formatTime(format="%F %T.%L", field="ContextTimeStamp")
+| Details:=format(format="\tTime:\t%s\nAgent ID:\t%s\nUser SID:\t%s\n\tFile:\t%s\n\tPath:\t%s\nCmd Line:\t%s\n\n", field=[ContextTimeStamp, aid, UserSid, FileName, FilePath, CommandLine])
+// Un-comment one rootURL value
+| rootURL  := "https://falcon.crowdstrike.com/" /* US-1 */
+//| rootURL  := "https://falcon.us-2.crowdstrike.com/" /* US-2 */
+//| rootURL  := "https://falcon.laggar.gcw.crowdstrike.com/" /* Gov */
+//| rootURL  := "https://falcon.eu-1.crowdstrike.com/"  /* EU */
+| format("[Graph Explorer](%sgraphs/process-explorer/graph?id=pid:%s:%s)", field=["rootURL", "aid", "falconPID"], as="Graph Explorer") 
+| rename(field="Details", as="Execution Details")
+| rename(field="DomainName", as="IOC")
+| rename(field="falcon_intel", as="Falcon Intelligence")
+| select([IOC, "Falcon Intelligence", "Execution Details", "Graph Explorer"])
+```

--- a/Queries-Only/Cool-Query-Friday/2023-08-04 - Cool Query Friday - Creating Your Own, Bespoke Hunting Repo with Falcon LTR.md
+++ b/Queries-Only/Cool-Query-Friday/2023-08-04 - Cool Query Friday - Creating Your Own, Bespoke Hunting Repo with Falcon LTR.md
@@ -1,0 +1,83 @@
+---
+title: "Creating Your Own, Bespoke Hunting Repo with Falcon LTR"
+date: 2023-08-04
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/15i3i80/20230804_cool_query_friday_creating_your_own/"
+mitre: [T1562.001]
+series: Cool Query Friday
+---
+
+# Creating Your Own, Bespoke Hunting Repo with Falcon LTR
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/15i3i80/20230804_cool_query_friday_creating_your_own/](https://www.reddit.com/r/crowdstrike/comments/15i3i80/20230804_cool_query_friday_creating_your_own/) — by Andrew-CS (CrowdStrike) — 2023-08-04
+
+Welcome to our sixtieth installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/) (sexagenarian!). The format will be: (1) description of what we're doing (2) walk through of each step (3) application in the wild.
+
+## Query 1
+```cql
+#event_simpleName=CommandHistory event_platform=Win CommandHistory=/(csagent|csfalcon)/i
+```
+
+## Query 2
+```cql
+#event_simpleName=CommandHistory event_platform=Win CommandHistory=/(csagent|csfalcon)/i
+| groupBy([ApplicationName, UserName, UserSid])
+```
+
+## Query 3
+```cql
+#event_simpleName=CommandHistory event_platform=Win CommandHistory=/(csagent|csfalcon)/i ApplicationName!="cmd.exe"
+```
+
+## Query 4
+```cql
+#event_simpleName=CommandHistory event_platform=Win CommandHistory=/(csagent|csfalcon)/i
+| HuntingLeadID:=1
+```
+
+## Query 5
+```cql
+#event_simpleName=CommandHistory event_platform=Win CommandHistory=/(csagent|csfalcon)/i
+| HuntingLeadID:=1
+| HuntingLeadName:="UnexpectedFalconProcessCall"
+| ATT&CK:="T1562.001"
+| Description:="The CrowdStrike Falcon driver or process name was unexpected invoked from the command line."
+```
+
+## Query 6
+```cql
+#event_simpleName=ProcessRollup2 event_platform=Win ImageFileName=/\\whoami\.exe/i
+| groupBy([ParentBaseFileName])
+| sort(_count, order=desc)
+```
+
+## Query 7
+```cql
+​​#event_simpleName=ProcessRollup2 event_platform=Win ImageFileName=/\\whoami\.exe/i ParentBaseFileName="cmd.exe"
+| groupBy([UserSid])
+| sort(_count, order=desc)
+```
+
+## Query 8
+```cql
+#event_simpleName=ProcessRollup2 event_platform=Win ImageFileName=/\\whoami\.exe/i
+| HuntingLeadID:=2
+```
+
+## Query 9
+```cql
+HuntingLeadID=*
+| HuntingLeadID =~ match(file="HuntingLeadID.csv", column=HuntingLeadID, strict=false)
+| LeadName=*
+| groupBy([aid, ComputerName], function=([sum(Weight, as=Weight), count(HuntingLeadID, as=totalLeads), collect([LeadName]), min(@timestamp, as=firstLead), max(@timestamp, as=lastLead)]))
+| firstLead:=formatTime(format="%F %T.%L", field="firstLead")
+| lastLead:=formatTime(format="%F %T.%L", field="lastLead")
+| sort(Weight, order=desc)
+```
+
+## Query 10
+```cql
+HuntingLeadID=*
+| HuntingLeadID =~ match(file="HuntingLeadID.csv", column=HuntingLeadID, strict=false)
+| sankey(source="ComputerName", target="LeadName", weight=sum(Weight))
+```

--- a/Queries-Only/Cool-Query-Friday/2023-08-11 - Cool Query Friday - [T1036.005] Inventorying LOLBINs and Hunting for System Folder Binary Masquerading.md
+++ b/Queries-Only/Cool-Query-Friday/2023-08-11 - Cool Query Friday - [T1036.005] Inventorying LOLBINs and Hunting for System Folder Binary Masquerading.md
@@ -1,0 +1,156 @@
+---
+title: "[T1036.005] Inventorying LOLBINs and Hunting for System Folder Binary Masquerading"
+date: 2023-08-11
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/15oa5io/20230811_cool_query_friday_t1036005_inventorying/"
+mitre: [T1036, T1036.005]
+series: Cool Query Friday
+---
+
+# [T1036.005] Inventorying LOLBINs and Hunting for System Folder Binary Masquerading
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/15oa5io/20230811_cool_query_friday_t1036005_inventorying/](https://www.reddit.com/r/crowdstrike/comments/15oa5io/20230811_cool_query_friday_t1036005_inventorying/) — by Andrew-CS (CrowdStrike) — 2023-08-11
+
+Welcome to our sixty-first installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/collection/8016c539-c284-442c-9726-6bc05053d7a9/). The format will be: (1) description of what we're doing (2) walk through of each step (3) application in the wild.
+
+## Query 1
+```cql
+#event_simpleName=/^(ProcessRollup2|SyntheticProcessRollup2)$/ event_platform=Win ImageFileName=/\\Windows\\(System32|SysWOW64)\\/
+```
+
+## Query 2
+```cql
+| ImageFileName=/(\\Device\\HarddiskVolume\d+)?(?<FilePath>\\.+\\)(?<FileName>.+$)/
+```
+
+## Query 3
+```cql
+| FileName:=lower(FileName)
+```
+
+## Query 4
+```cql
+| lower(field=FileName, as=FileName)
+```
+
+## Query 5
+```cql
+| groupBy([FileName, FilePath], function=([count(aid, distinct=true, as=uniqueEndpoints), count(aid, as=executionCount)]))
+```
+
+## Query 6
+```cql
+#event_simpleName=/^(ProcessRollup2|SyntheticProcessRollup2)$/ event_platform=Win ImageFileName=/\\Windows\\(System32|SysWOW64)\\/
+| ImageFileName=/(\\Device\\HarddiskVolume\d+)?(?<FilePath>\\.+\\)(?<FileName>.+$)/
+| lower(field=FileName, as=FileName)
+| groupBy([FileName, FilePath], function=([count(aid, distinct=true, as=uniqueEndpoints), count(aid, as=executionCount)]))
+```
+
+## Query 7
+```cql
+| uniqueEndpoints:=format("%,.0f",field="uniqueEndpoints")
+| executionCount:=format("%,.0f",field="executionCount")
+```
+
+## Query 8
+```cql
+| expectedFileName:=rename(field="FileName")
+| expectedFilePath:=rename(field="FilePath")
+```
+
+## Query 9
+```cql
+| details:=format(format="The file %s has been executed %s time on %s unique endpoints in the past 30 days.\nThe expected file path for this binary is: %s.", field=[expectedFileName, executionCount, uniqueEndpoints, expectedFilePath])
+| select([expectedFileName, expectedFilePath, uniqueEndpoints, executionCount, details])
+```
+
+## Query 10
+```cql
+#event_simpleName=/^(ProcessRollup2|SyntheticProcessRollup2)$/ event_platform=Win ImageFileName=/\\Windows\\(System32|SysWOW64)\\/
+| ImageFileName=/(\\Device\\HarddiskVolume\d+)?(?<FilePath>\\.+\\)(?<FileName>.+$)/
+| lower(field=FileName, as=FileName)
+| groupBy([FileName, FilePath], function=([count(aid, distinct=true, as=uniqueEndpoints), count(aid, as=executionCount)]))
+| uniqueEndpoints:=format("%,.0f",field="uniqueEndpoints")
+| executionCount:=format("%,.0f",field="executionCount")
+| expectedFileName:=rename(field="FileName")
+| expectedFilePath:=rename(field="FilePath")
+| details:=format(format="The file %s has been executed %s time on %s unique endpoints in the past 30 days.\nThe expected file path for this binary is: %s.", field=[expectedFileName, executionCount, uniqueEndpoints, expectedFilePath])
+| select([expectedFileName, expectedFilePath, uniqueEndpoints, executionCount, details])
+```
+
+## Query 11
+```cql
+#event_simpleName=/^(ProcessRollup2|SyntheticProcessRollup2)$/ event_platform=Win ImageFileName!=/\\Windows\\(System32|SysWOW64)\\/
+| ImageFileName=/(\\Device\\HarddiskVolume\d+)?(?<FilePath>\\.+\\)(?<FileName>.+$)/
+| lower(field=FileName, as=FileName)
+```
+
+## Query 12
+```cql
+| FileName =~ match(file="win-sys-folder-inventory.csv", column=expectedFileName, strict=true)
+```
+
+## Query 13
+```cql
+| groupBy([FileName], function=([count(aid, as=executionCount), count(aid, distinct=true, as=endpointCount), collect([FilePath, details])]))
+```
+
+## Query 14
+```cql
+#event_simpleName=/^(ProcessRollup2|SyntheticProcessRollup2)$/ event_platform=Win ImageFileName!=/\\Windows\\(System32|SysWOW64)\\/
+| ImageFileName=/(\\Device\\HarddiskVolume\d+)?(?<FilePath>\\.+\\)(?<FileName>.+$)/
+| lower(field=FileName, as=FileName)
+| FileName =~ match(file="win-sys-folder-inventory.csv", column=expectedFileName, strict=true)
+| groupBy([FileName], function=([count(aid, as=executionCount), count(aid, distinct=true, as=endpointCount), collect([FilePath, details])]))
+```
+
+## Query 15
+```cql
+#event_simpleName=/^(ProcessRollup2|SyntheticProcessRollup2)$/ event_platform=Win ImageFileName!=/\\Windows\\(System32|SysWOW64)\\/
+| ImageFileName=/(\\Device\\HarddiskVolume\d+)?(?<FilePath>\\.+\\)(?<FileName>.+$)/
+| FilePath!=/[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}/
+```
+
+## Query 16
+```cql
+#event_simpleName=/^(ProcessRollup2|SyntheticProcessRollup2)$/ event_platform=Win ImageFileName!=/\\Windows\\(System32|SysWOW64)\\/
+| ImageFileName=/(\\Device\\HarddiskVolume\d+)?(?<FilePath>\\.+\\)(?<FileName>.+$)/
+| FilePath!=/[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}/
+| lower(field=FileName, as=FileName)
+| !in(field="FileName", values=["onedrivesetup.exe"])
+```
+
+## Query 17
+```cql
+| !in(field="FileName", values=["onedrivesetup.exe", "myCustomApp.exe"])
+```
+
+## Query 18
+```cql
+#event_simpleName=/^(ProcessRollup2|SyntheticProcessRollup2)$/ event_platform=Win ImageFileName!=/\\Windows\\(UUS|System32|SysWOW64)\\/
+```
+
+## Query 19
+```cql
+| test(executionCount < 30)
+```
+
+## Query 20
+```cql
+// Get all process execution events ocurring ourside of the system folder.
+#event_simpleName=/^(ProcessRollup2|SyntheticProcessRollup2)$/ event_platform=Win ImageFileName!=/\\Windows\\(UUS|System32|SysWOW64)\\/
+// Create fields FilePath and FileName from ImageFileName.
+| ImageFileName=/(\\Device\\HarddiskVolume\d+)?(?<FilePath>\\.+\\)(?<FileName>.+$)/
+// Omit all file paths with GUID. Optional.
+| FilePath!=/[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}/
+// Force field FileName to lower case.
+| FileName:=lower(field=FileName)
+// Include file names to be omitted. Optional.
+| !in(field="FileName", values=["onedrivesetup.exe", "mycustomApp.exe"])
+// Check events above against system folder inventory. Remove non-matches. Output all columns from lookup file.
+| FileName =~ match(file="win-sys-folder-inventory.csv", column=expectedFileName, strict=true)
+// Group matches by FileName value.
+| groupBy([FileName], function=([count(aid, as=executionCount), count(aid, distinct=true, as=endpointCount), collect([FilePath, expectedFilePath, details])]))
+// Set threshold after which results are dropped. Optional.
+| test(executionCount < 30)
+```

--- a/Queries-Only/Cool-Query-Friday/2023-09-20 - Cool Query Friday - Live from Fal.Con - Up-leveling Teams With Multipurpose, Text-box Driven Queries.md
+++ b/Queries-Only/Cool-Query-Friday/2023-09-20 - Cool Query Friday - Live from Fal.Con - Up-leveling Teams With Multipurpose, Text-box Driven Queries.md
@@ -1,0 +1,129 @@
+---
+title: "Live from Fal.Con - Up-leveling Teams With Multipurpose, Text-box Driven Queries"
+date: 2023-09-20
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/16soii4/20230920_cool_query_friday_live_from_falcon/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Live from Fal.Con - Up-leveling Teams With Multipurpose, Text-box Driven Queries
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/16soii4/20230920_cool_query_friday_live_from_falcon/](https://www.reddit.com/r/crowdstrike/comments/16soii4/20230920_cool_query_friday_live_from_falcon/) — by Andrew-CS (CrowdStrike) — 2023-09-20
+
+Welcome to our sixty-third installment of Cool Query Friday. The format will be: (1) description of what we're doing (2) walk through of each step (3) application in the wild.
+
+## Query 1
+```cql
+// Get all execution and DNS request events
+#event_simpleName=/^(ProcessRollup2|DnsRequest)$/
+```
+
+## Query 2
+```cql
+// Normalize Falcon PID value
+| falconPID:=TargetProcessId
+| falconPID:=ContextProcessId
+```
+
+## Query 3
+```cql
+// Use selfJoin to filter our instances on only one event happening
+| selfJoinFilter(field=[aid, falconPID], where=[{#event_simpleName=ProcessRollup2}, {#event_simpleName=DnsRequest}])
+```
+
+## Query 4
+```cql
+// Aggregate to include desired fields
+| groupBy([aid, falconPID], function=([collect([ComputerName, UserName, ParentBaseFileName, FileName, DomainName, CommandLine])]))
+```
+
+## Query 5
+```cql
+// Get specific events and provide option to specify host
+#event_simpleName=/^(ProcessRollup2|DnsRequest)$/
+
+// Normalize UPID value
+| falconPID:=TargetProcessId
+| falconPID:=ContextProcessId
+
+// Use selfJoin to filter our instances on only one event happening
+| selfJoinFilter(field=[aid, falconPID], where=[{#event_simpleName=ProcessRollup2}, {#event_simpleName=DnsRequest}])
+
+// Aggregate to include desired fields
+| groupBy([aid, falconPID], function=([collect([ComputerName, UserName, ParentBaseFileName, FileName, DomainName, CommandLine])]))
+```
+
+## Query 6
+```cql
+// Get specific events and provide option to specify host
+#event_simpleName=/^(ProcessRollup2|DnsRequest)$/
+```
+
+## Query 7
+```cql
+// Get specific events and provide option to specify host
+#event_simpleName=/^(ProcessRollup2|DnsRequest)$/
+
+// Check for ComputerName
+| ComputerName=~wildcard(?ComputerName, ignoreCase=true)
+```
+
+## Query 8
+```cql
+// Create case statement to manipulate fields based on event type and provide option to specify parameters based on event
+
+| case {
+    #event_simpleName=ProcessRollup2
+       | UserName=~wildcard(?UserName, ignoreCase=true)
+       | FileName=~wildcard(?FileName, ignoreCase=true)
+       | ParentBaseFileName=~wildcard(?ParentBaseFileName, ignoreCase=true)
+       | ExecutionChain:=format(format="%s\n\t└ %s (%s)", field=[ParentBaseFileName, FileName, RawProcessId]);
+    #event_simpleName=DnsRequest
+       | DomainName=~wildcard(?DomainName, ignoreCase=true);
+}
+```
+
+## Query 9
+```cql
+| ExecutionChain:=format(format="%s\n\t└ %s (%s)", field=[ParentBaseFileName, FileName, RawProcessId]);
+```
+
+## Query 10
+```cql
+// Add link to graph explorer in US-2
+| format("[Graph Explorer](https://falcon.us-2.crowdstrike.com/graphs/process-explorer/graph?id=pid:%s:%s)", field=["aid", "falconPID"], as="Graph Explorer")
+```
+
+## Query 11
+```cql
+// Get specific events and provide option to specify host
+#event_simpleName=/^(ProcessRollup2|DnsRequest)$/
+
+// Check for ComputerName
+| ComputerName=~wildcard(?ComputerName, ignoreCase=true)
+
+// Create case statement to manipulate fields based on event type and provide option to specify parameters based on file type
+| case {
+    #event_simpleName=ProcessRollup2
+        | UserName=~wildcard(?UserName, ignoreCase=true)
+        | FileName=~wildcard(?FileName, ignoreCase=true)
+        | ParentBaseFileName=~wildcard(?ParentBaseFileName, ignoreCase=true)
+        | ExecutionChain:=format(format="%s\n\t└ %s (%s)", field=[ParentBaseFileName, FileName, RawProcessId]);
+    #event_simpleName=DnsRequest
+        | DomainName=~wildcard(?DomainName, ignoreCase=true);
+}
+
+// Normalize UPID value
+| falconPID:=TargetProcessId
+| falconPID:=ContextProcessId
+
+// Use selfJoin to filter our instances on only one event happening
+| selfJoinFilter(field=[aid, falconPID], where=[{#event_simpleName=ProcessRollup2}, {#event_simpleName=DnsRequest}])
+
+// Aggregate to include desired fields
+| groupBy([aid, falconPID], function=([collect([ComputerName, UserName, ExecutionChain, DomainName, CommandLine])]))
+
+// Add link to graph explorer in US-2
+| format("[Graph Explorer](https://falcon.us-2.crowdstrike.com/graphs/process-explorer/graph?id=pid:%s:%s)", field=["aid", "falconPID"], as="Graph Explorer")
+```

--- a/Queries-Only/Cool-Query-Friday/2023-09-20 - Cool Query Friday - Live from Fal.Con - Up-leveling Teams With Multipurpose, Text-box Driven Queries.md
+++ b/Queries-Only/Cool-Query-Friday/2023-09-20 - Cool Query Friday - Live from Fal.Con - Up-leveling Teams With Multipurpose, Text-box Driven Queries.md
@@ -127,3 +127,29 @@ Welcome to our sixty-third installment of Cool Query Friday. The format will be:
 // Add link to graph explorer in US-2
 | format("[Graph Explorer](https://falcon.us-2.crowdstrike.com/graphs/process-explorer/graph?id=pid:%s:%s)", field=["aid", "falconPID"], as="Graph Explorer")
 ```
+
+## Community & Staff Additions
+*Harvested from this post's [r/CrowdStrike](https://www.reddit.com/r/crowdstrike/) comment thread — not part of the original CQF post. **[CS]** = CrowdStrike staff · **[Community]** = other r/CrowdStrike users. Upvote scores shown for context.*
+
+### Query variants
+
+```cql
+// Get specific events and provide option to specify host
+(#event_simpleName=ProcessRollup2 CommandLine!=/PcaPatch/i) OR (#event_simpleName=DnsRequest)
+
+// Normalize UPID value | falconPID:=TargetProcessId | falconPID:=ContextProcessId
+
+// Use selfJoin to filter our instances on only one event happening | selfJoinFilter(field=[aid, falconPID], where=[{#event_simpleName=ProcessRollup2}, {#event_simpleName=DnsRequest}])
+
+// Aggregate to include desired fields | groupBy([aid, falconPID], function=([collect([ComputerName, UserName, ParentBaseFileName, FileName, DomainName, CommandLine])]))
+
+// Remove false negatives from selfJoinFilter
+| CommandLine=* DomainName=*
+```
+— [CS] Andrew-CS · comment score 2
+
+### Q&A
+
+**Q — [Community] amjcyb:** If `CommandLine` field was part of `DnsRequest` event life will be much easier :)!! Any how, I'm addapting to the new CQL. One doubt I got here is related with how do I omit results. I've tried different ways to exclude parameters, for example: ``` | selfJoinFilter(field=[aid, falconPID], where=[{#e …
+
+**A — [CS] Andrew-CS:** Hi there. The second one is more efficient. If you have a large dataset, you could have false negatives in the mix with selfJoinFilter — it does this awesome nondeterministic thing to keep itself fast.. You can do this to omit them. // Get specific events and provide option to specify host (#event_simpleName=ProcessRollup2 CommandLine!=/PcaPatch/i) OR (#event_simpleName=DnsRequest) // Normalize UPID value | falconPID:=TargetProcessId | falconPID:=ContextProcessId // Use selfJoin to filter our in …

--- a/Queries-Only/Cool-Query-Friday/2023-10-20 - Cool Query Friday - ATT&CK Edition T1087.003.md
+++ b/Queries-Only/Cool-Query-Friday/2023-10-20 - Cool Query Friday - ATT&CK Edition T1087.003.md
@@ -1,0 +1,84 @@
+---
+title: "ATT&CK Edition: T1087.003"
+date: 2023-10-20
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/17c9nel/20231020_cool_query_friday_attck_edition_t1087003/"
+mitre: [T1087, T1087.002, T1087.003]
+series: Cool Query Friday
+---
+
+# ATT&CK Edition: T1087.003
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/17c9nel/20231020_cool_query_friday_attck_edition_t1087003/](https://www.reddit.com/r/crowdstrike/comments/17c9nel/20231020_cool_query_friday_attck_edition_t1087003/) — by Andrew-CS (CrowdStrike) — 2023-10-20
+
+Welcome to our sixty-sixth installment of Cool Query Friday. The format will be: (1) description of what we're doing (2) walk through of each step (3) application in the wild.
+
+## Query 1
+```cql
+| eval Description=case(match(CommandLine,".*(Get-AddressList|Get-GlobalAddressList|Get-OfflineAddressBook).*"), "T1087.003 discovered in command line invocation.", match(CommandHistory,".*(Get-AddressList|Get-GlobalAddressList|Get-OfflineAddressBook).*"), "T1087.003 discovered in command line history.", match(ScriptContent,".*(Get-AddressList|Get-GlobalAddressList|Get-OfflineAddressBook).*"), "T1087.003 discovered in script contents.")
+```
+
+## Query 2
+```cql
+| eval Details=coalesce(CommandLine, CommandHistory, ScriptContent)
+```
+
+## Query 3
+```cql
+| table _time, ComputerName, aid, UserName, UserSid_readable, TargetProcessId_decimal, Description, Details
+```
+
+## Query 4
+```cql
+#event_simpleName=/^(ProcessRollup2$|CommandHistory$|ScriptControl)/ event_platform=Win
+```
+
+## Query 5
+```cql
+#event_simpleName=/^(ProcessRollup2$|CommandHistory$|ScriptControl)/
+| /(Get-AddressList|Get-GlobalAddressList|Get-OfflineAddressBook)/i
+```
+
+## Query 6
+```cql
+// Get events in scope for T1087.003
+#event_simpleName=/^(ProcessRollup2$|CommandHistory$|ScriptControl)/
+
+// Get strings of interest
+| /(Get-AddressList|Get-GlobalAddressList|Get-OfflineAddressBook)/i
+
+// Create "Description" field based on location of target string
+| case {
+   #event_simpleName=CommandHistory AND CommandHistory=/(Get-AddressList|Get-GlobalAddressList|Get-OfflineAddressBook)/i | Description:="T1087.003 discovered in command line history.";
+   #event_simpleName=ProcessRollup2 AND CommandLine=/(Get-AddressList|Get-GlobalAddressList|Get-OfflineAddressBook)/i | Description:="T1087.003 discovered in command line invocation.";
+   #event_simpleName=/^ScriptControl/ AND ScriptContent=/(Get-AddressList|Get-GlobalAddressList|Get-OfflineAddressBook)/i | Description:="T1087.003 discovered in script contents.";
+   * | Description:="T1087.003 discovered in general event telemetry.";
+}
+
+// Concatenate fields of interest from events of interest
+| Details:=concat([CommandHistory,CommandLine,ScriptContent])
+
+// Format output into table
+| select([@timestamp, ComputerName, aid, UserName, UserSid, TargetProcessId, Description, Details])
+
+// Add link to Graph Explorer
+| format("[Graph Explorer](https://falcon.crowdstrike.com/graphs/process-explorer/graph?id=pid:%s:%s)", field=["aid", "TargetProcessId"], as="Graph Explorer")
+```
+
+## Query 7
+```cql
+```Get events in scope for T1087.003```
+event_simpleName IN (ProcessRollup2, CommandHistory, ScriptControl*) event_platform=Win ("Get-AddressList" OR "Get-GlobalAddressList" OR "Get-OfflineAddressBook")
+
+```Create "Description" field based on location of target string```
+| eval Description=case(match(CommandLine,".*(Get-AddressList|Get-GlobalAddressList|Get-OfflineAddressBook).*"), "T1087.003 discovered in command line invocation.", match(CommandHistory,".*(Get-AddressList|Get-GlobalAddressList|Get-OfflineAddressBook).*"), "T1087.003 discovered in command line history.", match(ScriptContent,".*(Get-AddressList|Get-GlobalAddressList|Get-OfflineAddressBook).*"), "T1087.003 discovered in script contents.")
+
+```Concat fields of interest from events of interest```
+| eval Details=coalesce(CommandLine, CommandHistory, ScriptContent)
+
+```Format output into table```
+| table _time, ComputerName, aid, UserName, UserSid_readable, TargetProcessId_decimal, Description, Details
+
+```Add link to Graph Explorer```
+| eval GraphExplorer=case(TargetProcessId_decimal!="","https://falcon.crowdstrike.com/graphs/process-explorer/graph?id=pid:" .aid. ":" . TargetProcessId_decimal)
+```

--- a/Queries-Only/Cool-Query-Friday/2023-11-10 - Cool Query Friday - ATT&CK Edition T1087.004.md
+++ b/Queries-Only/Cool-Query-Friday/2023-11-10 - Cool Query Friday - ATT&CK Edition T1087.004.md
@@ -1,0 +1,101 @@
+---
+title: "ATT&CK Edition: T1087.004"
+date: 2023-11-10
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/17s63ri/20231110_cool_query_friday_attck_edition_t1087004/"
+mitre: [T1087, T1087.001, T1087.002, T1087.003, T1087.004]
+series: Cool Query Friday
+---
+
+# ATT&CK Edition: T1087.004
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/17s63ri/20231110_cool_query_friday_attck_edition_t1087004/](https://www.reddit.com/r/crowdstrike/comments/17s63ri/20231110_cool_query_friday_attck_edition_t1087004/) — by Andrew-CS (CrowdStrike) — 2023-11-10
+
+Welcome to our sixty-seventh installment of Cool Query Friday. The format will be: (1) description of what we're doing (2) walk through of each step (3) application in the wild.
+
+## Query 1
+```cql
+| eval Description=case(match(CommandLine,".*(Get-MsolRoleMember).*"), "T1087.004 discovered in command line invocation.", match(CommandHistory,".*(Get-MsolRoleMember).*"), "T1087.004 discovered in command line history.", match(ScriptContent,".*(Get-MsolRoleMember).*"), "T1087.004 discovered in script contents.")
+```
+
+## Query 2
+```cql
+| eval Details=coalesce(CommandLine, CommandHistory, ScriptContent)
+```
+
+## Query 3
+```cql
+| table _time, ComputerName, aid, UserName, UserSid_readable, TargetProcessId_decimal, Description, Details
+```
+
+## Query 4
+```cql
+| eval GraphExplorer=case(TargetProcessId_decimal!="","https://falcon.crowdstrike.com/graphs/process-explorer/graph?id=pid:" .aid. ":" . TargetProcessId_decimal)
+
+*Public Cloud Tools*
+```
+
+## Query 5
+```cql
+event_simpleName=ProcessRollup2 ("az" OR "aws" OR "gcloud")
+    | regex CommandLine="(az\s+ad\s+user\s+list|aws\s+iam\s+list\-(roles|users)|gcloud\s+ (iam\s+service\-accounts\s+list|projects\s+get\-iam\-policy))"
+```
+
+## Query 6
+```cql
+| table _time, ComputerName, aid, UserName, UserSid_readable, TargetProcessId_decimal, FileName, CommandLine
+```
+
+## Query 7
+```cql
+// Search for PowerShell Commandlet Invocations that Enumerate Office365 Role Membership
+#event_simpleName=/^(ProcessRollup2$|CommandHistory$|ScriptControl)/ event_platform=Win /Get-MsolRoleMember/
+// Concatenate fields of interest from events of interest
+| Details:=concat([CommandHistory,CommandLine,ScriptContent])
+// Create "Description" field based on location of target string
+| case {
+#event_simpleName=CommandHistory AND CommandHistory=/(Get-MsolRoleMember)/i | Description:="T1087.004 discovered in command line history.";
+#event_simpleName=ProcessRollup2 AND CommandLine=/(Get-MsolRoleMember)/i | Description:="T1087.004 discovered in command line invocation.";
+#event_simpleName=/^ScriptControl/ AND ScriptContent=/(Get-MsolRoleMember)/i | Description:="T1087.004 discovered in script contents.";
+* | Description:="T1087.003 discovered in general event telemetry.";
+}
+// Format output into table
+| select([@timestamp, ComputerName, aid, UserName, UserSid, TargetProcessId, Description, Details])
+// Add link to Graph Explorer
+| format("[Graph Explorer](https://falcon.crowdstrike.com/graphs/process-explorer/graph?id=pid:%s:%s)", field=["aid", "TargetProcessId"], as="Graph Explorer")
+```
+
+## Query 8
+```cql
+// Search for public cloud command line tool invocation
+(#event_simpleName=ProcessRollup2 CommandLine=/az\s+ad\s+user\s+list/i) OR (#event_simpleName=ProcessRollup2 CommandLine=/aws\s+iam\s+list\-(roles|users)/i) OR (#event_simpleName=ProcessRollup2 CommandLine=/gcloud\s+ (iam\s+service\-accounts\s+list|projects\s+get\-iam\-policy)/i)
+// Format output into table
+| select([@timestamp, ComputerName, aid, UserName, UserSid, TargetProcessId, FileName, CommandLine])
+// Add link to Graph Explorer
+| format("[Graph Explorer](https://falcon.crowdstrike.com/graphs/process-explorer/graph?id=pid:%s:%s)", field=["aid", "TargetProcessId"], as="Graph Explorer")
+```
+
+## Query 9
+```cql
+```Get events in scope for T1087.004```
+event_simpleName IN (ProcessRollup2, CommandHistory, ScriptControl*) event_platform=Win "Get-MsolRoleMember"
+```Create "Description" field based on location of target string```
+| eval Description=case(match(CommandLine,".*(Get-MsolRoleMember).*"), "T1087.004 discovered in command line invocation.", match(CommandHistory,".*(Get-MsolRoleMember).*"), "T1087.004 discovered in command line history.", match(ScriptContent,".*(Get-MsolRoleMember).*"), "T1087.004 discovered in script contents.")
+```Concat fields of interest from events of interest```
+| eval Details=coalesce(CommandLine, CommandHistory, ScriptContent)
+```Format output into table```
+| table _time, ComputerName, aid, UserName, UserSid_readable, TargetProcessId_decimal, Description, Details
+```Add link to Graph Explorer```
+| eval GraphExplorer=case(TargetProcessId_decimal!="","https://falcon.crowdstrike.com/graphs/process-explorer/graph?id=pid:" .aid. ":" . TargetProcessId_decimal)
+```
+
+## Query 10
+```cql
+```Search for public cloud command line tool invocation```
+event_simpleName=ProcessRollup2 ("az" OR "aws" OR "gcloud")
+| regex CommandLine="(az\s+ad\s+user\s+list|aws\s+iam\s+list\-(roles|users)|gcloud\s+ (iam\s+service\-accounts\s+list|projects\s+get\-iam\-policy))"
+```Format output into table```
+| table _time, ComputerName, aid, UserName, UserSid_readable, TargetProcessId_decimal, FileName, CommandLine
+```Add link to Graph Explorer```
+| eval GraphExplorer=case(TargetProcessId_decimal!="","https://falcon.crowdstrike.com/graphs/process-explorer/graph?id=pid:" .aid. ":" . TargetProcessId_decimal)
+```

--- a/Queries-Only/Cool-Query-Friday/2023-11-17 - Cool Query Friday - ATT&CK Edition T1010.md
+++ b/Queries-Only/Cool-Query-Friday/2023-11-17 - Cool Query Friday - ATT&CK Edition T1010.md
@@ -1,0 +1,81 @@
+---
+title: "ATT&CK Edition: T1010"
+date: 2023-11-17
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/17xa6vm/20231117_cool_query_friday_attck_edition_t1010/"
+mitre: [T1010, T1087, T1087.001, T1087.002, T1087.003, T1087.004]
+series: Cool Query Friday
+---
+
+# ATT&CK Edition: T1010
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/17xa6vm/20231117_cool_query_friday_attck_edition_t1010/](https://www.reddit.com/r/crowdstrike/comments/17xa6vm/20231117_cool_query_friday_attck_edition_t1010/) — by Andrew-CS (CrowdStrike) — 2023-11-17
+
+Welcome to our sixty-eighth installment of Cool Query Friday. The format will be: (1) description of what we're doing (2) walk through of each step (3) application in the wild.
+
+## Query 1
+```cql
+| eval Description=case(match(event_simpleName,"ProcessRollup2"), "T1010 discovered in command line invocation.", match(event_simpleName,"CommandHistory"), "T1010 discovered in command line history.", match(event_simpleName,"ScriptControl.*"), "T1010 discovered in script contents.")
+```
+
+## Query 2
+```cql
+| eval Details=coalesce(CommandLine, CommandHistory, ScriptContent)
+```
+
+## Query 3
+```cql
+| eval falconPID=coalesce(TargetProcessId_decimal, ContextProcessId_decimal)
+```
+
+## Query 4
+```cql
+| table _time, ComputerName, aid, UserName, UserSid_readable, falconPID, Description, Details
+```
+
+## Query 5
+```cql
+// Get events of interest where enumeration APIs may be called in scope for T1010.
+#event_simpleName=/^(ProcessRollup2$|CommandHistory$|ScriptControl)/ event_platform=Win /(mainWindowTitle|Get-Process|GetForegroundWindow|GetProcesses)/i
+
+// Concatenate fields of interest from events of interest
+| Details:=concat([CommandHistory,CommandLine,ScriptContent])
+
+// Create "Description" field based on location of target string
+| case {
+#event_simpleName=CommandHistory | Description:="T1010 discovered in command line history.";
+#event_simpleName=ProcessRollup2 | Description:="T1010 discovered in command line invocation.";
+#event_simpleName=/^ScriptControl/ | Description:="T1010 discovered in script contents.";
+* | Description:="T1010 discovered in general event telemetry.";
+}
+
+// Normalize UPID
+| falconPID:=TargetProcessId | falconPID:=ContextProcessId
+
+// Format output to table
+| select([@timestamp, ComputerName, aid, UserName, UserSid, falconPID, Description, Details])
+
+// Add link to Graph Explorer
+| format("[Graph Explorer](https://falcon.crowdstrike.com/graphs/process-explorer/graph?id=pid:%s:%s)", field=["aid", "falconPID"], as="Graph Explorer")
+```
+
+## Query 6
+```cql
+```Get events of interest where enumeration APIs may be called in scope for T1010```
+event_simpleName IN (ProcessRollup2, CommandHistory, ScriptControl*) event_platform=Win ("mainWindowTitle" OR "Get-Process" OR "GetForegroundWindow" OR "GetProcesses")
+
+```Create "Description" field based on location of target string```
+| eval Description=case(match(event_simpleName,"ProcessRollup2"), "T1010 discovered in command line invocation.", match(event_simpleName,"CommandHistory"), "T1010 discovered in command line history.", match(event_simpleName,"ScriptControl.*"), "T1010 discovered in script contents.")
+
+```Concat fields of interest from events of interest```
+| eval Details=coalesce(CommandLine, CommandHistory, ScriptContent)
+
+```Normalize UPID```
+| eval falconPID=coalesce(TargetProcessId_decimal, ContextProcessId_decimal)
+
+```Format output into table```
+| table _time, ComputerName, aid, UserName, UserSid_readable, falconPID, Description, Details
+
+```Add link to Graph Explorer```
+| eval GraphExplorer=case(TargetProcessId_decimal!="","https://falcon.crowdstrike.com/graphs/process-explorer/graph?id=pid:" .aid. ":" . falconPID)
+```

--- a/Queries-Only/Cool-Query-Friday/2023-12-01 - Cool Query Friday - ATT&CK Edition T1217.md
+++ b/Queries-Only/Cool-Query-Friday/2023-12-01 - Cool Query Friday - ATT&CK Edition T1217.md
@@ -1,0 +1,130 @@
+---
+title: "ATT&CK Edition: T1217"
+date: 2023-12-01
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/188e5ci/20231201_cool_query_friday_attck_edition_t1217/"
+mitre: [T1010, T1087, T1087.001, T1087.002, T1087.003, T1087.004, T1217]
+series: Cool Query Friday
+---
+
+# ATT&CK Edition: T1217
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/188e5ci/20231201_cool_query_friday_attck_edition_t1217/](https://www.reddit.com/r/crowdstrike/comments/188e5ci/20231201_cool_query_friday_attck_edition_t1217/) — by Andrew-CS (CrowdStrike) — 2023-12-01
+
+Welcome to our sixty-ninth (not saying a word) installment of Cool Query Friday. The format will be: (1) description of what we're doing (2) walk through of each step (3) application in the wild.
+
+## Query 1
+```cql
+| eval BrowserTarget=case(match(Details,"(?i).*\\\\AppData\\\\Local\\\\Google\\\\Chrome\\\\User\sData\\\\Default.*"), "Windows - Google Chrome", match(Details,"(?i).*\/Users\/.+\/Library\/Application\sSupport\/Google\/Chrome\/Default.*"), "macOS - Google Chrome", match(Details,"(?i).*\/home\/.+\/\.config\/google\-chrome\/Default.*"), "Linux - Google Chrome")
+```
+
+## Query 2
+```cql
+| eval Location=case(match(event_simpleName,"ProcessRollup2"), "Process Execution - Command Line", match(event_simpleName,"CommandHistory"), "Process Execution - Command History", match(event_simpleName,"^ScriptControl.*"), "Script - Script Contents")
+```
+
+## Query 3
+```cql
+| eval ShortDetails=substr(Details,1,100)
+```
+
+## Query 4
+```cql
+| stats dc(aid) as UniqueEndpoints, count(aid) as ExecutionCount, last(aid) as aid, last(falconPID) as falconPID by event_platform, BrowserTarget, Location, ShortDetails
+```
+
+## Query 5
+```cql
+| where UniqueEndpoints < 50
+```
+
+## Query 6
+```cql
+| eval LastExecution=case(falconPID!="","https://falcon.crowdstrike.com/graphs/process-explorer/graph?id=pid:" .aid. ":" . falconPID)
+```
+
+## Query 7
+```cql
+// Get events of interest for T1217
+#event_simpleName=/^(ProcessRollup2|CommandHistory|ScriptControl)/
+
+// Omit events where the browser is the executing process
+| FileName!="chrome*"
+
+// Normalize details field
+| Details:=concat([CommandLine, CommandHistory,ScriptContent])
+
+// Further narrow events with brute force search against Details field
+| Details=/chrome/i
+
+// Normalize Falcon UPID value
+| falconPID:=TargetProcessId | falconPID:=ContextProcessId
+
+// Check to see which operating system is being targeted
+| case {
+   Details=/\\AppData\\Local\\Google\\Chrome\\User\sData\\Default/i                | BrowserTarget:="Windows - Google Chrome";
+   Details=/\/Users\/\S+\/Library\/Application\sSupport\/Google\/Chrome\/Default/i | BrowserTarget:="macOS - Google Chrome";
+   Details=/\/home\/\S+\/\.config\/google\-chrome\/Default\//i                     | BrowserTarget:="Linux - Google Chrome"; 
+}
+
+// Check to see where targeting is found
+| case {
+   #event_simpleName=ProcessRollup2   | Location:="Process Execution - Command Line";
+   #event_simpleName=CommandHistory   | Location:="Process Execution - Command History";
+   #event_simpleName=/^ScriptControl/ | Location:="Script - Script Contents"; 
+}
+
+// Calculate hash for details field for use in groupBy statement
+| DetailsHash:=hash(field=Details)
+
+// Created shortened Details field of 100 characters to improve readability
+| ShortDetails:=format("%,.100s", field=Details)
+
+//Aggregate results
+| groupBy([event_platform, BrowserTarget, Location, DetailsHash, ShortDetails], function=([count(aid, distinct=true, as=UniqueEndpoints), count(aid, as=ExecutionCount), selectFromMax(field="@timestamp", include=[aid, falconPID])]))
+
+// Set threshold to look for results that have occurred on fewer than 50 unique endpoints; adjust up or down as desired
+| test(UniqueEndpoints<50)
+
+// Add link to Graph Explorer
+| format("[Last Execution](https://falcon.crowdstrike.com/graphs/process-explorer/graph?id=pid:%s:%s)", field=["aid", "falconPID"], as="Graph Explorer")
+
+// Drop unneeded fields
+| drop([aid, DetailsHash, falconPID])
+```
+
+## Query 8
+```cql
+```Get events of interest for T1217```
+event_simpleName IN (ProcessRollup2, CommandHistory, ScriptControl*) "chrome"
+
+```Normalize details field``` 
+| eval Details=coalesce(CommandLine, CommandHistory,ScriptContent)
+
+```Further narrow events with brute force search against Details field``` 
+| search Details="*chrome*"
+
+```Normalize Falcon UPID value``` 
+| eval falconPID=coalesce(ContextProcessId_decimal, TargetProcessId_decimal) 
+
+```Check to see which operating system Chrome is being targeted```
+| eval BrowserTarget=case(match(Details,"(?i).*\\\\AppData\\\\Local\\\\Google\\\\Chrome\\\\User\sData\\\\Default.*"), "Windows - Google Chrome", match(Details,"(?i).*\/Users\/.+\/Library\/Application\sSupport\/Google\/Chrome\/Default.*"), "macOS - Google Chrome", match(Details,"(?i).*\/home\/.+\/\.config\/google\-chrome\/Default.*"), "Linux - Google Chrome")
+
+```Check to see where targeting is found```
+| eval Location=case(match(event_simpleName,"ProcessRollup2"), "Process Execution - Command Line", match(event_simpleName,"CommandHistory"), "Process Execution - Command History", match(event_simpleName,"^ScriptControl.*"), "Script - Script Contents")
+
+```Created shortened Details field of 100 characters to improve readability```
+| eval ShortDetails=substr(Details,1,100)
+
+```Aggregate results```
+| stats dc(aid) as UniqueEndpoints, count(aid) as ExecutionCount, last(aid) as aid, last(falconPID) as falconPID by event_platform, BrowserTarget, Location, ShortDetails
+
+```Set threshold to look for results that have occurred on fewer than 50 unique endpoints; adjust up or down as desired```
+| where UniqueEndpoints < 50
+
+```Add link to Graph Explorer```
+| eval LastExecution=case(falconPID!="","https://falcon.crowdstrike.com/graphs/process-explorer/graph?id=pid:" .aid. ":" . falconPID) 
+
+```Output to table```
+| table event_platform, BrowserTarget, Location, ShortDetails, UniqueEndpoints, ExecutionCount, LastExecution
+```

--- a/Queries-Only/Cool-Query-Friday/2023-12-08 - Cool Query Friday - ATT&CK Edition T1580.md
+++ b/Queries-Only/Cool-Query-Friday/2023-12-08 - Cool Query Friday - ATT&CK Edition T1580.md
@@ -1,0 +1,114 @@
+---
+title: "ATT&CK Edition: T1580"
+date: 2023-12-08
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/18dnavb/20231208_cool_query_friday_attck_edition_t1580/"
+mitre: [T1010, T1087, T1087.001, T1087.002, T1087.003, T1087.004, T1217, T1580]
+series: Cool Query Friday
+---
+
+# ATT&CK Edition: T1580
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/18dnavb/20231208_cool_query_friday_attck_edition_t1580/](https://www.reddit.com/r/crowdstrike/comments/18dnavb/20231208_cool_query_friday_attck_edition_t1580/) — by Andrew-CS (CrowdStrike) — 2023-12-08
+
+Welcome to our seventieth installment of Cool Query Friday. The format will be: (1) description of what we're doing (2) walk through of each step (3) application in the wild.
+
+## Query 1
+```cql
+| eval Cloud=case(match(Details,"(?i).*(DescribeInstances|ListBuckets|HeadBucket|GetPublicAccessBlock|DescribeDBInstances).*"), "AWS", match(Details,"(?i).*gcloud\s+.*"), "GCP", match(Details,"(?i)az\s+.*"), "Azure")
+```
+
+## Query 2
+```cql
+| eval CommandDetails=substr(Details,1,200)
+```
+
+## Query 3
+```cql
+| rex field=Details ".*(?<Command>(DescribeInstances|ListBuckets|HeadBucket|GetPublicAccessBlock|DescribeDBInstances|gcloud\s+|az\s+).*)"
+```
+
+## Query 4
+```cql
+| stats values(Command) as Command, values(CommandDetails) as CommandDetails, dc(aid) as UniqueEndpoints, count(aid) as ExecutionCount, last(aid) as aid, last(falconPID) as falconPID by Details, Cloud, event_simpleName
+```
+
+## Query 5
+```cql
+| where UniqueEndpoints < 50
+```
+
+## Query 6
+```cql
+| eval LastExecution=case(falconPID!="","https://falcon.crowdstrike.com/graphs/process-explorer/graph?id=pid:" .aid. ":" . falconPID)
+```
+
+## Query 7
+```cql
+// Get events of interest for T1580
+(#event_simpleName=/^(ProcessRollup2|CommandHistory|ScriptControl)/ /(DescribeInstances|ListBuckets|HeadBucket|GetPublicAccessBlock|DescribeDBInstances)/i) OR (#event_simpleName=/^(ProcessRollup2|CommandHistory|ScriptControl)/ /(gcloud\s+compute\s+instances\s+list)/i) OR (#event_simpleName=/^(ProcessRollup2|CommandHistory|ScriptControl)/ /(az\s+vm\s+list)/i)
+
+// Normalize details field
+| Details:=concat([CommandLine, CommandHistory,ScriptContent])
+
+// Created shortened Details field of 100 characters to improve readability
+| CommandDetails:=format("%,.200s", field=Details)
+
+// Normalize Falcon UPID value
+| falconPID:=TargetProcessId | falconPID:=ContextProcessId
+
+// Check cloud provider
+| case {
+    Details=/(DescribeInstances|ListBuckets|HeadBucket|GetPublicAccessBlock|DescribeDBInstances)/i | Cloud:="AWS";
+    Details=/gcloud\s+/i | Cloud:="GCP";
+    Details=/az\s+/i | Cloud:="Azure";
+}
+
+// Get API or command line program
+| regex("(?<Command>(DescribeInstances|ListBuckets|HeadBucket|GetPublicAccessBlock|DescribeDBInstances|gcloud\s+|az\s+))", field=Details, strict=false)
+
+// Organize output
+| groupBy([Details, Cloud, #event_simpleName], function=([collect([Command, CommandDetails]), count(aid, distinct=true, as=UniqueEndpoints), count(aid, as=ExecutionCount), selectFromMax(field="@timestamp", include=[aid, falconPID])]))
+
+// Set threshold
+| test(ExecutionCount<10)
+
+// Dispaly link for Graph Explorer for last execution
+| format("[Last Execution](https://falcon.crowdstrike.com/graphs/process-explorer/graph?id=pid:%s:%s)", field=["aid", "falconPID"], as="Graph Explorer")
+
+// Drop unneeded fields
+| drop([Details, aid, falconPID])
+```
+
+## Query 8
+```cql
+```Get events of interest for T1580```
+(event_simpleName IN (ProcessRollup2,CommandHistory,ScriptControl*) AND ("DescribeInstances" OR "ListBuckets" OR "HeadBucket" OR "GetPublicAccessBlock" OR "DescribeDBInstances")) OR (event_simpleName IN (ProcessRollup2,CommandHistory,ScriptControl*) ("gcloud" AND "instances" AND "list")) OR (event_simpleName IN (ProcessRollup2,CommandHistory,ScriptControl*) ("az" AND "vm" AND "list"))
+
+```Normalize details field``` 
+| eval Details=coalesce(CommandLine, CommandHistory,ScriptContent)
+
+```Normalize Falcon UPID value``` 
+| eval falconPID=coalesce(ContextProcessId_decimal, TargetProcessId_decimal) 
+
+```Check cloud provider```
+| eval Cloud=case(match(Details,"(?i).*(DescribeInstances|ListBuckets|HeadBucket|GetPublicAccessBlock|DescribeDBInstances).*"), "AWS", match(Details,"(?i).*gcloud\s+.*"), "GCP", match(Details,"(?i)az\s+.*"), "Azure")
+
+```Created shortened Details field of 200 characters to improve readability```
+| eval CommandDetails=substr(Details,1,200)
+
+```Get command or API used```
+| rex field=Details ".*(?<Command>(DescribeInstances|ListBuckets|HeadBucket|GetPublicAccessBlock|DescribeDBInstances|gcloud\s+|az\s+).*)"
+
+```Aggregate results```
+| stats values(Command) as Command, values(CommandDetails) as CommandDetails, dc(aid) as UniqueEndpoints, count(aid) as ExecutionCount, last(aid) as aid, last(falconPID) as falconPID by Details, Cloud, event_simpleName
+
+```Set threshold to look for results that have occurred on fewer than 50 unique endpoints; adjust up or down as desired```
+| where UniqueEndpoints < 50
+
+```Add link to Graph Explorer```
+| eval LastExecution=case(falconPID!="","https://falcon.crowdstrike.com/graphs/process-explorer/graph?id=pid:" .aid. ":" . falconPID) 
+
+``` Organize output to table```
+|  table Cloud, event_simpleName, Command, CommandDetails, UniqueEndpoints, ExecutionCount, LastExecution
+```

--- a/Queries-Only/Cool-Query-Friday/2023-12-22 - Cool Query Friday - New Feature in Raptor Falcon Helper.md
+++ b/Queries-Only/Cool-Query-Friday/2023-12-22 - Cool Query Friday - New Feature in Raptor Falcon Helper.md
@@ -1,0 +1,61 @@
+---
+title: "New Feature in Raptor: Falcon Helper"
+date: 2023-12-22
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/18off35/20231222_cool_query_friday_new_feature_in_raptor/"
+mitre: []
+series: Cool Query Friday
+---
+
+# New Feature in Raptor: Falcon Helper
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/18off35/20231222_cool_query_friday_new_feature_in_raptor/](https://www.reddit.com/r/crowdstrike/comments/18off35/20231222_cool_query_friday_new_feature_in_raptor/) — by Andrew-CS (CrowdStrike) — 2023-12-22
+
+Welcome to our seventy-first installment of Cool Query Friday. The format will be: (1) description of what we're doing (2) walk through of each step (3) application in the wild.
+
+## Query 1
+```cql
+#event_simpleName=UserLogon
+| case {
+        LogonType = "2"  | LogonType := "Interactive" ;
+        LogonType = "3"  | LogonType := "Network" ;
+        LogonType = "4"  | LogonType := "Batch" ;
+        LogonType = "5"  | LogonType := "Service" ;
+        LogonType = "6"  | LogonType := "Proxy" ;
+        LogonType = "7"  | LogonType := "Unlock" ;
+        LogonType = "8"  | LogonType := "Network Cleartext" ;
+        LogonType = "9"  | LogonType := "New Credential" ;
+        LogonType = "10" | LogonType := "Remote Interactive" ;
+        LogonType = "11" | LogonType := "Cached Interactive" ;
+        LogonType = "12" | LogonType := "Cached Remote Interactive" ;
+        LogonType = "13" | LogonType := "Cached Unlock" ; 
+        * }
+| table([@timestamp, aid, ComputerName, UserName, LogonType])
+```
+
+## Query 2
+```cql
+#event_simpleName=UserLogon
+| $falcon/helper:enrich(field=LogonType)
+| table([@timestamp, aid, ComputerName, UserName, LogonType])
+```
+
+## Query 3
+```cql
+| $falcon/helper:enrich(field=FIELD)
+```
+
+## Query 4
+```cql
+#event_simpleName=ProcessRollup2 event_platform=Win
+| select([@timestamp, aid, ComputerName, FileName, UserName, UserSid, TokenType, IntegrityLevel, ImageSubsystem])
+```
+
+## Query 5
+```cql
+#event_simpleName=ProcessRollup2 event_platform=Win
+| select([@timestamp, aid, ComputerName, FileName, UserName, UserSid, TokenType, IntegrityLevel, ImageSubsystem])
+| $falcon/helper:enrich(field=IntegrityLevel)
+| $falcon/helper:enrich(field=TokenType)
+| $falcon/helper:enrich(field=ImageSubsystem)
+```

--- a/Queries-Only/Cool-Query-Friday/2023-12-22 - Cool Query Friday - New Feature in Raptor Falcon Helper.md
+++ b/Queries-Only/Cool-Query-Friday/2023-12-22 - Cool Query Friday - New Feature in Raptor Falcon Helper.md
@@ -59,3 +59,107 @@ Welcome to our seventy-first installment of Cool Query Friday. The format will b
 | $falcon/helper:enrich(field=TokenType)
 | $falcon/helper:enrich(field=ImageSubsystem)
 ```
+
+## Community & Staff Additions
+*Harvested from this post's [r/CrowdStrike](https://www.reddit.com/r/crowdstrike/) comment thread — not part of the original CQF post. **[CS]** = CrowdStrike staff · **[Community]** = other r/CrowdStrike users. Upvote scores shown for context.*
+
+### Query variants
+
+```cql
+#event_simpleName=UserLogon
+| $falcon/helper:enrich(field=LogonType)
+| table([@timestamp, aid, ComputerName, UserName, LogonType], limit=20000)
+```
+— [CS] Andrew-CS · comment score 2
+
+```cql
+| readFile("falcon/helper/mappings.csv")
+| groupBy([Event])
+```
+— [CS] Andrew-CS · comment score 2
+
+```cql
+| _1 := ?field
+| format("%s_%s", field=[_1, ?field], as=_3)
+| match(field=_3, column=Key, include=[KeyValue], strict=false, file="mappings.csv")
+| rename(KeyValue, as=?field)
+| drop([_1, _2, _3, KeyValue])
+```
+— [CS] Andrew-CS · comment score 3
+
+```cql
+| $helper(field=LogonType)
+```
+— [CS] Andrew-CS · comment score 3
+
+```cql
+#event_simpleName=UserLogon LogonType=/^(2|10)$/
+| tail(10)
+| $helper(field=LogonType)
+| $helper(field=UserIsAdmin)
+| table([@timestamp, aid, ComputerName, UserName, UserIsAdmin, LogonType])
+```
+— [CS] Andrew-CS · comment score 3
+
+```cql
+| rootURL := "https://falcon.crowdstrike.com/"
+| format("[Graph Explorer](%sgraphs/process-explorer/graph?id=pid:%s:%s)", field=["rootURL", "aid", "TargetProcessId"], as="Graph Explorer")
+```
+— [CS] Andrew-CS · comment score 2
+
+```cql
+#event_simpleName=ProcessRollup2 
+| tail(10)
+| rootURL := "https://falcon.crowdstrike.com/"
+| format("[Graph Explorer](%sgraphs/process-explorer/graph?id=pid:%s:%s)", field=["rootURL",
+"aid", "TargetProcessId"], as="Graph Explorer") 
+| select([aid, ComputerName, FileName, "Graph Explorer"])
+```
+— [CS] Andrew-CS · comment score 2
+
+```cql
+#event_simpleName=ProcessRollup2 
+| tail(10)
+| select([aid, ComputerName, FileName])
+| rootURL := "https://falcon.crowdstrike.com/"
+| format("[Graph Explorer](%sgraphs/process-explorer/graph?id=pid:%s:%s)", field=["rootURL", "aid", "TargetProcessId"], as="Graph Explorer")
+```
+— [CS] Andrew-CS · comment score 2
+
+```cql
+#event_simpleName=DnsRequest 
+| tail(10)
+| rootURL := "https://falcon.crowdstrike.com/"
+| format("[Graph Explorer](%sgraphs/process-explorer/graph?id=pid:%s:%s)", field=["rootURL", "aid", "ContextProcessId"], as="Graph Explorer") 
+| select([aid, ComputerName, ContextBaseFileName, DomainName, "Graph Explorer"])
+```
+— [CS] Andrew-CS · comment score 2
+
+```cql
+| join({#data_source_name=cid_name | groupBy([cid], function=selectFromMax(field="@timestamp", include=[name]))}, field=cid, include=name, mode=left)
+```
+— [CS] Andrew-CS · comment score 2
+
+```cql
+#event_simpleName=ProcessRollup2
+| tail(1)
+| table([cid, aid, ComputerName, FileName, CommandLine])
+| $getCID()
+```
+— [CS] Andrew-CS · comment score 2
+
+```cql
+#data_source_name=*
+| groupBy(#data_source_name)
+```
+— [CS] Andrew-CS · comment score 1
+
+### Q&A
+
+**Q — [Community] vim_enthusiast:** If you ingest Falcon data to your own on-prem/cloud Splunk is it possible to install Falcon Helper somewhere?
+
+**A — [CS] Andrew-CS:** Hi there. There is not. I don't know of a way to recreate this using SpQL based on how that query language works.
+
+**Q — [Community] AlphaDomain:** Yup that worked and this is totally awesome and helpful. One more question as I am still a newbie, how would I throw in a limit=max. I am having trouble getting past the 200 elements by default limit when I remove the tail function.
+
+**A — [CS] Andrew-CS:** | table([@timestamp, aid, ComputerName, UserName, UserIsAdmin, LogonType], limit=20000) That should do it!

--- a/Queries-Only/Cool-Query-Friday/2024-01-19 - Cool Query Friday - Raptor + AID Master.md
+++ b/Queries-Only/Cool-Query-Friday/2024-01-19 - Cool Query Friday - Raptor + AID Master.md
@@ -1,0 +1,104 @@
+---
+title: "Raptor + AID Master"
+date: 2024-01-19
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/19akavg/20240119_cool_query_friday_raptor_aid_master/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Raptor + AID Master
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/19akavg/20240119_cool_query_friday_raptor_aid_master/](https://www.reddit.com/r/crowdstrike/comments/19akavg/20240119_cool_query_friday_raptor_aid_master/) — by Andrew-CS (CrowdStrike) — 2024-01-19
+
+Welcome to our seventy-second installment of Cool Query Friday. The format will be: (1) description of what we're doing (2) walk through of each step (3) application in the wild.
+
+## Query 1
+```cql
+| inputlookup aid_master
+```
+
+## Query 2
+```cql
+event_simpleName=ProcessRollup2
+| head 5
+| table aid, ComputerName, UserName, FileName
+| lookup local=true aid_master aid OUTPUT Version
+```
+
+## Query 3
+```cql
+// Enter aid_master repository
+#repo=sensor_metadata #data_source_name=aidmaster
+
+// Fill blank FalconGroupingTags fields with a dash
+| default(value="-", field=[FalconGroupingTags], replaceEmpty=true)
+
+// For every aid, output the latest values for ComputerName, Version, AgentVersion, FalconGroupingTags
+| groupBy([aid], function=([selectFromMax(field="@timestamp", include=[ComputerName, Version, AgentVersion, FalconGroupingTags])]))
+```
+
+## Query 4
+```cql
+// Enter aid_master repository for Windows systems
+#repo=sensor_metadata #data_source_name=aidmaster event_platform=Win
+
+// For every aid, output the latest values for event_platform, Version
+| groupBy([aid], function=([selectFromMax(field="@timestamp", include=[Version])]))
+
+// Aggregate for chart creation
+| groupBy([Version])
+```
+
+## Query 5
+```cql
+#event_simpleName=ProcessRollup2 
+| tail(5)
+| table([aid, ComputerName, UserName, FileName])
+| join(query={#repo=sensor_metadata #data_source_name=aidmaster | groupBy([aid], function=([selectFromMax(field="@timestamp", include=[Version])]))
+}, field=[aid], include=[Version])
+```
+
+## Query 6
+```cql
+| join(query={#repo=sensor_metadata #data_source_name=aidmaster | groupBy([aid], function=([selectFromMax(field="@timestamp", include=[Version])]))
+}, field=[aid], include=[Version])
+```
+
+## Query 7
+```cql
+#event_simpleName=ProcessRollup2
+| tail(5)
+| table([aid, ComputerName, UserName, FileName])
+| join(query={#repo=sensor_metadata #data_source_name=aidmaster | groupBy([aid], function=([selectFromMax(field="@timestamp", include=[AgentVersion, Version, FirstSeen, Time])]))
+}, field=[aid], include=[AgentVersion, Version, FirstSeen, Time])
+| FirstSeen:=FirstSeen*1000 | FirstSeen:=formatTime(format="%F %T", field="FirstSeen")
+| rename(field="Time", as="LastSeen")
+```
+
+## Query 8
+```cql
+| join(query={#repo=sensor_metadata #data_source_name=aidmaster | groupBy([aid], function=([selectFromMax(field="@timestamp", include=[AgentVersion, Version, FirstSeen, Time])]))
+}, field=[aid], include=[AgentVersion, Version, FirstSeen, Time])
+```
+
+## Query 9
+```cql
+#repo=sensor_metadata #data_source_name=aidmaster event_platform=Win
+| groupBy([aid], function=([selectFromMax(field="@timestamp", include=[AgentVersion, @timestamp])]))
+| timeChart(AgentVersion, function=count(aid),span=1d, limit=10)
+```
+
+## Query 10
+```cql
+#repo=sensor_metadata #data_source_name=aidmaster event_platform=Lin
+| groupBy([aid], function=([selectFromMax(field="@timestamp", include=[Version])]))
+| groupBy([Version])
+```
+
+## Query 11
+```cql
+#repo=sensor_metadata #data_source_name=aidmaster FalconGroupingTags!=""
+| groupBy([aid], function=([selectFromMax(field="@timestamp", include=[ComputerName]), collect([FalconGroupingTags], multival=false)]))
+| sankey(source="ComputerName", target="FalconGroupingTags", weight=count(aid))
+```

--- a/Queries-Only/Cool-Query-Friday/2024-01-19 - Cool Query Friday - Raptor + AID Master.md
+++ b/Queries-Only/Cool-Query-Friday/2024-01-19 - Cool Query Friday - Raptor + AID Master.md
@@ -102,3 +102,32 @@ event_simpleName=ProcessRollup2
 | groupBy([aid], function=([selectFromMax(field="@timestamp", include=[ComputerName]), collect([FalconGroupingTags], multival=false)]))
 | sankey(source="ComputerName", target="FalconGroupingTags", weight=count(aid))
 ```
+
+## Community & Staff Additions
+*Harvested from this post's [r/CrowdStrike](https://www.reddit.com/r/crowdstrike/) comment thread — not part of the original CQF post. **[CS]** = CrowdStrike staff · **[Community]** = other r/CrowdStrike users. Upvote scores shown for context.*
+
+### Query variants
+
+```cql
+//| in(name, values=[NeighborListIP4V2, NeighborListIP4MacV1])
+```
+— [CS] Andrew-CS · comment score 1
+
+```cql
+| $falcon/investigate:not_managed()
+```
+— [CS] Andrew-CS · comment score 1
+
+```cql
+#repo=base_sensor #event_simpleName=ImageHash FileName=cellulardatacapabilityhandler.dll
+| join(query={#repo=sensor_metadata #data_source_name=aidmaster 
+| groupBy([aid], function=selectLast(AgentVersion), limit=max)} , field=[aid], include=[AgentVersion]) 
+| table(fields=["aid","AgentVersion","FileName"])
+```
+— [CS] Andrew-CS · comment score 1
+
+### Q&A
+
+**Q — [Community] 65c0aedb:** How do you enrich events with `ComputerName` based on `aid` when you have more than 100000 hosts in `aid_master` ? Here my `groupBy` are yielding all sorts of warnings about chopped data, and a random number of `ComputerName` get outputted each time, usually 0 or 1. I sorted out my situation by pick …
+
+**A — [CS] Andrew-CS:** You would want to override the default `groupBy` limit. #repo=base_sensor #event_simpleName=ImageHash FileName=cellulardatacapabilityhandler.dll | join(query={#repo=sensor_metadata #data_source_name=aidmaster | groupBy([aid], function=selectLast(AgentVersion), limit=max)} , field=[aid], include=[AgentVersion]) | table(fields=["aid","AgentVersion","FileName"])

--- a/Queries-Only/Cool-Query-Friday/2024-02-02 - Cool Query Friday - Size and case Statements.md
+++ b/Queries-Only/Cool-Query-Friday/2024-02-02 - Cool Query Friday - Size and case Statements.md
@@ -114,3 +114,27 @@ Welcome to our seventy-third installment of Cool Query Friday. The format will b
 | groupBy([aid, ComputerName], function=([count(aid, as=TotalWrites), sum(Size, as=TotalWritten), collect([ShortFile])]), limit=max)
 | sort(order=desc, TotalWritten, limit=200)
 ```
+
+## Community & Staff Additions
+*Harvested from this post's [r/CrowdStrike](https://www.reddit.com/r/crowdstrike/) comment thread — not part of the original CQF post. **[CS]** = CrowdStrike staff · **[Community]** = other r/CrowdStrike users. Upvote scores shown for context.*
+
+### Query variants
+
+```cql
+#event_simpleName=ProcessRollup2
+| in(field="FileName", values=["CMD.EXE"], ignoreCase=true)
+| groupBy([FileName])
+```
+— [CS] Andrew-CS · comment score 1
+
+```cql
+#event_simpleName=ProcessRollup2 FileName=/^CMD\.EXE$/i
+| groupBy([FileName])
+```
+— [CS] Andrew-CS · comment score 1
+
+### Q&A
+
+**Q — [Community] williebones:** Is there a way to make an entire search case insensitive? If not maybe specifically a in() function?
+
+**A — [CS] Andrew-CS:** Hi there. There sure is. You can use `in` or regex. Example for `in`: #event_simpleName=ProcessRollup2 | in(field="FileName", values=["CMD.EXE"], ignoreCase=true) | groupBy([FileName]) Example using regex: #event_simpleName=ProcessRollup2 FileName=/^CMD\.EXE$/i | groupBy([FileName]) I hope that helps!

--- a/Queries-Only/Cool-Query-Friday/2024-02-02 - Cool Query Friday - Size and case Statements.md
+++ b/Queries-Only/Cool-Query-Friday/2024-02-02 - Cool Query Friday - Size and case Statements.md
@@ -1,0 +1,116 @@
+---
+title: "Size and case Statements"
+date: 2024-02-02
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/1ah8sn1/20240202_cool_query_friday_size_and_case/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Size and case Statements
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/1ah8sn1/20240202_cool_query_friday_size_and_case/](https://www.reddit.com/r/crowdstrike/comments/1ah8sn1/20240202_cool_query_friday_size_and_case/) — by Andrew-CS (CrowdStrike) — 2024-02-02
+
+Welcome to our seventy-third installment of Cool Query Friday. The format will be: (1) description of what we're doing (2) walk through of each step (3) application in the wild.
+
+## Query 1
+```cql
+#event_simpleName=/FileWritten$/ FilePath=/(\\|\/)Downloads(\\|\/)/
+```
+
+## Query 2
+```cql
+| case {
+    Size<1024 | SizeCommon:=format("%,.2f Bytes",field=["Size"]);
+    *;
+}
+```
+
+## Query 3
+```cql
+| case {
+    Size>=1024 | SizeCommon:=unit:convert(Size, to=k) | format("%,.2f KB",field=["SizeCommon"], as="SizeCommon");
+    Size<1024 | SizeCommon:=format("%,.2f Bytes",field=["Size"]);
+    *;
+}
+```
+
+## Query 4
+```cql
+| case {
+    Size>=1048576| SizeCommon:=unit:convert(Size, to=M) | format("%,.2f MB",field=["SizeCommon"], as="SizeCommon");
+    Size>=1024 | SizeCommon:=unit:convert(Size, to=k) | format("%,.2f KB",field=["SizeCommon"], as="SizeCommon");
+    Size<1024 | SizeCommon:=format("%,.2f Bytes",field=["Size"]);
+    *;
+}
+```
+
+## Query 5
+```cql
+| case {
+    Size>=1073741824 | SizeCommon:=unit:convert(Size, to=G) | format("%,.2f GB",field=["SizeCommon"], as="SizeCommon");
+    Size>=1048576| SizeCommon:=unit:convert(Size, to=M) | format("%,.2f MB",field=["SizeCommon"], as="SizeCommon");
+    Size>=1024 | SizeCommon:=unit:convert(Size, to=k) | format("%,.2f KB",field=["SizeCommon"], as="SizeCommon");
+    Size<1024 | SizeCommon:=format("%,.2f Bytes",field=["Size"]);
+    *;
+}
+```
+
+## Query 6
+```cql
+| case {
+    Size>=1099511627776 | SizeCommon:=unit:convert(SumSize, to=T) | format("%,.2f TB",field=["SizeCommon"], as="SizeCommon");
+    Size>=1073741824 | SizeCommon:=unit:convert(Size, to=G) | format("%,.2f GB",field=["SizeCommon"], as="SizeCommon");
+    Size>=1048576| SizeCommon:=unit:convert(Size, to=M) | format("%,.2f MB",field=["SizeCommon"], as="SizeCommon");
+    Size>=1024 | SizeCommon:=unit:convert(Size, to=k) | format("%,.2f KB",field=["SizeCommon"], as="SizeCommon");
+    Size<1024 | SizeCommon:=format("%,.2f Bytes",field=["Size"]);
+    *;
+}
+```
+
+## Query 7
+```cql
+#event_simpleName=/FileWritten$/ FilePath=/(\\|\/)Downloads(\\|\/)/
+| case {
+    Size>=1099511627776 | SizeCommon:=unit:convert(SumSize, to=T) | format("%,.2f TB",field=["SizeCommon"], as="SizeCommon");
+    Size>=1073741824 | SizeCommon:=unit:convert(Size, to=G) | format("%,.2f GB",field=["SizeCommon"], as="SizeCommon");
+    Size>=1048576| SizeCommon:=unit:convert(Size, to=M) | format("%,.2f MB",field=["SizeCommon"], as="SizeCommon");
+    Size>=1024 | SizeCommon:=unit:convert(Size, to=k) | format("%,.2f KB",field=["SizeCommon"], as="SizeCommon");
+    Size<1024 | SizeCommon:=format("%,.2f Bytes",field=["Size"]);
+    *;
+}
+| select([aid, ComputerName, FileName, Size, SizeCommon, FilePath])
+```
+
+## Query 8
+```cql
+| TargetFileName=/(\\Device\\HarddiskVolume\d+)?(?<ShortFile>.+$)/
+| ShortFile:=format(format="%s (%s)", field=[ShortFile, SizeCommon])
+```
+
+## Query 9
+```cql
+| groupBy([aid, ComputerName], function=([count(aid, as=TotalWrites), collect([ShortFile])]))
+```
+
+## Query 10
+```cql
+| groupBy([aid, ComputerName], function=([count(aid, as=TotalWrites), sum(Size, as=TotalWritten), collect([ShortFile])]))
+```
+
+## Query 11
+```cql
+#event_simpleName=/FileWritten$/ FilePath=/(\\|\/)Downloads(\\|\/)/
+| case {
+    Size>=1099511627776 | SizeCommon:=unit:convert(SumSize, to=T) | format("%,.2f TB",field=["SizeCommon"], as="SizeCommon");
+    Size>=1073741824 | SizeCommon:=unit:convert(Size, to=G) | format("%,.2f GB",field=["SizeCommon"], as="SizeCommon");
+    Size>=1048576| SizeCommon:=unit:convert(Size, to=M) | format("%,.2f MB",field=["SizeCommon"], as="SizeCommon");
+    Size>=1024 | SizeCommon:=unit:convert(Size, to=k) | format("%,.2f KB",field=["SizeCommon"], as="SizeCommon");
+    Size<1024 | SizeCommon:=format("%,.2f Bytes",field=["Size"]);
+    *;
+}
+| TargetFileName=/(\\Device\\HarddiskVolume\d+)?(?<ShortFile>.+$)/
+| ShortFile:=format(format="%s (%s)", field=[ShortFile, SizeCommon])
+| groupBy([aid, ComputerName], function=([count(aid, as=TotalWrites), sum(Size, as=TotalWritten), collect([ShortFile])]), limit=max)
+| sort(order=desc, TotalWritten, limit=200)
+```

--- a/Queries-Only/Cool-Query-Friday/2024-05-30 - Cool Query Friday - Auto-Enriching Alerts with Bespoke Raptor Queries and Fusion SOAR Workflows.md
+++ b/Queries-Only/Cool-Query-Friday/2024-05-30 - Cool Query Friday - Auto-Enriching Alerts with Bespoke Raptor Queries and Fusion SOAR Workflows.md
@@ -1,0 +1,60 @@
+---
+title: "Auto-Enriching Alerts with Bespoke Raptor Queries and Fusion SOAR Workflows"
+date: 2024-05-30
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/1d46szz/20240530_cool_query_friday_autoenriching_alerts/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Auto-Enriching Alerts with Bespoke Raptor Queries and Fusion SOAR Workflows
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/1d46szz/20240530_cool_query_friday_autoenriching_alerts/](https://www.reddit.com/r/crowdstrike/comments/1d46szz/20240530_cool_query_friday_autoenriching_alerts/) — by Andrew-CS (CrowdStrike) — 2024-05-30
+
+Welcome to our seventy-fourth installment of Cool Query Friday. The format will be: (1) description of what we're doing (2) walk through of each step (3) application in the wild.
+
+## Query 1
+```cql
+// Create parameter for Agent ID; Get AssociateIndicator Events and ProcessRollup2 Events
+aid=?aid (#event_simpleName=AssociateIndicator OR #event_simpleName=ProcessRollup2)
+// Use selfJoinFilter to join events
+| selfJoinFilter(field=[aid, TargetProcessId], where=[{#event_simpleName=AssociateIndicator}, {#event_simpleName=ProcessRollup2}])
+```
+
+## Query 2
+```cql
+// Create parameter for Agent ID; Get AssociateIndicator Events and ProcessRollup2 Events
+aid=?aid (#event_simpleName=AssociateIndicator OR #event_simpleName=ProcessRollup2)
+// Use selfJoinFilter to join events
+| selfJoinFilter(field=[aid, TargetProcessId], where=[{#event_simpleName=AssociateIndicator}, {#event_simpleName=ProcessRollup2}])
+// Create pretty process tree for ProcessRollup2 events
+| case {
+#event_simpleName="ProcessRollup2" | ExecutionChain:=format(format="%s → %s (%s)", field=[ParentBaseFileName, FileName, RawProcessId]);
+*;
+}
+// Use groupBy to aggregate
+| groupBy([aid, TargetProcessId], function=([count(aid, as=Occurrences), selectFromMin(field="@timestamp", include=[@timestamp]), collect([ComputerName, UserName, ExecutionChain, Tactic, Technique, DetectDescription, CommandLine])]))
+```
+
+## Query 3
+```cql
+// Create parameter for Agent ID; Get AssociateIndicator Events and ProcessRollup2 Events
+aid=?aid (#event_simpleName=AssociateIndicator OR #event_simpleName=ProcessRollup2)
+// Use selfJoinFilter to join events
+| selfJoinFilter(field=[aid, TargetProcessId], where=[{#event_simpleName=AssociateIndicator}, {#event_simpleName=ProcessRollup2}])
+// Create pretty process tree for ProcessRollup2 events
+| case {
+#event_simpleName="ProcessRollup2" | ExecutionChain:=format(format="%s → %s (%s)", field=[ParentBaseFileName, FileName, RawProcessId]);
+*;
+}
+// Use groupBy to aggregate
+| groupBy([aid, TargetProcessId], function=([count(aid, as=Occurrences), selectFromMin(field="@timestamp", include=[@timestamp]), collect([ComputerName, UserName, ExecutionChain, Tactic, Technique, DetectDescription, CommandLine])]))
+// Add Process Tree link to ease investigation; Uncomment your cloud
+| rootURL := "https://falcon.crowdstrike.com/" /* US-1 */
+//| rootURL  := "https://falcon.us-2.crowdstrike.com/" /* US-2 */
+//| rootURL  := "https://falcon.laggar.gcw.crowdstrike.com/" /* Gov */
+//| rootURL  := "https://falcon.eu-1.crowdstrike.com/"  /* EU */
+| format("[Process Explorer](%sgraphs/process-explorer/tree?id=pid:%s:%s)", field=["rootURL", "aid", "TargetProcessId"], as="Falcon")
+| drop([rootURL])
+| sort(@timestamp, order=desc, limit=20000)
+```

--- a/Queries-Only/Cool-Query-Friday/2024-05-30 - Cool Query Friday - Auto-Enriching Alerts with Bespoke Raptor Queries and Fusion SOAR Workflows.md
+++ b/Queries-Only/Cool-Query-Friday/2024-05-30 - Cool Query Friday - Auto-Enriching Alerts with Bespoke Raptor Queries and Fusion SOAR Workflows.md
@@ -58,3 +58,29 @@ aid=?aid (#event_simpleName=AssociateIndicator OR #event_simpleName=ProcessRollu
 | drop([rootURL])
 | sort(@timestamp, order=desc, limit=20000)
 ```
+
+## Community & Staff Additions
+*Harvested from this post's [r/CrowdStrike](https://www.reddit.com/r/crowdstrike/) comment thread — not part of the original CQF post. **[CS]** = CrowdStrike staff · **[Community]** = other r/CrowdStrike users. Upvote scores shown for context.*
+
+### Query variants
+
+```cql
+| groupBy([aid, TargetProcessId], function=([count(aid, as=Occurrences), selectFromMin(field="@timestamp", include=[@timestamp]), collect([ComputerName, UserName, ExecutionChain, Tactic, Technique, DetectDescription, CommandLine])]))
+```
+— [CS] Andrew-CS · comment score 2
+
+```cql
+| groupBy([aid, TargetProcessId], function=([count(aid, as=Occurrences), selectFromMin(field="@timestamp", include=[@timestamp]), collect([ComputerName, UserName, ExecutionChain, Tactic, Technique, DetectDescription, CommandLine])]), limit=max)
+```
+— [CS] Andrew-CS · comment score 2
+
+### Operational caveats
+
+> Comments have a certain size limit and adding raw syntax will likely always break that limit. The comments section isn't really designed to show JSON. You might be able to link to the workflow execution URL so you can quickly pivot to the formatted results.
+— [CS] Andrew-CS · score 1
+
+### Q&A
+
+**Q — [Community] xplorationz:** Can you trigger Fusion workflow using API? and get output via API. (New to Falcon)
+
+**A — [CS] bk-CS:** Yes, on-demand fusion workflows can be triggered using `POST /workflows/entities/execute/v1`. You can separate the event search portion of Andrew's example into an on-demand workflow which would allow you to trigger it via API and also call it in a detection-triggered workflow.

--- a/Queries-Only/Cool-Query-Friday/2024-06-03 - Cool Query Friday - (mini) - The Triumphant Return of aid_master as a File.md
+++ b/Queries-Only/Cool-Query-Friday/2024-06-03 - Cool Query Friday - (mini) - The Triumphant Return of aid_master as a File.md
@@ -1,0 +1,87 @@
+---
+title: "(mini) - The Triumphant Return of aid_master as a File"
+date: 2024-06-03
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/1d76iro/20240603_cool_query_friday_mini_the_triumphant/"
+mitre: []
+series: Cool Query Friday
+---
+
+# (mini) - The Triumphant Return of aid_master as a File
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/1d76iro/20240603_cool_query_friday_mini_the_triumphant/](https://www.reddit.com/r/crowdstrike/comments/1d76iro/20240603_cool_query_friday_mini_the_triumphant/) — by Andrew-CS (CrowdStrike) — 2024-06-03
+
+Welcome to our seventy-fourth-and-a-half installment (there are no rules, here!) of Cool Query Friday. The format will be: (1) description of what we're doing (2) walk through of each step (3) application in the wild.
+
+## Query 1
+```cql
+| inputlookup aid_master
+```
+
+## Query 2
+```cql
+| readFile(aid_master_main.csv)
+```
+
+## Query 3
+```cql
+| readFile(aid_master_details.csv)
+```
+
+## Query 4
+```cql
+#event_simpleName=ProcessRollup2 event_platform=Win
+| tail(10)
+| match(file="aid_master_main.csv", field=aid, include=[AgentVersion, Version], ignoreCase=true, strict=false)
+| table([aid, Computername, TargetProcessId, FileName, AgentVersion, Version])
+```
+
+## Query 5
+```cql
+| match(file="aid_master_main.csv", field=aid, include=[AgentVersion, Version], ignoreCase=true, strict=false)
+```
+
+## Query 6
+```cql
+#event_simpleName=ProcessRollup2 event_platform=Win
+| tail(10)
+| aid =~ match(file="aid_master_main.csv", column=aid, strict=false)
+| table([aid, Computername, TargetProcessId, FileName, AgentVersion, Version])
+```
+
+## Query 7
+```cql
+| aid =~ match(file="aid_master_main.csv", column=aid, strict=false)
+```
+
+## Query 8
+```cql
+#event_simpleName=ProcessRollup2 event_platform=Win
+| tail(10)
+| aid =~ match(file="aid_master_main.csv", column=aid, strict=false)
+| table([aid, Computername, TargetProcessId, FileName, AgentVersion, Version, MAC, ProductType])
+```
+
+## Query 9
+```cql
+| readFile("aid_master_main.csv")
+| test(FirstSeen>(now()-604800000))
+| FirstSeen:=formatTime(format="%F %F", field="FirstSeen")
+```
+
+## Query 10
+```cql
+#event_simpleName=UserLogon
+| groupBy([aid, ComputerName], function=([selectFromMax(field="@timestamp", include=[UserName])]))
+| match(file="aid_master_details.csv", field=aid, include=[SystemSerialNumber], ignoreCase=true, strict=false)
+| rename(field="UserName", as="LastLoggedOnUser")
+```
+
+## Query 11
+```cql
+#event_simpleName=DnsRequest DomainName=/github.com$/i
+| match(file="aid_master_main.csv", field=aid, include=[ProductType, Version], ignoreCase=true, strict=false)
+| in(field="ProductType", values=[2,3])
+| groupBy([aid, ComputerName, ContextBaseFileName], function=([collect([ProductType, Version, DomainName])]))
+| $falcon/helper:enrich(field=ProductType)
+```

--- a/Queries-Only/Cool-Query-Friday/2024-06-07 - Cool Query Friday - Custom Lookup Files in Raptor.md
+++ b/Queries-Only/Cool-Query-Friday/2024-06-07 - Cool Query Friday - Custom Lookup Files in Raptor.md
@@ -1,0 +1,91 @@
+---
+title: "Custom Lookup Files in Raptor"
+date: 2024-06-07
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/1dal47a/20240607_cool_query_friday_custom_lookup_files_in/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Custom Lookup Files in Raptor
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/1dal47a/20240607_cool_query_friday_custom_lookup_files_in/](https://www.reddit.com/r/crowdstrike/comments/1dal47a/20240607_cool_query_friday_custom_lookup_files_in/) — by Andrew-CS (CrowdStrike) — 2024-06-07
+
+Welcome to our seventy-fifth installment of Cool Query Friday. The format will be: (1) description of what we're doing (2) walk through of each step (3) application in the wild.
+
+## Query 1
+```cql
+| readFile("win_lolbins.csv")
+```
+
+## Query 2
+```cql
+// Get all process executions for Windows systems
+#event_simpleName=ProcessRollup2 event_platform="Win"
+// Check to make sure FileName is on our LOLBINS list located in lookup file
+| match(file="win_lolbins.csv", field="FileName", column=FileName, include=[FileName, Description, Paths, URL], strict=true)
+```
+
+## Query 3
+```cql
+// Massage ImageFileName so a true key pair value can be created that combines file path and file name
+| regex("(\\\\Device\\\\HarddiskVolume\\d+)?(?<ShortFN>.+)", field=ImageFileName, strict=false)
+| ShortFN:=lower("ShortFN")
+| FileNameLower:=lower("FileName")
+| RunningKey:=format(format="%s_%s", field=[FileNameLower, ShortFN])
+// Check to see where the executing file's key doesn't match an expected key value for an LOLBIN
+| !match(file="win_lolbins.csv", field="RunningKey", column=key, strict=true)
+```
+
+## Query 4
+```cql
+// Output results to table
+| table([aid, ComputerName, UserName, ParentProcessId, ParentBaseFileName, FileName, ShortFN, Paths, CommandLine, Description, Paths, URL])
+// Clean up "Paths" to make it easier to read
+| Paths =~replace("\, ", with="\n")
+// Rename two fields so they are more explicit
+| rename([[ShortFN, ExecutingFilePath], [Paths, ExpectFilePath]])
+// Add Link for Process Explorer
+| rootURL := "https://falcon.crowdstrike.com/" /* US-1 */
+//| rootURL  := "https://falcon.us-2.crowdstrike.com/" /* US-2 */
+//| rootURL  := "https://falcon.laggar.gcw.crowdstrike.com/" /* Gov */
+//| rootURL  := "https://falcon.eu-1.crowdstrike.com/"  /* EU */
+| format("[PrEx](%sgraphs/process-explorer/tree?id=pid:%s:%s)", field=["rootURL", "aid", "ParentProcessId"], as="ProcessExplorer")
+// Add link back to LOLBAS Project
+| format("[LOLBAS](%s)", field=[URL], as="Link")
+// Remove unneeded fields
+| drop([rootURL, ParentProcessId, URL])
+The syntax is well commented, so you can see what’s going on.
+```
+
+## Query 5
+```cql
+// Get all process executions for Windows systems
+#event_simpleName=ProcessRollup2 event_platform="Win"
+// Check to make sure FileName is on our LOLBINS list located in lookup file
+| match(file="win_lolbins.csv", field="FileName", column=FileName, include=[FileName, Description, Paths, URL], strict=true)
+// Massage ImageFileName so a true key pair value can be created that combines file path and file name
+| regex("(\\\\Device\\\\HarddiskVolume\\d+)?(?<ShortFN>.+)", field=ImageFileName, strict=false)
+| ShortFN:=lower("ShortFN")
+| FileNameLower:=lower("FileName")
+| RunningKey:=format(format="%s_%s", field=[FileNameLower, ShortFN])
+// Check to see where the executing file's key doesn't match an expected key value for an LOLBIN
+| !match(file="win_lolbins.csv", field="RunningKey", column=key, strict=true)
+// Output results to table
+| table([aid, ComputerName, UserName, ParentProcessId, ParentBaseFileName, FileName, ShortFN, Paths, CommandLine, Description, Paths, URL])
+// Clean up "Paths" to make it easier to read
+| Paths =~replace("\, ", with="\n")
+// Rename two fields so they are more explicit
+| rename([[ShortFN, ExecutingFilePath], [Paths, ExpectFilePath]])
+// Add Link for Process Explorer
+| rootURL := "https://falcon.crowdstrike.com/" /* US-1 */
+//| rootURL  := "https://falcon.us-2.crowdstrike.com/" /* US-2 */
+//| rootURL  := "https://falcon.laggar.gcw.crowdstrike.com/" /* Gov */
+//| rootURL  := "https://falcon.eu-1.crowdstrike.com/"  /* EU */
+| format("[PrEx](%sgraphs/process-explorer/tree?id=pid:%s:%s)", field=["rootURL", "aid", "ParentProcessId"], as="ProcessExplorer")
+// Add link back to LOLBAS Project
+| format("[LOLBAS](%s)", field=[URL], as="Link")
+// Remove unneeded fields
+| drop([rootURL, ParentProcessId, URL])
+Once executed, you will have output that looks similar to this:
+```

--- a/Queries-Only/Cool-Query-Friday/2024-06-07 - Cool Query Friday - Custom Lookup Files in Raptor.md
+++ b/Queries-Only/Cool-Query-Friday/2024-06-07 - Cool Query Friday - Custom Lookup Files in Raptor.md
@@ -89,3 +89,28 @@ The syntax is well commented, so you can see what’s going on.
 | drop([rootURL, ParentProcessId, URL])
 Once executed, you will have output that looks similar to this:
 ```
+
+## Community & Staff Additions
+*Harvested from this post's [r/CrowdStrike](https://www.reddit.com/r/crowdstrike/) comment thread — not part of the original CQF post. **[CS]** = CrowdStrike staff · **[Community]** = other r/CrowdStrike users. Upvote scores shown for context.*
+
+### Query variants
+
+```cql
+#event_simpleName=ProcessRollup2 event_platform="Win"
+| !in(field=FileName, values=[wsl.exe], ignoreCase=true)
+```
+— [CS] Andrew-CS · comment score 1
+
+### Q&A
+
+**Q — [Community] HJForsythe:** Weird question but if you know that is a threat why not detect and alert on it by default?
+
+**A — [CS] Andrew-CS:** Hey there. Not weird at all. In my instance, this was me testing so I had dummy data. I took an icon from the Desktop and named it cmd.exe and just ran it. Nothing malicious was happening. Falcon has native detections for masquerading, but I always like knowing what's going on. You'll find that some application makers will bundle things named "cmd.exe" or "explorer.exe" with their programs. It's kind of annoying. I hope that helps.
+
+**Q — [Community] jarks_20:** If we import the MAC address like you mentioned for example, is there an specific format we need to follow when importing it?
+
+**A — [CS] Andrew-CS:** Oh. The easiest way would be to use a MAC in a lookup in the same format they are in in `aid_master_main` (which is 00-00-00-00-00-00). Capitalization doesn't matter. You could then merge against that. If you have MAC addresses in a different format (00:00:00:00:00:00), you could always use `replace()` on the Falcon data so it matches.
+
+**Q — [Community] Rude-Comfortable9463:** how would i exclude specific FileName, for example wsl.exe in the query without the need to alter the csv?
+
+**A — [CS] Andrew-CS:** Make the first two lines: #event_simpleName=ProcessRollup2 event_platform="Win" | !in(field=FileName, values=[wsl.exe], ignoreCase=true)

--- a/Queries-Only/Cool-Query-Friday/2024-06-21 - Cool Query Friday - Browser Extension Collection on Windows and macOS.md
+++ b/Queries-Only/Cool-Query-Friday/2024-06-21 - Cool Query Friday - Browser Extension Collection on Windows and macOS.md
@@ -1,0 +1,101 @@
+---
+title: "Browser Extension Collection on Windows and macOS"
+date: 2024-06-21
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/1dl3bo5/20240621_cool_query_friday_browser_extension/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Browser Extension Collection on Windows and macOS
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/1dl3bo5/20240621_cool_query_friday_browser_extension/](https://www.reddit.com/r/crowdstrike/comments/1dl3bo5/20240621_cool_query_friday_browser_extension/) — by Andrew-CS (CrowdStrike) — 2024-06-21
+
+Welcome to our seventy-sixth installment of Cool Query Friday. The format will be: (1) description of what we're doing (2) walk through of each step (3) application in the wild.
+
+## Query 1
+```cql
+#event_simpleName=InstalledBrowserExtension
+| fieldstats()
+```
+
+## Query 2
+```cql
+#event_simpleName=InstalledBrowserExtension BrowserExtensionId!="no-extension-available"
+| groupBy([event_platform, BrowserName, BrowserExtensionId, BrowserExtensionName], function=([count(aid, distinct=true, as=TotalEndpoints)]))
+```
+
+## Query 3
+```cql
+// Get browser extension event
+#event_simpleName=InstalledBrowserExtension BrowserExtensionId!="no-extension-available"
+// Aggregate by event_platform, BrowserName, ExtensionID and ExtensionName
+| groupBy([event_platform, BrowserName, BrowserExtensionId, BrowserExtensionName], function=([count(aid, distinct=true, as=TotalEndpoints)]))
+// Check to see if the extension is installed on fewer than 50 systems
+| test(TotalEndpoints<50)
+// Create a link to the Chrome Extension Store
+| format("[See Extension](https://chromewebstore.google.com/detail/%s)", field=[BrowserExtensionId], as="Chrome Store Link")
+// Sort in descending order
+| sort(order=desc, TotalEndpoints, limit=1000)
+// Convert the browser name from decimal to human-readable
+| case{
+BrowserName="3" | BrowserName:="Chrome";
+BrowserName="4" | BrowserName:="Edge";
+*;
+}
+```
+
+## Query 4
+```cql
+// Get browser extension event
+#event_simpleName=InstalledBrowserExtension BrowserExtensionId!="no-extension-available"
+// Aggregate by BrowserName
+| groupBy([BrowserExtensionName], function=([count(aid, distinct=true, as=TotalEndpoints)]))
+| sort(TotalEndpoints, order=desc)
+```
+
+## Query 5
+```cql
+// Get browser extension event
+#event_simpleName=InstalledBrowserExtension BrowserExtensionId!="no-extension-available"
+// Look for string "vpn" in extension name
+| BrowserExtensionName=/vpn/i
+// Make a new field that includes the extension ID and Name
+| Extension:=format(format="%s (%s)", field=[BrowserExtensionId, BrowserExtensionName])
+// Aggregate by endpoint and browser profile
+| groupBy([event_platform, aid, ComputerName, UserName, BrowserProfileId, BrowserName], function=([collect([Extension])]))
+// Get unnecessary field
+| drop([_count])
+// Convert browser name from decimal to human readable
+| case{
+BrowserName="3" | BrowserName:="Chrome";
+BrowserName="4" | BrowserName:="Edge";
+*;
+}
+```
+
+## Query 6
+```cql
+// Get browser extension event
+#event_simpleName=InstalledBrowserExtension BrowserExtensionId!="no-extension-available"
+// Look for side loaded extensions or extensions from third-party stores
+| in(field="BrowserExtensionInstallMethod", values=[4,5])
+// Make a new field that includes the extension ID and Name
+| Extension:=format(format="%s (%s)", field=[BrowserExtensionId, BrowserExtensionName])
+// Aggregate by endpoint and browser profile
+| groupBy([event_platform, aid, ComputerName, UserName, BrowserProfileId, BrowserName, BrowserExtensionInstallMethod], function=([collect([Extension])]))
+// Get unnecessary field
+| drop([_count])
+// Convert browser name from decimal to human readable
+| case{
+BrowserName="3" | BrowserName:="Chrome";
+BrowserName="4" | BrowserName:="Edge";
+*;
+}
+// Convert install method from decimal to human readable
+| case{
+BrowserExtensionInstallMethod="4" | BrowserExtensionInstallMethod:="Sideload";
+BrowserExtensionInstallMethod="5" | BrowserExtensionInstallMethod:="Third-Party Store";
+*;
+}
+```

--- a/Queries-Only/Cool-Query-Friday/2024-06-21 - Cool Query Friday - Browser Extension Collection on Windows and macOS.md
+++ b/Queries-Only/Cool-Query-Friday/2024-06-21 - Cool Query Friday - Browser Extension Collection on Windows and macOS.md
@@ -99,3 +99,58 @@ BrowserExtensionInstallMethod="5" | BrowserExtensionInstallMethod:="Third-Party 
 *;
 }
 ```
+
+## Community & Staff Additions
+*Harvested from this post's [r/CrowdStrike](https://www.reddit.com/r/crowdstrike/) comment thread — not part of the original CQF post. **[CS]** = CrowdStrike staff · **[Community]** = other r/CrowdStrike users. Upvote scores shown for context.*
+
+### Query variants
+
+```cql
+| !in(BrowserExtensionId, values=[
+aapocclcgogkmnckokdopfmhonfmgoek, // (Slides)
+aohghmighlieiainnegkcijnfilokake, // (Docs)
+lmjegmlicamnimmfhcmpkclmigmmcbeh, // (Application Launcher For Drive (by Google))
+ghbmnnjooekpmoecnnnilnnbdlolhkhi, // (Google Docs Offline)
+felcaaldnbdncclmgdcncolpebgiejap, // (Sheets)
+jlhmfgmfgeifomenelglieieghnjghma, // (Cisco Webex Extension)
+jhknlonaankphkkbnmjdlpehkinifeeg, // (Google Forms)
+nmmhkkegccagdldgiimedpiccmgmieda, // (Chrome Web Store Payments)
+nckgahadagoaajjgafhacjanaoiihapd // (Google Hangouts)
+])
+```
+— [Community] blahdidbert · comment score 2
+
+```cql
+| !match(file="good_extensions.csv", column="BrowserExtensionId", field=BrowserExtensionId)
+```
+— [CS] Andrew-CS · comment score 1
+
+```cql
+// Get browser extension event
+#event_simpleName=InstalledBrowserExtension BrowserExtensionId!="no-extension-available"
+// Normalize timestamp
+| BrowserExtensionInstalledTimestamp:=BrowserExtensionInstalledTimestamp*1000
+// Get detla from install time to now in milliseconds
+| InstallDelta:=now()-BrowserExtensionInstalledTimestamp
+// Check to see if installed in last 7 days in milliseconds
+| InstallDelta>=86400000
+```
+— [CS] Andrew-CS · comment score 1
+
+### Q&A
+
+**Q — [Community] blahdidbert:** Absolutely true but a couple questions: 1. What are the roles that someone needs to have to create, update, delete lookup files? 2. What would be the syntax to exclude a lookup file instead?
+
+**A — [CS] Andrew-CS:** 1. Falcon Admin &#8203; | !match(file="good_extensions.csv", column="BrowserExtensionId", field=BrowserExtensionId) You would want to upload a csv with the column BrowserExtensionId that includes the common or allowed extensions. This would exclude them from results. You could also manage a list of unapproved extensions and hunt against that list.
+
+**Q — [Community] festivusmiracle:** So how do you know what the numerical values for some of these fields represents? Like for the BrowserName=3, you convert the 3 to Chrome. And the BrowserExtensionInstallMethod=4 you convert to Sideload. Is there a way to know all of the possible values so we can make them all human readable? Thank …
+
+**A — [CS] Andrew-CS:** Yes sir. They are in the Event Data Dictionary. There's a screen shot (second one) in the post above.
+
+**Q — [Community] Beeefin:** Is there a way to query only recently installed browser extensions?
+
+**A — [CS] Andrew-CS:** Yes. You can verify against the field `BrowserExtensionInstalledTimestamp`. This would be q short example. // Get browser extension event #event_simpleName=InstalledBrowserExtension BrowserExtensionId!="no-extension-available" // Normalize timestamp | BrowserExtensionInstalledTimestamp:=BrowserExtensionInstalledTimestamp*1000 // Get detla from install time to now in milliseconds | InstallDelta:=now()-BrowserExtensionInstalledTimestamp // Check to see if installed in last 7 days in milliseconds | …
+
+**Q — [Community] Old_Organization9205:** Is it possible to group all Domain Names (URLs) which were called by each extension? Final outcome would be to lookup those URLs in a search for malicious ones.
+
+**A — [CS] Andrew-CS:** It would not be possible to tell since the chrome process is resolving those domains and not the extension itself.

--- a/Queries-Only/Cool-Query-Friday/2024-08-23 - Cool Query Friday - Hunting CommandHistory in Windows.md
+++ b/Queries-Only/Cool-Query-Friday/2024-08-23 - Cool Query Friday - Hunting CommandHistory in Windows.md
@@ -98,3 +98,32 @@ Welcome to our seventy-seventh installment of Cool Query Friday. The format will
 // Format ProcessStartTime to human-readable
 | ProcessStartTime:=ProcessStartTime*1000 | ProcessStartTime:=formatTime(format="%F %T.%L %Z", field="ProcessStartTime")
 ```
+
+## Community & Staff Additions
+*Harvested from this post's [r/CrowdStrike](https://www.reddit.com/r/crowdstrike/) comment thread — not part of the original CQF post. **[CS]** = CrowdStrike staff · **[Community]** = other r/CrowdStrike users. Upvote scores shown for context.*
+
+### Query variants
+
+```cql
+// Calculate length of CommandHistory event
+| CommandLength:=length(CommandHistory) 
+
+// Aggregate to merge PR2 and CH events
+| groupBy([aid, TargetProcessId], function=([
+    collect([ProcessStartTime, ComputerName, UserName, UserSid, ExecutionChain, CommandLength, CommandHistoryClean])]), limit=max)
+```
+— [CS] Andrew-CS · comment score 2
+
+```cql
+// Check to see if event name is CommandHistory
+    #event_simpleName=CommandHistory
+    // This is keyword list; modify as desired
+    | CommandHistory=/(add|user|password|pass|stop|start)/i
+```
+— [CS] Andrew-CS · comment score 1
+
+### Q&A
+
+**Q — [Community] LongRichardMan:** If I wanted the query to only detect if it matched ALL of the keywords or, say only if the command history has 3 of the keywords listed. Is there a way to accomplish that?
+
+**A — [CS] Andrew-CS:** It would be pretty simple, honestly. // Get CommandHistory with keywords and ProcessRollup2 events on Windows event_platform=Win (#event_simpleName=CommandHistory CommandHistory=/word1/i CommandHistory=/word2/i CommandHistory=/word3/i) OR (#event_simpleName=ProcessRollup2) You can change the first line to that and remove the following from the case statement: // Check to see if event name is CommandHistory #event_simpleName=CommandHistory // This is keyword list; modify as desired | CommandHisto …

--- a/Queries-Only/Cool-Query-Friday/2024-08-23 - Cool Query Friday - Hunting CommandHistory in Windows.md
+++ b/Queries-Only/Cool-Query-Friday/2024-08-23 - Cool Query Friday - Hunting CommandHistory in Windows.md
@@ -1,0 +1,100 @@
+---
+title: "Hunting CommandHistory in Windows"
+date: 2024-08-23
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/1ezcbjx/20240823_cool_query_friday_hunting_commandhistory/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Hunting CommandHistory in Windows
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/1ezcbjx/20240823_cool_query_friday_hunting_commandhistory/](https://www.reddit.com/r/crowdstrike/comments/1ezcbjx/20240823_cool_query_friday_hunting_commandhistory/) — by Andrew-CS (CrowdStrike) — 2024-08-23
+
+Welcome to our seventy-seventh installment of Cool Query Friday. The format will be: (1) description of what we're doing (2) walk through of each step (3) application in the wild.
+
+## Query 1
+```cql
+// Get CommandHistory and ProcessRollup2 events on Windows
+#event_simpleName=/^(CommandHistory|ProcessRollup2)$/ event_platform=Win
+```
+
+## Query 2
+```cql
+| case{
+    // Check to see if event is CommandHistory
+    #event_simpleName=CommandHistory
+    // This is keyword list; modify as desired
+    | CommandHistory=/(add|user|password|pass|stop|start)/i
+    // This puts the CommandHistory entries into an array
+    | CommandHistorySplit:=splitString(by="¶", field=CommandHistory)
+    // This combines the array values and separates them with a new-line
+    | concatArray("CommandHistorySplit", separator="\n", as=CommandHistoryClean);
+    // Check to see if event is ProcessRollup2. If yes, create mini process tree
+    #event_simpleName="ProcessRollup2" | ExecutionChain:=format(format="%s\n\t└ %s (%s)", field=[ParentBaseFileName, FileName, RawProcessId]);
+}
+```
+
+## Query 3
+```cql
+// This is keyword list; modify as desired
+| CommandHistory=/(add|user|pass|stop|start|sc\s+|whoami)/i
+```
+
+## Query 4
+```cql
+// Use selfJoinFilter to pair PR2 and CH events
+| selfJoinFilter(field=[aid, TargetProcessId], where=[{#event_simpleName="ProcessRollup2"}, {#event_simpleName="CommandHistory"}])
+```
+
+## Query 5
+```cql
+// Aggregate to display details
+| groupBy([aid, TargetProcessId], function=([collect([ProcessStartTime, ComputerName, UserName, UserSid, ExecutionChain, CommandHistoryClean])]), limit=max)
+```
+
+## Query 6
+```cql
+// Check to make sure CommandHistoryClean is populated due to non-deterministic nature of selfJoinFilter
+| CommandHistoryClean=*
+
+// OPTIONAL: exclude UserName values of administrators that are authorized
+| !in(field="UserName", values=[svc_runbook, janeHR], ignoreCase=true)
+
+// Format ProcessStartTime to human-readable
+| ProcessStartTime:=ProcessStartTime*1000 | ProcessStartTime:=formatTime(format="%F %T.%L %Z", field="ProcessStartTime")
+```
+
+## Query 7
+```cql
+// Get CommandHistory and ProcessRollup2 events on Windows
+#event_simpleName=/^(CommandHistory|ProcessRollup2)$/ event_platform=Win
+
+| case{
+    // Check to see if event name is CommandHistory
+    #event_simpleName=CommandHistory
+    // This is keyword list; modify as desired
+    | CommandHistory=/(add|user|password|pass|stop|start)/i
+    // This puts the CommandHistory entries into an array
+    | CommandHistorySplit:=splitString(by="¶", field=CommandHistory)
+    // This combines the array values and separates them with a new-line
+    | concatArray("CommandHistorySplit", separator="\n", as=CommandHistoryClean);
+    // Check to see if event name is ProcessRollup2. If yes, create mini process tree
+    #event_simpleName="ProcessRollup2" | ExecutionChain:=format(format="%s\n\t└ %s (%s)", field=[ParentBaseFileName, FileName, RawProcessId]);
+}
+
+// Use selfJoinFilter to pair PR2 and CH events
+| selfJoinFilter(field=[aid, TargetProcessId], where=[{#event_simpleName="ProcessRollup2"}, {#event_simpleName="CommandHistory"}])
+
+// Aggregate to merge PR2 and CH events
+| groupBy([aid, TargetProcessId], function=([collect([ProcessStartTime, ComputerName, UserName, UserSid, ExecutionChain, CommandHistoryClean])]), limit=max)
+
+// Check to make sure CommandHistoryClean is populated due to non-deterministic nature of selfJoinFilter
+| CommandHistoryClean=*
+
+// OPTIONAL: exclude UserName values of administrators that are authorized
+| !in(field="UserName", values=[userName1, userName2], ignoreCase=true)
+
+// Format ProcessStartTime to human-readable
+| ProcessStartTime:=ProcessStartTime*1000 | ProcessStartTime:=formatTime(format="%F %T.%L %Z", field="ProcessStartTime")
+```

--- a/Queries-Only/Cool-Query-Friday/2024-09-27 - Cool Query Friday - Hunting Newly Seen DNS Resolutions in PowerShell.md
+++ b/Queries-Only/Cool-Query-Friday/2024-09-27 - Cool Query Friday - Hunting Newly Seen DNS Resolutions in PowerShell.md
@@ -1,0 +1,136 @@
+---
+title: "Hunting Newly Seen DNS Resolutions in PowerShell"
+date: 2024-09-27
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/1fqokic/20240927_cool_query_friday_hunting_newly_seen_dns/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Hunting Newly Seen DNS Resolutions in PowerShell
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/1fqokic/20240927_cool_query_friday_hunting_newly_seen_dns/](https://www.reddit.com/r/crowdstrike/comments/1fqokic/20240927_cool_query_friday_hunting_newly_seen_dns/) — by Andrew-CS (CrowdStrike) — 2024-09-27
+
+Welcome to our seventy-eighth installment of Cool Query Friday. The format will be: (1) description of what we're doing (2) walk through of each step (3) application in the wild.
+
+## Query 1
+```cql
+// Use case() to create buckets; "Current" will be within last one day and "Historical" will be anything before the past 1d as defined by the time-picker
+| case {
+    test(@timestamp < (now() - duration(1d))) | HistoricalState:="1";
+    test(@timestamp > (now() - duration(1d))) | CurrentState:="1";
+}
+// Set default values for HistoricalState and CurrentState
+| default(value="0", field=[HistoricalState, CurrentState])
+```
+
+## Query 2
+```cql
+// Aggregate by Historical or Current status and DomainName; gather helpful metrics
+| groupBy([DomainName], function=[max("HistoricalState",as=HistoricalState), max(CurrentState, as=CurrentState), max(ContextTimeStamp, as=LastSeen), count(aid, as=ResolutionCount), count(aid, distinct=true, as=EndpointCount), collect([FirstIP4Record])], limit=max)
+
+// Check to make sure that the DomainName field as NOT been seen in the Historical dataset and HAS been seen in the current dataset
+| HistoricalState=0 AND CurrentState=1
+```
+
+## Query 3
+```cql
+// Get DnsRequest events tied to PowerShell
+#event_simpleName=DnsRequest event_platform=Win ContextBaseFileName=powershell.exe
+
+// Use case() to create buckets; "Current" will be withing last one day and "Historical" will be anything before the past 1d as defined by the time-picker
+| case {
+    test(@timestamp < (now() - duration(1d))) | HistoricalState:="1";
+    test(@timestamp > (now() - duration(1d))) | CurrentState:="1";
+}
+
+// Set default values for HistoricalState and CurrentState
+| default(value="0", field=[HistoricalState, CurrentState])
+
+// Aggregate by Historical or Current status and DomainName; gather helpful metrics
+| groupBy([DomainName], function=[max("HistoricalState",as=HistoricalState), max(CurrentState, as=CurrentState), max(ContextTimeStamp, as=LastSeen), count(aid, as=ResolutionCount), count(aid, distinct=true, as=EndpointCount), collect([FirstIP4Record])], limit=max)
+
+// Check to make sure that the DomainName field as NOT been seen in the Historical dataset and HAS been seen in the current dataset
+| HistoricalState=0 AND CurrentState=1
+```
+
+## Query 4
+```cql
+// Convert LastSeen to Human Readable
+| LastSeen:=formatTime(format="%F %T %Z", field="LastSeen")
+```
+
+## Query 5
+```cql
+// Get GeoIP data for first IPv4 record of domain name
+| ipLocation(FirstIP4Record)
+```
+
+## Query 6
+```cql
+// SET FLACON CLOUD; ADJUST COMMENTS TO YOUR CLOUD
+| rootURL := "https://falcon.crowdstrike.com/" /* US-1*/
+//rootURL  := "https://falcon.eu-1.crowdstrike.com/" ; /*EU-1 */
+//rootURL  := "https://falcon.us-2.crowdstrike.com/" ; /*US-2 */
+//rootURL  := "https://falcon.laggar.gcw.crowdstrike.com/" ; /*GOV-1 */
+
+// Create link to Indicator Graph for easier scoping
+| format("[Indicator Graph](%sintelligence/graph?indicators=domain:'%s')", field=["rootURL", "DomainName"], as="Indicator Graph")
+
+// Create link to Domain Search for easier scoping
+| format("[Domain Search](%sinvestigate/dashboards/domain-search?domain=%s&isLive=false&sharedTime=true&start=7d)", field=["rootURL", "DomainName"], as="Search Domain")
+```
+
+## Query 7
+```cql
+// Drop HistoricalState, CurrentState, Latitude, Longitude, and rootURL (optional)
+| drop([HistoricalState, CurrentState, FirstIP4Record.lat, FirstIP4Record.lon, rootURL])
+
+// Set default values for GeoIP fields to make output look prettier (optional)
+| default(value="-", field=[FirstIP4Record.country, FirstIP4Record.city, FirstIP4Record.state])
+```
+
+## Query 8
+```cql
+// Get DnsRequest events tied to PowerShell
+#event_simpleName=DnsRequest event_platform=Win ContextBaseFileName=powershell.exe
+
+// Use case() to create buckets; "Current" will be withing last one day and "Historical" will be anything before the past 1d as defined by the time-picker
+| case {
+    test(@timestamp < (now() - duration(1d))) | HistoricalState:="1";
+    test(@timestamp > (now() - duration(1d))) | CurrentState:="1";
+}
+
+// Set default values for HistoricalState and CurrentState
+| default(value="0", field=[HistoricalState, CurrentState])
+
+// Aggregate by Historical or Current status and DomainName; gather helpful metrics
+| groupBy([DomainName], function=[max("HistoricalState",as=HistoricalState), max(CurrentState, as=CurrentState), max(ContextTimeStamp, as=LastSeen), count(aid, as=ResolutionCount), count(aid, distinct=true, as=EndpointCount), collect([FirstIP4Record])], limit=max)
+
+// Check to make sure that the DomainName field as NOT been seen in the Historical dataset and HAS been seen in the current dataset
+| HistoricalState=0 AND CurrentState=1
+
+// Convert LastSeen to Human Readable
+| LastSeen:=formatTime(format="%F %T %Z", field="LastSeen")
+
+// Get GeoIP data for first IPv4 record of domain name
+| ipLocation(FirstIP4Record)
+
+// SET FLACON CLOUD; ADJUST COMMENTS TO YOUR CLOUD
+| rootURL := "https://falcon.crowdstrike.com/" /* US-1*/
+//rootURL  := "https://falcon.eu-1.crowdstrike.com/" ; /*EU-1 */
+//rootURL  := "https://falcon.us-2.crowdstrike.com/" ; /*US-2 */
+//rootURL  := "https://falcon.laggar.gcw.crowdstrike.com/" ; /*GOV-1 */
+
+// Create link to Indicator Graph for easier scoping
+| format("[Indicator Graph](%sintelligence/graph?indicators=domain:'%s')", field=["rootURL", "DomainName"], as="Indicator Graph")
+
+// Create link to Domain Search for easier scoping
+| format("[Domain Search](%sinvestigate/dashboards/domain-search?domain=%s&isLive=false&sharedTime=true&start=7d)", field=["rootURL", "DomainName"], as="Search Domain")
+
+// Drop HistoricalState, CurrentState, Latitude, Longitude, and rootURL (optional)
+| drop([HistoricalState, CurrentState, FirstIP4Record.lat, FirstIP4Record.lon, rootURL])
+
+// Set default values for GeoIP fields to make output look prettier
+| default(value="-", field=[FirstIP4Record.country, FirstIP4Record.city, FirstIP4Record.state])
+```

--- a/Queries-Only/Cool-Query-Friday/2024-09-27 - Cool Query Friday - Hunting Newly Seen DNS Resolutions in PowerShell.md
+++ b/Queries-Only/Cool-Query-Friday/2024-09-27 - Cool Query Friday - Hunting Newly Seen DNS Resolutions in PowerShell.md
@@ -134,3 +134,21 @@ Welcome to our seventy-eighth installment of Cool Query Friday. The format will 
 // Set default values for GeoIP fields to make output look prettier
 | default(value="-", field=[FirstIP4Record.country, FirstIP4Record.city, FirstIP4Record.state])
 ```
+
+## Community & Staff Additions
+*Harvested from this post's [r/CrowdStrike](https://www.reddit.com/r/crowdstrike/) comment thread — not part of the original CQF post. **[CS]** = CrowdStrike staff · **[Community]** = other r/CrowdStrike users. Upvote scores shown for context.*
+
+### Query variants
+
+```cql
+// Get DnsRequest events tied to PowerShell
+#event_simpleName=DnsRequest event_platform=Win ContextBaseFileName=powershell.exe
+| DomainName!=/(.?myinternaldomain.com$)/
+```
+— [CS] Andrew-CS · comment score 1
+
+### Q&A
+
+**Q — [Community] yankeesfan01x:** Is there a way to only include external DNS name resolutions and nothing internal?
+
+**A — [CS] Andrew-CS:** How do you classify internal? You could make the first two lines something like: // Get DnsRequest events tied to PowerShell #event_simpleName=DnsRequest event_platform=Win ContextBaseFileName=powershell.exe | DomainName!=/(.?myinternaldomain.com$)/

--- a/Queries-Only/Cool-Query-Friday/2024-10-11 - Cool Query Friday - New Regex Engine Edition.md
+++ b/Queries-Only/Cool-Query-Friday/2024-10-11 - Cool Query Friday - New Regex Engine Edition.md
@@ -1,0 +1,71 @@
+---
+title: "New Regex Engine Edition"
+date: 2024-10-11
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/1g1hw21/20241011_cool_query_friday_new_regex_engine/"
+mitre: []
+series: Cool Query Friday
+---
+
+# New Regex Engine Edition
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/1g1hw21/20241011_cool_query_friday_new_regex_engine/](https://www.reddit.com/r/crowdstrike/comments/1g1hw21/20241011_cool_query_friday_new_regex_engine/) — by Andrew-CS (CrowdStrike) — 2024-10-11
+
+Welcome to our seventy-ninth installment of Cool Query Friday. The format will be: (1) description of what we're doing (2) walk through of each step (3) application in the wild.
+
+## Query 1
+```cql
+| regex("foo", field=myField, flags=i, strict=true)
+```
+
+## Query 2
+```cql
+| myField=/foo/i
+```
+
+## Query 3
+```cql
+| CommandLine=/ENCRYPTED/
+```
+
+## Query 4
+```cql
+| CommandLine=/ENCRYPTED/i
+```
+
+## Query 5
+```cql
+------------------------------------------------------------------------------------
+Regex \ Engine                          |  Old Eng |     Java |     New Engine 
+------------------------------------------------------------------------------------
+Twain                                   |   257 ms |    61.7% |    50.7% 
+(?i)Twain                               |   645 ms |    83.2% |    83.7% 
+[a-z]shing                              |   780 ms |   139.6% |    15.6% 
+Huck[a-zA-Z]+|Saw[a-zA-Z]+              |   794 ms |   108.9% |    24.5% 
+[a-q][^u-z]{13}x                        |  2378 ms |    79.0% |    46.7% 
+Tom|Sawyer|Huckleberry|Finn             |   984 ms |   139.5% |    31.5% 
+(?i)(Tom|Sawyer|Huckleberry|Finn)       |  1408 ms |   172.0% |    89.0% 
+.{0,2}(?:Tom|Sawyer|Huckleberry|Finn)   |  2935 ms |   271.9% |    66.6% 
+.{2,4}(Tom|Sawyer|Huckleberry|Finn)     |  5190 ms |   162.2% |    51.9% 
+Tom.{10,25}river|river.{10,25}Tom       |   972 ms |    70.0% |    20.9% 
+\s[a-zA-Z]{0,12}ing\s                   |  1328 ms |   150.2% |    58.0% 
+([A-Za-z]awyer|[A-Za-z]inn)\s           |  1679 ms |   155.5% |    13.8% 
+["'][^"']{0,30}[?!\.]["']               |   753 ms |    77.3% |    39.4% 
+------------------------------------------------------------------------------------
+```
+
+## Query 6
+```cql
+| myField=/foo/iF
+```
+
+## Query 7
+```cql
+| regex("foo", field=myField, flags=iF, strict=true)
+```
+
+## Query 8
+```cql
+#event_simpleName=ProcessRollup2 event_platform=Win ImageFileName = /\\powershell(_ise)?\.exe/i
+| CommandLine=/\s-[e^]{1,2}[ncodema^]+\s(?<base64string>\S+)/i
+```

--- a/Queries-Only/Cool-Query-Friday/2024-10-18 - Cool Query Friday - Hunting Windows RMM Tools.md
+++ b/Queries-Only/Cool-Query-Friday/2024-10-18 - Cool Query Friday - Hunting Windows RMM Tools.md
@@ -1,0 +1,91 @@
+---
+title: "Hunting Windows RMM Tools"
+date: 2024-10-18
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/1g6iupi/20241018_cool_query_friday_hunting_windows_rmm/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Hunting Windows RMM Tools
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/1g6iupi/20241018_cool_query_friday_hunting_windows_rmm/](https://www.reddit.com/r/crowdstrike/comments/1g6iupi/20241018_cool_query_friday_hunting_windows_rmm/) — by Andrew-CS (CrowdStrike) — 2024-10-18
+
+Welcome to our eightieth installment of Cool Query Friday. The format will be: (1) description of what we're doing (2) walk through of each step (3) application in the wild.
+
+## Query 1
+```cql
+grep -ERi "\-\s\w+\.exe" . | awk -F\- '{ print $2 }' | sed "s/^[ \t]*//" | awk '{print tolower($0)}' | sort -u
+```
+
+## Query 2
+```cql
+// Get all Windows Process Executions
+#event_simpleName=ProcessRollup2 event_platform=Win
+
+// Check to see if FileName matches our list of RMM tools
+| match(file="rmm_executables_list.csv", field=[FileName], column=rmm, ignoreCase=true)
+
+// Create short file path field
+| FilePath=/\\Device\\HarddiskVolume\d+(?<ShortPath>.+$)/
+
+// Aggregate results by FileName
+| groupBy([FileName], function=([count(), count(aid, distinct=true, as=UniqueEndpoints), collect([ShortPath])]))
+
+// Sort in descending order so most prevalent binaries appear first
+| sort(_count, order=desc, limit=5000)
+```
+
+## Query 3
+```cql
+// Get all Windows Process Executions
+#event_simpleName=ProcessRollup2 event_platform=Win
+
+// Create exclusions for approved filenames
+| !in(field="FileName", values=[mstsc.exe], ignoreCase=true)
+
+// Check to see if FileName matches our list of RMM tools
+| match(file="rmm_executables_list.csv", field=[FileName], column=rmm, ignoreCase=true)
+```
+
+## Query 4
+```cql
+// Get all Windows Process Executions
+#event_simpleName=ProcessRollup2 event_platform=Win
+
+// Create exclusions for approved filenames
+| !in(field="FileName", values=[mstsc.exe], ignoreCase=true)
+
+// Check to see if FileName matches our list of RMM tools
+| match(file="rmm_executables_list.csv", field=[FileName], column=rmm, ignoreCase=true)
+
+// Create pretty ExecutionChain field
+| ExecutionChain:=format(format="%s\n\t└ %s (%s)", field=[ParentBaseFileName, FileName, RawProcessId])
+
+// Perform aggregation
+| groupBy([@timestamp, aid, ComputerName, UserName, ExecutionChain, CommandLine, TargetProcessId, SHA256HashData], function=[], limit=max)
+
+// Create link to VirusTotal to search SHA256
+| format("[Virus Total](https://www.virustotal.com/gui/file/%s)", field=[SHA256HashData], as="VT")
+
+// SET FLACON CLOUD; ADJUST COMMENTS TO YOUR CLOUD
+| rootURL := "https://falcon.crowdstrike.com/" /* US-1*/
+//rootURL  := "https://falcon.eu-1.crowdstrike.com/" ; /*EU-1 */
+//rootURL  := "https://falcon.us-2.crowdstrike.com/" ; /*US-2 */
+//rootURL  := "https://falcon.laggar.gcw.crowdstrike.com/" ; /*GOV-1 */
+
+// Create link to Indicator Graph for easier scoping by SHA256
+| format("[Indicator Graph](%sintelligence/graph?indicators=hash:'%s')", field=["rootURL", "SHA256HashData"], as="Indicator Graph")
+
+// Create link to Graph Explorer for process specific investigation
+| format("[Graph Explorer](%sgraphs/process-explorer/graph?id=pid:%s:%s)", field=["rootURL", "aid", "TargetProcessId"], as="Graph Explorer")
+
+// Drop unneeded fields
+| drop([SHA256HashData, TargetProcessId, rootURL])
+```
+
+## Query 5
+```cql
+// Create exclusions for approved users
+| !in(field="UserName", values=[Admin, Administrator, Bob, Alice], ignoreCase=true)
+```

--- a/Queries-Only/Cool-Query-Friday/2024-10-18 - Cool Query Friday - Hunting Windows RMM Tools.md
+++ b/Queries-Only/Cool-Query-Friday/2024-10-18 - Cool Query Friday - Hunting Windows RMM Tools.md
@@ -89,3 +89,38 @@ grep -ERi "\-\s\w+\.exe" . | awk -F\- '{ print $2 }' | sed "s/^[ \t]*//" | awk '
 // Create exclusions for approved users
 | !in(field="UserName", values=[Admin, Administrator, Bob, Alice], ignoreCase=true)
 ```
+
+## Community & Staff Additions
+*Harvested from this post's [r/CrowdStrike](https://www.reddit.com/r/crowdstrike/) comment thread — not part of the original CQF post. **[CS]** = CrowdStrike staff · **[Community]** = other r/CrowdStrike users. Upvote scores shown for context.*
+
+### Query variants
+
+```cql
+| readFile("rmm_list.csv")
+| regex("(?<short_binary_name>\w+)\.exe", field=rmm_binary)
+| groupBy([rmm_program], function=([collect([rmm_binary]), collect([short_binary_name], separator="|"), count(rmm_binary, as=FileCount)]))
+| short_binary_name:=lower("short_binary_name")
+| case{
+    FileCount>1 | IOAruleRegex:=format(format="\\\\(%s)\\.exe", field=[short_binary_name]);
+    FileCount=1 | IOAruleRegex:=format(format="\\\\%s\\.exe", field=[short_binary_name]);
+}
+| drop([short_binary_name])
+| rename(field="rmm_binary", as="Binary_Coverage")
+| rename(field="rmm_program", as="Program_Name")
+| table([Program_Name, IOAruleRegex, Binary_Coverage])
+```
+— [CS] Andrew-CS · comment score 2
+
+### Operational caveats
+
+> Hi there. This is more of an application control use-case. You can use a Custom IOA to block the process names, but I would break that up into a rule for each program so you can tweak and tune as necessary.
+— [CS] Andrew-CS · score 1
+
+> Hi there. The attached RMM CSV file has been updated on GitHub. If you downloaded before 2024-10-22 @ 0800 EST, please redownload and replace the version you are using. There were some parsing errors so "teamviewer.exe" was showing up as "eamviewer.exe". Fixed now!
+— [CS] Andrew-CS · score 5
+
+### Q&A
+
+**Q — [Community] red_devillzz:** Can you help on how we can block execution of so many executable at scale in a corporate environment. Is there a way to do this in Crowdstrike?
+
+**A — [CS] Andrew-CS:** Hi there. This is more of an application control use-case. You can use a Custom IOA to block the process names, but I would break that up into a rule for each program so you can tweak and tune as necessary.

--- a/Queries-Only/Cool-Query-Friday/2024-10-24 - Cool Query Friday - Part II Hunting Windows RMM Tools, Custom IOAs, and SOAR Response.md
+++ b/Queries-Only/Cool-Query-Friday/2024-10-24 - Cool Query Friday - Part II Hunting Windows RMM Tools, Custom IOAs, and SOAR Response.md
@@ -69,3 +69,17 @@ Welcome to our eighty-first installment of Cool Query Friday. The format will be
 | rename([[rmm_program,RuleName],[rmm_binary,BinaryCoverage]])
 | table([RuleName, pattern_severity, enabled, description, disposition_id, ImageFileName_Regex, BinaryCoverage])
 ```
+
+## Community & Staff Additions
+*Harvested from this post's [r/CrowdStrike](https://www.reddit.com/r/crowdstrike/) comment thread — not part of the original CQF post. **[CS]** = CrowdStrike staff · **[Community]** = other r/CrowdStrike users. Upvote scores shown for context.*
+
+### Operational caveats
+
+> If you have any issues during the import of `RmmToolsIoaGroup.zip`, make sure your API client has the proper permissions and that you're using the latest version of PSFalcon. You can uninstall old versions and install the latest by running these commands (assuming you used the PowerShell Gallery): Uninstall-Module -Name PSFalcon -AllVersions Install-Module -Name PSFalcon
+— [CS] bk-CS · score 6
+
+### Q&A
+
+**Q — [Community] Dtektion_:** How can we get these IOAs if our ORG does not create APIs for users?
+
+**A — [CS] Andrew-CS:** You could also just run the second query above as that shows the regex syntax... but if you can't create API keys I don't think you can create Custom IOA Rules either. You need to have the user permission to do one or the other.

--- a/Queries-Only/Cool-Query-Friday/2024-10-24 - Cool Query Friday - Part II Hunting Windows RMM Tools, Custom IOAs, and SOAR Response.md
+++ b/Queries-Only/Cool-Query-Friday/2024-10-24 - Cool Query Friday - Part II Hunting Windows RMM Tools, Custom IOAs, and SOAR Response.md
@@ -1,0 +1,71 @@
+---
+title: "Part II: Hunting Windows RMM Tools, Custom IOAs, and SOAR Response"
+date: 2024-10-24
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/1gb30r9/20241024_cool_query_friday_part_ii_hunting/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Part II: Hunting Windows RMM Tools, Custom IOAs, and SOAR Response
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/1gb30r9/20241024_cool_query_friday_part_ii_hunting/](https://www.reddit.com/r/crowdstrike/comments/1gb30r9/20241024_cool_query_friday_part_ii_hunting/) — by Andrew-CS (CrowdStrike) — 2024-10-24
+
+Welcome to our eighty-first installment of Cool Query Friday. The format will be: (1) description of what we're doing (2) walk through of each step (3) application in the wild.
+
+## Query 1
+```cql
+// Get all Windows process execution events
+| #event_simpleName=ProcessRollup2 event_platform=Win
+
+// Check to see if FileName value matches the value or a known RMM tools as specified by our lookup file
+| match(file="rmm_list.csv", field=[FileName], column=rmm_binary, ignoreCase=true)
+
+// Do some light formatting
+| regex("(?<short_binary_name>\w+)\.exe", field=FileName)
+| short_binary_name:=lower("short_binary_name")
+| rmm_binary:=lower(rmm_binary)
+
+// Aggregate by RMM program name
+| groupBy([rmm_program], function=([
+    collect([rmm_binary]), 
+    collect([short_binary_name], separator="|"),  
+    count(FileName, distinct=true, as=FileCount), 
+    count(aid, distinct=true, as=EndpointCount), 
+    count(aid, as=ExecutionCount)
+]))
+
+// Create case statement to display what Custom IOA regex will look like
+| case{
+    FileCount>1 | ImageFileName_Regex:=format(format=".*\\\\(%s)\\.exe", field=[short_binary_name]);
+    FileCount=1 | ImageFileName_Regex:=format(format=".*\\\\%s\\.exe", field=[short_binary_name]);
+}
+
+// More formatting
+| description:=format(format="Unexpected use of %s observed. Please investigate.", field=[rmm_program])
+| rename([[rmm_program,RuleName],[rmm_binary,BinaryCoverage]])
+| table([RuleName, EndpointCount, ExecutionCount, description, ImageFileName_Regex, BinaryCoverage], sortby=ExecutionCount, order=desc)
+```
+
+## Query 2
+```cql
+| readFile("rmm_list.csv")
+| regex("(?<short_binary_name>\w+)\.exe", field=rmm_binary)
+| short_binary_name:=lower("short_binary_name")
+| rmm_binary:=lower(rmm_binary)
+| groupBy([rmm_program], function=([
+    collect([rmm_binary], separator=", "), 
+    collect([short_binary_name], separator="|"), 
+    count(rmm_binary, as=FileCount)
+]))
+| case{
+    FileCount>1 | ImageFileName_Regex:=format(format=".*\\\\(%s)\\.exe", field=[short_binary_name]);
+    FileCount=1 | ImageFileName_Regex:=format(format=".*\\\\%s\\.exe", field=[short_binary_name]);
+}
+| pattern_severity:=informational
+| enabled:=false
+| disposition_id:=20
+| description:=format(format="Unexpected use of %s observed. Please investigate.", field=[rmm_program])
+| rename([[rmm_program,RuleName],[rmm_binary,BinaryCoverage]])
+| table([RuleName, pattern_severity, enabled, description, disposition_id, ImageFileName_Regex, BinaryCoverage])
+```

--- a/Queries-Only/Cool-Query-Friday/2025-02-21 - Cool Query Friday - Impossible Time To Travel and the Speed of Sound.md
+++ b/Queries-Only/Cool-Query-Friday/2025-02-21 - Cool Query Friday - Impossible Time To Travel and the Speed of Sound.md
@@ -1,0 +1,185 @@
+---
+title: "Impossible Time To Travel and the Speed of Sound"
+date: 2025-02-21
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/1iuwne9/20250221_cool_query_friday_impossible_time_to/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Impossible Time To Travel and the Speed of Sound
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/1iuwne9/20250221_cool_query_friday_impossible_time_to/](https://www.reddit.com/r/crowdstrike/comments/1iuwne9/20250221_cool_query_friday_impossible_time_to/) — by Andrew-CS (CrowdStrike) — 2025-02-21
+
+Welcome to our eighty-second installment of Cool Query Friday. The format will be: (1) description of what we're doing (2) walk through of each step (3) application in the wild.
+
+## Query 1
+```cql
+// Omit results if the RemoteAddressIP4 field is RFC1819
+| !cidr(RemoteAddressIP4, subnet=["224.0.0.0/4", "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "127.0.0.1/32", "169.254.0.0/16", "0.0.0.0/32"])
+```
+
+## Query 2
+```cql
+// Create UserName + UserSid Hash
+| UserHash:=concat([UserName, UserSid]) | UserHash:=crypto:md5([UserHash])
+```
+
+## Query 3
+```cql
+// Perform initial aggregation; groupBy() will sort by UserHash then LogonTime
+| groupBy([UserHash, LogonTime], function=[collect([UserName, UserSid, RemoteAddressIP4, ComputerName, aid])], limit=max)
+```
+
+## Query 4
+```cql
+// Get geoIP for Remote IP
+| ipLocation(RemoteAddressIP4)
+```
+
+## Query 5
+```cql
+// Use new neighbor() function to get results for previous row
+| neighbor([UserHash, LogonTime, RemoteAddressIP4, RemoteAddressIP4.country, RemoteAddressIP4.lat, RemoteAddressIP4.lon, ComputerName], prefix=prev)
+```
+
+## Query 6
+```cql
+// Make sure neighbor() sequence does not span UserHash values; will occur at the end of a series
+| test(UserHash==prev.UserHash)
+```
+
+## Query 7
+```cql
+// Calculate logon time delta in milliseconds from LogonTime to prev.LogonTime and round
+| LogonDelta:=(LogonTime-prev.LogonTime)*1000
+| LogonDelta:=round(LogonDelta)
+```
+
+## Query 8
+```cql
+// Turn logon time delta from milliseconds to human readable
+| TimeToTravel:=formatDuration(LogonDelta, precision=2)
+```
+
+## Query 9
+```cql
+// Calculate distance between Login 1 and Login 2
+| DistanceKm:=(geography:distance(lat1="RemoteAddressIP4.lat", lat2="prev.RemoteAddressIP4.lat", lon1="RemoteAddressIP4.lon", lon2="prev.RemoteAddressIP4.lon"))/1000 | DistanceKm:=round(DistanceKm)
+```
+
+## Query 10
+```cql
+// Calculate speed required to get from Login 1 to Login 2
+| SpeedKph:=DistanceKm/(LogonDelta/1000/60/60) | SpeedKph:=round(SpeedKph)
+```
+
+## Query 11
+```cql
+// SET THRESHOLD: 1234kph is MACH 1
+| test(SpeedKph>1234)
+```
+
+## Query 12
+```cql
+// Format LogonTime Values
+| LogonTime:=LogonTime*1000           | formatTime(format="%F %T %Z", as="LogonTime", field="LogonTime")
+| prev.LogonTime:=prev.LogonTime*1000 | formatTime(format="%F %T %Z", as="prev.LogonTime", field="prev.LogonTime")
+
+// Make fields easier to read
+| Travel:=format(format="%s → %s", field=[prev.RemoteAddressIP4.country, RemoteAddressIP4.country])
+| IPs:=format(format="%s → %s", field=[prev.RemoteAddressIP4, RemoteAddressIP4])
+| Logons:=format(format="%s → %s", field=[prev.LogonTime, LogonTime])
+
+// Output results to table and sort by highest speed
+| table([aid, ComputerName, UserName, UserSid, System, IPs, Travel, DistanceKm, Logons, TimeToTravel, SpeedKph], limit=20000, sortby=SpeedKph, order=desc)
+
+// Express SpeedKph as a value of MACH
+| Mach:=SpeedKph/1234 | Mach:=round(Mach)
+| Speed:=format(format="MACH %s", field=[Mach])
+
+// Format distance and speed fields to include comma and unit of measure
+| format("%,.0f km",field=["DistanceKm"], as="DistanceKm")
+| format("%,.0f km/h",field=["SpeedKph"], as="SpeedKph")
+
+// Intelligence Graph; uncomment out one cloud
+| rootURL  := "https://falcon.crowdstrike.com/"
+//rootURL  := "https://falcon.laggar.gcw.crowdstrike.com/"
+//rootURL  := "https://falcon.eu-1.crowdstrike.com/"
+//rootURL  := "https://falcon.us-2.crowdstrike.com/"
+| format("[Link](%sinvestigate/dashboards/user-search?isLive=false&sharedTime=true&start=7d&user=%s)", field=["rootURL", "UserName"], as="User Search")
+
+// Drop unwanted fields
+| drop([Mach, rootURL])
+```
+
+## Query 13
+```cql
+// Get UserLogon events for Windows RDP sessions
+#event_simpleName=UserLogon event_platform=Win LogonType=10 RemoteAddressIP4=*
+
+// Omit results if the RemoteAddressIP4 field is RFC1819
+| !cidr(RemoteAddressIP4, subnet=["224.0.0.0/4", "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "127.0.0.1/32", "169.254.0.0/16", "0.0.0.0/32"])
+
+// Create UserName + UserSid Hash
+| UserHash:=concat([UserName, UserSid]) | UserHash:=crypto:md5([UserHash])
+
+// Perform initial aggregation; groupBy() will sort by UserHash then LogonTime
+| groupBy([UserHash, LogonTime], function=[collect([UserName, UserSid, RemoteAddressIP4, ComputerName, aid])], limit=max)
+
+// Get geoIP for Remote IP
+| ipLocation(RemoteAddressIP4)
+
+
+// Use new neighbor() function to get results for previous row
+| neighbor([LogonTime, RemoteAddressIP4, UserHash, RemoteAddressIP4.country, RemoteAddressIP4.lat, RemoteAddressIP4.lon, ComputerName], prefix=prev)
+
+// Make sure neighbor() sequence does not span UserHash values; will occur at the end of a series
+| test(UserHash==prev.UserHash)
+
+// Calculate logon time delta in milliseconds from LogonTime to prev.LogonTime and round
+| LogonDelta:=(LogonTime-prev.LogonTime)*1000
+| LogonDelta:=round(LogonDelta)
+
+// Turn logon time delta from milliseconds to human readable
+| TimeToTravel:=formatDuration(LogonDelta, precision=2)
+
+// Calculate distance between Login 1 and Login 2
+| DistanceKm:=(geography:distance(lat1="RemoteAddressIP4.lat", lat2="prev.RemoteAddressIP4.lat", lon1="RemoteAddressIP4.lon", lon2="prev.RemoteAddressIP4.lon"))/1000 | DistanceKm:=round(DistanceKm)
+
+// Calculate speed required to get from Login 1 to Login 2
+| SpeedKph:=DistanceKm/(LogonDelta/1000/60/60) | SpeedKph:=round(SpeedKph)
+
+// SET THRESHOLD: 1234kph is MACH 1
+| test(SpeedKph>1234)
+
+// Format LogonTime Values
+| LogonTime:=LogonTime*1000           | formatTime(format="%F %T %Z", as="LogonTime", field="LogonTime")
+| prev.LogonTime:=prev.LogonTime*1000 | formatTime(format="%F %T %Z", as="prev.LogonTime", field="prev.LogonTime")
+
+// Make fields easier to read
+| Travel:=format(format="%s → %s", field=[prev.RemoteAddressIP4.country, RemoteAddressIP4.country])
+| IPs:=format(format="%s → %s", field=[prev.RemoteAddressIP4, RemoteAddressIP4])
+| Logons:=format(format="%s → %s", field=[prev.LogonTime, LogonTime])
+
+// Output results to table and sort by highest speed
+| table([aid, ComputerName, UserName, UserSid, System, IPs, Travel, DistanceKm, Logons, TimeToTravel, SpeedKph], limit=20000, sortby=SpeedKph, order=desc)
+
+// Express SpeedKph as a value of MACH
+| Mach:=SpeedKph/1234 | Mach:=round(Mach)
+| Speed:=format(format="MACH %s", field=[Mach])
+
+// Format distance and speed fields to include comma and unit of measure
+| format("%,.0f km",field=["DistanceKm"], as="DistanceKm")
+| format("%,.0f km/h",field=["SpeedKph"], as="SpeedKph")
+
+// Intelligence Graph; uncomment out one cloud
+| rootURL  := "https://falcon.crowdstrike.com/"
+//rootURL  := "https://falcon.laggar.gcw.crowdstrike.com/"
+//rootURL  := "https://falcon.eu-1.crowdstrike.com/"
+//rootURL  := "https://falcon.us-2.crowdstrike.com/"
+| format("[Link](%sinvestigate/dashboards/user-search?isLive=false&sharedTime=true&start=7d&user=%s)", field=["rootURL", "UserName"], as="User Search")
+
+// Drop unwanted fields
+| drop([Mach, rootURL])
+```

--- a/Queries-Only/Cool-Query-Friday/2025-02-28 - Cool Query Friday - Electric Slide… ‘ing Time Windows.md
+++ b/Queries-Only/Cool-Query-Friday/2025-02-28 - Cool Query Friday - Electric Slide… ‘ing Time Windows.md
@@ -173,3 +173,25 @@ Welcome to our eighty-third installment of [Cool Query Friday](https://www.reddi
 // Final field organization
 | groupBy([aid, ComputerName, event_platform, LastSuccessfulLogon, LastLogonTime, FailedLogonAccounts, FailedLogonAttempts, "User Search", "Asset Graph", Description], function=[], limit=max)
 ```
+
+## Community & Staff Additions
+*Harvested from this post's [r/CrowdStrike](https://www.reddit.com/r/crowdstrike/) comment thread — not part of the original CQF post. **[CS]** = CrowdStrike staff · **[Community]** = other r/CrowdStrike users. Upvote scores shown for context.*
+
+### Query variants
+
+```cql
+| createEvents(["name=andrew-cs, shirt_color=blue", "name=andrew-cs, shirt_color=red", "name=andrew-cs, shirt_color=green"])
+| kvParse()
+| groupBy([name], function=([collect([shirt_color])]))
+
+| createEvents(["name=andrew-cs, shirt_color=blue", "name=andrew-cs, shirt_color=red", "name=andrew-cs, shirt_color=green"])
+| kvParse()
+| groupBy([name], function=([collect([shirt_color], multival=false)]))
+```
+— [CS] Andrew-CS · comment score 1
+
+### Q&A
+
+**Q — [Community] sixstringacks:** I’m trying the understand the multival parameter of collect a little better and the documentation is not clear. Can you explain the purpose of setting multival to false? Reviewing the results of the first groupBy query, setting multival=false or multival=true does not seem to affect the results.
+
+**A — [CS] Andrew-CS:** In the query above, it's to account for an edge case where two users with distinct user names attempt to login at the EXACT same time (down to the millisecond). I don't even know if that's possible, but that's why it's there. To see what multival does, run these two queries... | createEvents(["name=andrew-cs, shirt_color=blue", "name=andrew-cs, shirt_color=red", "name=andrew-cs, shirt_color=green"]) | kvParse() | groupBy([name], function=([collect([shirt_color])])) | createEvents(["name=andrew-c …

--- a/Queries-Only/Cool-Query-Friday/2025-02-28 - Cool Query Friday - Electric Slide… ‘ing Time Windows.md
+++ b/Queries-Only/Cool-Query-Friday/2025-02-28 - Cool Query Friday - Electric Slide… ‘ing Time Windows.md
@@ -1,0 +1,175 @@
+---
+title: "Electric Slide… ‘ing Time Windows"
+date: 2025-02-28
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/1izst3r/20250228_cool_query_friday_electric_slide_ing/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Electric Slide… ‘ing Time Windows
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/1izst3r/20250228_cool_query_friday_electric_slide_ing/](https://www.reddit.com/r/crowdstrike/comments/1izst3r/20250228_cool_query_friday_electric_slide_ing/) — by Andrew-CS (CrowdStrike) — 2025-02-28
+
+Welcome to our eighty-third installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/?f=flair_name%3A%22CQF%22). The format will be: (1) description of what we're doing (2) walk through of each step (3) application in the wild.
+
+## Query 1
+```cql
+// Get all Windows Process Execution Events
+#event_simpleName=ProcessRollup2 event_platform=Win
+
+// Restrict by common files used in Discovery TA0007
+| in(field="FileName", values=[ping.exe, net.exe, tracert.exe, whoami.exe, ipconfig.exe, nltest.exe, reg.exe, systeminfo.exe, hostname.exe], ignoreCase=true)
+```
+
+## Query 2
+```cql
+// Aggregate by key fields Agent ID and timestamp to arrange in sequence; collect relevant fields for use later
+| groupBy([aid, u/timestamp], function=([collect([#event_simpleName, ComputerName, UserName, UserSid, FileName], multival=false)]), limit=max)
+```
+
+## Query 3
+```cql
+// Use slidingTimeWindow to look for 4 or more Discovery commands in a 10 minute window
+| groupBy(
+   aid,
+   function=slidingTimeWindow(
+       [{#event_simpleName=ProcessRollup2 | count(FileName, as=DiscoveryCount, distinct=true)}, {collect([FileName])}],
+       span=10m
+   ), limit=max
+ )
+```
+
+## Query 4
+```cql
+// This is the Discovery command threshold
+| DiscoveryCount >= 4
+```
+
+## Query 5
+```cql
+// Get all Windows Process Execution Events
+#event_simpleName=ProcessRollup2 event_platform=Win
+
+// Restrict by common files used in Discovery TA0007
+| in(field="FileName", values=[ping.exe, net.exe, tracert.exe, whoami.exe, ipconfig.exe, nltest.exe, reg.exe, systeminfo.exe, hostname.exe], ignoreCase=true)
+
+// Aggregate by key fields Agent ID and timestamp to arrange in sequence; collect relevant fields for use later
+| groupBy([aid, @timestamp], function=([collect([#event_simpleName, ComputerName, UserName, UserSid, FileName], multival=false)]), limit=max)
+
+// Use slidingTimeWindow to look for 4 or more Discovery commands in a 10 minute window
+| groupBy(
+   aid,
+   function=slidingTimeWindow(
+       [{#event_simpleName=ProcessRollup2 | count(FileName, as=DiscoveryCount, distinct=true)}, {collect([FileName])}],
+       span=10m
+   ), limit=max
+ )
+// This is the Discovery command threshold
+| DiscoveryCount >= 4
+| drop([#event_simpleName])
+```
+
+## Query 6
+```cql
+// Get successful and failed user logon events
+(#event_simpleName=UserLogon OR #event_simpleName=UserLogonFailed2) UserName!=/^(DWM|UMFD)-\d+$/
+
+// Restrict to LogonType 2 and 10 (interactive)
+| in(field="LogonType", values=[2, 10])
+
+// Aggregate by key fields Agent ID and timestamp; collect the fields of interest
+| groupBy([aid, @timestamp], function=([collect([event_platform, #event_simpleName, UserName], multival=false), selectLast([ComputerName])]), limit=max)
+```
+
+## Query 7
+```cql
+// Use slidingTimeWindow to look for 3 or more failed user login events on a single Agent ID followed by a successful login event in a 10 minute window
+| groupBy(
+   aid,
+   function=slidingTimeWindow(
+       [{#event_simpleName=UserLogonFailed2 | count(as=FailedLogonAttempts)}, {collect([UserName]) | rename(field="UserName", as="FailedLogonAccounts")}],
+       span=10m
+   ), limit=max
+ )
+
+// Rename fields
+| rename([[UserName,LastSuccessfulLogon],[@timestamp,LastLogonTime]])
+
+// This is the FailedLogonAttempts threshold
+| FailedLogonAttempts >= 3
+
+// This is the event that needs to occur after the threshold is met
+| #event_simpleName=UserLogon
+```
+
+## Query 8
+```cql
+// Convert LastLogonTime to Human Readable format
+| LastLogonTime:=formatTime(format="%F %T.%L %Z", field="LastLogonTime")
+
+// User Search; uncomment out one cloud
+| rootURL  := "https://falcon.crowdstrike.com/"
+//rootURL  := "https://falcon.laggar.gcw.crowdstrike.com/"
+//rootURL  := "https://falcon.eu-1.crowdstrike.com/"
+//rootURL  := "https://falcon.us-2.crowdstrike.com/"
+| format("[Scope User](%sinvestigate/dashboards/user-search?isLive=false&sharedTime=true&start=7d&user=%s)", field=["rootURL", "LastSuccessfulLogon"], as="User Search")
+
+// Asset Graph
+| format("[Scope Asset](%sasset-details/managed/%s)", field=["rootURL", "aid"], as="Asset Graph")
+
+// Adding description
+| Description:=format(format="User %s logged on to system %s (Agent ID: %s) successfully after %s failed logon attempts were observed on the host.", field=[LastSuccessfulLogon, ComputerName, aid, FailedLogonAttempts])
+
+// Final field organization
+| groupBy([aid, ComputerName, event_platform, LastSuccessfulLogon, LastLogonTime, FailedLogonAccounts, FailedLogonAttempts, "User Search", "Asset Graph", Description], function=[], limit=max)
+```
+
+## Query 9
+```cql
+// Get successful and failed user logon events
+(#event_simpleName=UserLogon OR #event_simpleName=UserLogonFailed2) UserName!=/^(DWM|UMFD)-\d+$/
+
+// Restrict to LogonType 2 and 10
+| in(field="LogonType", values=[2, 10])
+
+// Aggregate by key fields Agent ID and timestamp; collect the event name
+| groupBy([aid, @timestamp], function=([collect([event_platform, #event_simpleName, UserName], multival=false), selectLast([ComputerName])]), limit=max)
+
+// Use slidingTimeWindow to look for 3 or more failed user login events on a single Agent ID followed by a successful login event in a 10 minute window
+| groupBy(
+   aid,
+   function=slidingTimeWindow(
+       [{#event_simpleName=UserLogonFailed2 | count(as=FailedLogonAttempts)}, {collect([UserName]) | rename(field="UserName", as="FailedLogonAccounts")}],
+       span=10m
+   ), limit=max
+ )
+
+// Rename fields
+| rename([[UserName,LastSuccessfulLogon],[@timestamp,LastLogonTime]])
+
+// This is the FailedLogonAttempts threshold
+| FailedLogonAttempts >= 3
+
+// This is the event that needs to occur after the threshold is met
+| #event_simpleName=UserLogon
+
+// Convert LastLogonTime to Human Readable format
+| LastLogonTime:=formatTime(format="%F %T.%L %Z", field="LastLogonTime")
+
+// User Search; uncomment out one cloud
+| rootURL  := "https://falcon.crowdstrike.com/"
+//rootURL  := "https://falcon.laggar.gcw.crowdstrike.com/"
+//rootURL  := "https://falcon.eu-1.crowdstrike.com/"
+//rootURL  := "https://falcon.us-2.crowdstrike.com/"
+| format("[Scope User](%sinvestigate/dashboards/user-search?isLive=false&sharedTime=true&start=7d&user=%s)", field=["rootURL", "LastSuccessfulLogon"], as="User Search")
+
+// Asset Graph
+| format("[Scope Asset](%sasset-details/managed/%s)", field=["rootURL", "aid"], as="Asset Graph")
+
+// Adding description
+| Description:=format(format="User %s logged on to system %s (Agent ID: %s) successfully after %s failed logon attempts were observed on the host.", field=[LastSuccessfulLogon, ComputerName, aid, FailedLogonAttempts])
+
+// Final field organization
+| groupBy([aid, ComputerName, event_platform, LastSuccessfulLogon, LastLogonTime, FailedLogonAccounts, FailedLogonAttempts, "User Search", "Asset Graph", Description], function=[], limit=max)
+```

--- a/Queries-Only/Cool-Query-Friday/2025-04-14 - Cool Query Friday - Hunting Fake CAPTCHA Artifacts in Windows.md
+++ b/Queries-Only/Cool-Query-Friday/2025-04-14 - Cool Query Friday - Hunting Fake CAPTCHA Artifacts in Windows.md
@@ -47,3 +47,11 @@ Get-ChildItem "Registry::HKEY_USERS" |
 | CommandLine=/https?/iF
 | table([@timestamp, aid, ComputerName, UserName, UserSid, FileName, CmdLength, CommandLine], sortby=CmdLength, order=desc, limit=500)
 ```
+
+## Community & Staff Additions
+*Harvested from this post's [r/CrowdStrike](https://www.reddit.com/r/crowdstrike/) comment thread — not part of the original CQF post. **[CS]** = CrowdStrike staff · **[Community]** = other r/CrowdStrike users. Upvote scores shown for context.*
+
+### Operational caveats
+
+> Hey there. Interrogating and clouding the contents of the call stack for every execution has a negative impact on system performance. That's why it isn't everywhere. Just so you know :) I'll get with research and see if there have been any movements, here.
+— [CS] Andrew-CS · score 2

--- a/Queries-Only/Cool-Query-Friday/2025-04-14 - Cool Query Friday - Hunting Fake CAPTCHA Artifacts in Windows.md
+++ b/Queries-Only/Cool-Query-Friday/2025-04-14 - Cool Query Friday - Hunting Fake CAPTCHA Artifacts in Windows.md
@@ -1,0 +1,49 @@
+---
+title: "Hunting Fake CAPTCHA Artifacts in Windows"
+date: 2025-04-14
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/1jz02j3/20250414_cool_query_friday_hunting_fake_captcha/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Hunting Fake CAPTCHA Artifacts in Windows
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/1jz02j3/20250414_cool_query_friday_hunting_fake_captcha/](https://www.reddit.com/r/crowdstrike/comments/1jz02j3/20250414_cool_query_friday_hunting_fake_captcha/) — by Andrew-CS (CrowdStrike) — 2025-04-14
+
+Welcome to our eighty-fourth installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/?f=flair_name%3A%22CQF%22) (on a Monday). The format will be: (1) description of what we're doing (2) walk through of each step (3) application in the wild.
+
+## Query 1
+```cql
+Get-ChildItem "Registry::HKEY_USERS" | 
+    ForEach-Object {
+        $SID = $_.PSChildName
+        $RunMRUPath = "Registry::HKEY_USERS\$SID\Software\Microsoft\Windows\CurrentVersion\Explorer\RunMRU"
+        
+        if (Test-Path $RunMRUPath) {
+            # Try to get username from SID
+            try {
+                $UserName = (New-Object System.Security.Principal.SecurityIdentifier($SID)).Translate([System.Security.Principal.NTAccount]).Value
+            }
+            catch {
+                $UserName = $SID  # Keep SID if translation fails
+            }
+            
+            $RunMRUValues = Get-ItemProperty -Path $RunMRUPath
+            $RunMRUValues.PSObject.Properties | 
+                Where-Object { $_.Name -match '^[a-z]$' } | 
+                ForEach-Object { Write-Output "$UserName : $($_.Name): $($_.Value)" }
+        }
+    }
+```
+
+## Query 2
+```cql
+#event_simpleName=ProcessRollup2 AND WindowFlags=1025 AND LinkName!="*" ParentBaseFileName=explorer.exe ImageSubsystem=3
+| CmdLength:=length("CommandLine")
+// Can raise or loweer this threshold
+| test(CmdLength>100)
+// Checks for presense of "http" or "https"
+| CommandLine=/https?/iF
+| table([@timestamp, aid, ComputerName, UserName, UserSid, FileName, CmdLength, CommandLine], sortby=CmdLength, order=desc, limit=500)
+```

--- a/Queries-Only/Cool-Query-Friday/2025-04-18 - Cool Query Friday - Agentic Charlotte Workflows, Baby Queries, and Prompt Engineering.md
+++ b/Queries-Only/Cool-Query-Friday/2025-04-18 - Cool Query Friday - Agentic Charlotte Workflows, Baby Queries, and Prompt Engineering.md
@@ -99,3 +99,16 @@ Welcome to our eighty-fifth installment of Cool Query Friday (on a Monday). The 
 | rename([[RemoteAddressIP4.country, Country], [RemoteAddressIP4.city, City], [RemoteAddressIP4.state, State], [RemoteAddressIP4.lat, Latitude], [RemoteAddressIP4.lon, Longitude]])
 | table([LogonTime, cid, aid, ComputerName, UserName, UserSid, RemoteAddressIP4, Country, State, City, Latitude, Longitude], limit=20000)
 ```
+
+## Community & Staff Additions
+*Harvested from this post's [r/CrowdStrike](https://www.reddit.com/r/crowdstrike/) comment thread — not part of the original CQF post. **[CS]** = CrowdStrike staff · **[Community]** = other r/CrowdStrike users. Upvote scores shown for context.*
+
+### Q&A
+
+**Q — [Community] cobaltpsyche:** I am curious, if I use AI to review data and send an email, how can I set this up to NOT send an email of nothing of interest was found?
+
+**A — [CS] Andrew-CS:** Yup! So you want to use Fusion to create a boolean variable, then prompt the LLM to populate the variable based on its findings. So say you create a variable named "Suspicious." You might ask the LLM to populate that variable with "true" if it has high confidence findings and "false" if it does not. You can then use an IF statement to say, "IF Suspicious is equal to true, email. Else, exit."
+
+**Q — [Community] Critical_Quarter_245:** Do you have any examples of using agentic AI to triage alerts and reducing false positives? Maybe cross referencing with other data sources, threat intel, or data in a workflow?
+
+**A — [CS] Andrew-CS:** If you have a Charlotte AI license, you have "Triage with Charlotte." That will automatically generate: 1. Recommendation (Escalate or not) 2. Escalation priority (number to give weighting to the escalation recommendation) 3. Verdict (true\_positive, false\_positive, inconclusive) 4. Verdict confidence (High, Medium, Low, Inconclusive) There is also a summary of why the above categories were set the way they were. [https://imgur.com/a/i3I4YmW](https://imgur.com/a/i3I4YmW) So you could take the r …

--- a/Queries-Only/Cool-Query-Friday/2025-04-18 - Cool Query Friday - Agentic Charlotte Workflows, Baby Queries, and Prompt Engineering.md
+++ b/Queries-Only/Cool-Query-Friday/2025-04-18 - Cool Query Friday - Agentic Charlotte Workflows, Baby Queries, and Prompt Engineering.md
@@ -1,0 +1,101 @@
+---
+title: "Agentic Charlotte Workflows, Baby Queries, and Prompt Engineering"
+date: 2025-04-18
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/1k26eov/20250418_cool_query_friday_agentic_charlotte/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Agentic Charlotte Workflows, Baby Queries, and Prompt Engineering
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/1k26eov/20250418_cool_query_friday_agentic_charlotte/](https://www.reddit.com/r/crowdstrike/comments/1k26eov/20250418_cool_query_friday_agentic_charlotte/) — by Andrew-CS (CrowdStrike) — 2025-04-18
+
+Welcome to our eighty-fifth installment of Cool Query Friday (on a Monday). The format will be: (1) description of what we're doing (2) walk through of each step (3) application in the wild.
+
+## Query 1
+```cql
+// Get UserLogon events for Windows RDP sessions
+#event_simpleName=UserLogon event_platform=Win LogonType=10 RemoteAddressIP4=*
+
+// Omit results if the RemoteAddressIP4 field is RFC1819
+| !cidr(RemoteAddressIP4, subnet=["224.0.0.0/4", "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "127.0.0.1/32", "169.254.0.0/16", "0.0.0.0/32"])
+
+// Create UserName + UserSid Hash
+| UserHash:=concat([UserName, UserSid]) | UserHash:=crypto:md5([UserHash])
+
+// Perform initial aggregation; groupBy() will sort by UserHash then LogonTime
+| groupBy([UserHash, LogonTime], function=[collect([UserName, UserSid, RemoteAddressIP4, ComputerName, aid])], limit=max)
+
+// Get geoIP for Remote IP
+| ipLocation(RemoteAddressIP4)
+
+
+// Use new neighbor() function to get results for previous row
+| neighbor([LogonTime, RemoteAddressIP4, UserHash, RemoteAddressIP4.country, RemoteAddressIP4.lat, RemoteAddressIP4.lon, ComputerName], prefix=prev)
+
+// Make sure neighbor() sequence does not span UserHash values; will occur at the end of a series
+| test(UserHash==prev.UserHash)
+
+// Calculate logon time delta in milliseconds from LogonTime to prev.LogonTime and round
+| LogonDelta:=(LogonTime-prev.LogonTime)*1000
+| LogonDelta:=round(LogonDelta)
+
+// Turn logon time delta from milliseconds to human readable
+| TimeToTravel:=formatDuration(LogonDelta, precision=2)
+
+// Calculate distance between Login 1 and Login 2
+| DistanceKm:=(geography:distance(lat1="RemoteAddressIP4.lat", lat2="prev.RemoteAddressIP4.lat", lon1="RemoteAddressIP4.lon", lon2="prev.RemoteAddressIP4.lon"))/1000 | DistanceKm:=round(DistanceKm)
+
+// Calculate speed required to get from Login 1 to Login 2
+| SpeedKph:=DistanceKm/(LogonDelta/1000/60/60) | SpeedKph:=round(SpeedKph)
+
+// SET THRESHOLD: 1234kph is MACH 1
+| test(SpeedKph>1234)
+
+// Format LogonTime Values
+| LogonTime:=LogonTime*1000           | formatTime(format="%F %T %Z", as="LogonTime", field="LogonTime")
+| prev.LogonTime:=prev.LogonTime*1000 | formatTime(format="%F %T %Z", as="prev.LogonTime", field="prev.LogonTime")
+
+// Make fields easier to read
+| Travel:=format(format="%s → %s", field=[prev.RemoteAddressIP4.country, RemoteAddressIP4.country])
+| IPs:=format(format="%s → %s", field=[prev.RemoteAddressIP4, RemoteAddressIP4])
+| Logons:=format(format="%s → %s", field=[prev.LogonTime, LogonTime])
+
+// Output results to table and sort by highest speed
+| table([aid, ComputerName, UserName, UserSid, System, IPs, Travel, DistanceKm, Logons, TimeToTravel, SpeedKph], limit=20000, sortby=SpeedKph, order=desc)
+
+// Express SpeedKph as a value of MACH
+| Mach:=SpeedKph/1234 | Mach:=round(Mach)
+| Speed:=format(format="MACH %s", field=[Mach])
+
+// Format distance and speed fields to include comma and unit of measure
+| format("%,.0f km",field=["DistanceKm"], as="DistanceKm")
+| format("%,.0f km/h",field=["SpeedKph"], as="SpeedKph")
+
+// Intelligence Graph; uncomment out one cloud
+| rootURL  := "https://falcon.crowdstrike.com/"
+//rootURL  := "https://falcon.laggar.gcw.crowdstrike.com/"
+//rootURL  := "https://falcon.eu-1.crowdstrike.com/"
+//rootURL  := "https://falcon.us-2.crowdstrike.com/"
+| format("[Link](%sinvestigate/dashboards/user-search?isLive=false&sharedTime=true&start=7d&user=%s)", field=["rootURL", "UserName"], as="User Search")
+
+// Drop unwanted fields
+| drop([Mach, rootURL])
+```
+
+## Query 2
+```cql
+#event_simpleName=UserLogon LogonType=10 event_platform=Win RemoteAddressIP4=*
+| table([LogonTime, cid, aid, ComputerName, UserName, UserSid, RemoteAddressIP4])
+| ipLocation(RemoteAddressIP4)
+```
+
+## Query 3
+```cql
+#event_simpleName=UserLogon LogonType=10 event_platform=Win RemoteAddressIP4=*
+| !cidr(RemoteAddressIP4, subnet=["224.0.0.0/4", "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "127.0.0.1/32", "169.254.0.0/16", "0.0.0.0/32"])
+| ipLocation(RemoteAddressIP4)
+| rename([[RemoteAddressIP4.country, Country], [RemoteAddressIP4.city, City], [RemoteAddressIP4.state, State], [RemoteAddressIP4.lat, Latitude], [RemoteAddressIP4.lon, Longitude]])
+| table([LogonTime, cid, aid, ComputerName, UserName, UserSid, RemoteAddressIP4, Country, State, City, Latitude, Longitude], limit=20000)
+```

--- a/Queries-Only/Cool-Query-Friday/2026-03-02 - Cool Query Friday - Hunting for Typosquatted Domains.md
+++ b/Queries-Only/Cool-Query-Friday/2026-03-02 - Cool Query Friday - Hunting for Typosquatted Domains.md
@@ -156,3 +156,57 @@ Welcome back to another installment of [Cool Query Friday](https://www.reddit.co
 
 | drop(rootURL)
 ```
+
+## Community & Staff Additions
+*Harvested from this post's [r/CrowdStrike](https://www.reddit.com/r/crowdstrike/) comment thread — not part of the original CQF post. **[CS]** = CrowdStrike staff · **[Community]** = other r/CrowdStrike users. Upvote scores shown for context.*
+
+### Query variants
+
+```cql
+// Technique: T1036.005 - Masquerading: Match Legitimate Name or Location
+#event_simpleName=ProcessRollup2
+
+// Extract just the filename from the full path
+| ImageFileName=/(?<process_name>[^\\\/]+)$/
+
+// Calculate Levenshtein distance against the legitimate process name
+| text:editDistance(
+    target=process_name,
+    reference="svchost.exe",
+    maxDistance=5,
+    ignoreCase=true,
+    as=name_distance)
+
+// Exclude exact matches — we want near-misses only
+| name_distance > 0
+
+// Keep only close lookalikes (1-2 edits = high confidence masquerading)
+| name_distance <= 2
+
+// Exclude known legitimate Windows binaries that fall within edit distance
+| !in(process_name, values=[
+    "sihost.exe",
+    "conhost.exe",
+    "dllhost.exe",
+    "taskhost.exe",
+    "wshost.exe",
+    "srmhost.exe",
+    "SMSvcHost.exe"
+  ])
+
+// Sort by closest match for triage priority
+| groupBy([process_name, name_distance], function=[count(as=execution_count), collect([ComputerName, ImageFileName, CommandLine, ParentBaseFileName, UserName, SHA256HashData])], limit=10000)
+| sort(name_distance, order=asc)
+```
+— [Community] strawhatintel · comment score 2
+
+```cql
+| groupBy([Observed_Domain,Reference_Domain,lev_dist], function=[selectLast(@timestamp),collect([DomainName,ComputerName,aid])], limit=max)
+```
+— [CS] Dylan-CS · comment score 5
+
+### Q&A
+
+**Q — [Community] Charming_Antelope452:** Is it possible to swap out the domains array (references=\["crowdstrike.com","servicenowservices.com"\]) for references=\[match(domainslist.csv ...)? This would help clean up the rule when looking for many domains, i tried to get it work but it wouldnt produce any results Thanks
+
+**A — [CS] Dylan-CS:** Hi! As of now, there's not a great way to accomplish that. I've passed along your feedback to the team.

--- a/Queries-Only/Cool-Query-Friday/2026-03-02 - Cool Query Friday - Hunting for Typosquatted Domains.md
+++ b/Queries-Only/Cool-Query-Friday/2026-03-02 - Cool Query Friday - Hunting for Typosquatted Domains.md
@@ -1,0 +1,158 @@
+---
+title: "Hunting for Typosquatted Domains"
+date: 2026-03-02
+author: "Dylan-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/1rixd9d/20260302_cool_query_friday_hunting_for/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Hunting for Typosquatted Domains
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/1rixd9d/20260302_cool_query_friday_hunting_for/](https://www.reddit.com/r/crowdstrike/comments/1rixd9d/20260302_cool_query_friday_hunting_for/) — by Dylan-CS (CrowdStrike) — 2026-03-02
+
+Welcome back to another installment of [Cool Query Friday](https://www.reddit.com/r/crowdstrike/?f=flair_name%3A%22CQF%22) (on a Monday). I’ll be your guest host for today’s session. As always, the format will be: (1) description of what we're doing (2) walk through of each step (3) application in the wild.
+
+## Query 1
+```cql
+// Normalize input as a URI so we can reliably work with hostnames
+| parseUri(DomainName, defaultBase="https://")
+
+// Extract the registrable/base domain into base_domain (extend TLD list as needed)
+| DomainName.host=/(?<base_domain>[-a-zA-Z0-9]+\.(?:co\.uk|com\.tr|com|net|org|edu|gov|io|co))$/
+```
+
+## Query 2
+```cql
+// Compare the observed base_domain against the provided reference domain
+| text:editDistance(
+    target=base_domain,
+    reference="crowdstrike.com",
+    maxDistance=10,
+    ignoreCase=true,
+    as=lev_dist)
+```
+
+## Query 3
+```cql
+// Remove exact matches (distance 0 means it is one of our legitimate reference domains)
+| lev_dist != 0
+
+// Keep only near matches for triage (tune as needed)
+| lev_dist <=3
+```
+
+## Query 4
+```cql
+// Get DNS request telemetry from Falcon sensor
+#event_simpleName=DnsRequest
+
+// Normalize input as a URI so we can reliably work with hostnames
+| parseUri(DomainName, defaultBase="https://")
+
+// Extract the registrable/base domain into base_domain (extend TLD list as needed)
+| DomainName.host=/(?<base_domain>[-a-zA-Z0-9]+\.(?:co\.uk|com\.tr|com|net|org|edu|gov|io|co))$/
+
+// Compare the observed base_domain against the provided reference domain
+| text:editDistance(
+    target=base_domain,
+    reference="crowdstrike.com",
+    maxDistance=10,
+    ignoreCase=true,
+    as=lev_dist)
+
+// Remove exact matches (distance 0 means it is one of our legitimate reference domains)
+| lev_dist != 0
+
+// Keep only near matches for triage (tune as needed)
+| lev_dist <=3
+```
+
+## Query 5
+```cql
+// Compare the observed base_domain to multiple reference domains
+| text:editDistanceAsArray(
+    target=base_domain,
+    references=["crowdstrike.com","servicenowservices.com"],
+    maxDistance=10
+)
+```
+
+## Query 6
+```cql
+// Split the _distance[] object array so each reference comparison becomes its own row
+| split(_distance)
+
+// Remove exact matches (distance 0 means it is one of our legitimate reference domains)
+| _distance.distance != 0
+
+// Keep only near matches for triage (tune as needed)
+| _distance.distance <= 3
+```
+
+## Query 7
+```cql
+// Rename fields for clarity in the output
+| Reference_Domain:=_distance.reference
+| Observed_Domain:=base_domain
+| lev_dist:=_distance.distance
+
+// Output results and sort by closest match first
+| groupBy([Observed_Domain,Reference_Domain,lev_dist], function=collect([DomainName,ComputerName,aid]), limit=max)
+| sort(lev_dist, order=asc)
+
+// Intelligence Graph; uncomment out one cloud
+| rootURL := "https://falcon.crowdstrike.com/"
+// | rootURL := "https://falcon.laggar.gcw.crowdstrike.com/"
+// | rootURL := "https://falcon.eu-1.crowdstrike.com/"
+// | rootURL := "https://falcon.us-2.crowdstrike.com/"
+| format("[Link](%sinvestigate/dashboards/domain-search?isLive=false&sharedTime=true&start=7d&domain=*%s)", field=["rootURL", "Observed_Domain"], as="Domain Search")
+
+| drop(rootURL)
+```
+
+## Query 8
+```cql
+// Get DNS request telemetry from Falcon sensor
+#event_simpleName=DnsRequest
+
+// Normalize input as a URI so we can reliably work with hostnames
+| parseUri(DomainName, defaultBase="https://")
+
+// Extract the registrable/base domain into base_domain (extend TLD list as needed)
+| DomainName.host=/(?<base_domain>[-a-zA-Z0-9]+\.(?:co\.uk|com\.tr|com|net|org|edu|gov|io|co))$/
+
+// Compare the observed base_domain to multiple reference domains
+| text:editDistanceAsArray(
+    target=base_domain,
+    references=["crowdstrike.com","servicenowservices.com"],
+    maxDistance=10
+)
+
+// Split the _distance[] object array so each reference comparison becomes its own row
+| split(_distance)
+
+// Remove exact matches (distance 0 means it is one of our legitimate reference domains)
+| _distance.distance != 0
+
+// Keep only near matches for triage (tune as needed)
+| _distance.distance <= 3
+
+// Rename fields for clarity in the output
+| Reference_Domain:=_distance.reference
+| Observed_Domain:=base_domain
+| lev_dist:=_distance.distance
+
+// Output results and sort by closest match first
+| groupBy([Observed_Domain,Reference_Domain,lev_dist], function=collect([DomainName,ComputerName,aid]), limit=max)
+| sort(lev_dist, order=asc)
+
+// Intelligence Graph; uncomment out one cloud
+| rootURL := "https://falcon.crowdstrike.com/"
+// | rootURL := "https://falcon.laggar.gcw.crowdstrike.com/"
+// | rootURL := "https://falcon.eu-1.crowdstrike.com/"
+// | rootURL := "https://falcon.us-2.crowdstrike.com/"
+| format("[Link](%sinvestigate/dashboards/domain-search?isLive=false&sharedTime=true&start=7d&domain=*%s)", field=["rootURL", "Observed_Domain"], as="Domain Search")
+
+| drop(rootURL)
+```

--- a/Queries-Only/Cool-Query-Friday/2026-03-11 - Cool Query Friday - correlate().md
+++ b/Queries-Only/Cool-Query-Friday/2026-03-11 - Cool Query Friday - correlate().md
@@ -1,0 +1,91 @@
+---
+title: "correlate()"
+date: 2026-03-11
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/1rquf4q/20260311_cool_query_friday_correlate/"
+mitre: []
+series: Cool Query Friday
+---
+
+# correlate()
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/1rquf4q/20260311_cool_query_friday_correlate/](https://www.reddit.com/r/crowdstrike/comments/1rquf4q/20260311_cool_query_friday_correlate/) — by Andrew-CS (CrowdStrike) — 2026-03-11
+
+Welcome to our eighty-seventh installment of Cool Query Friday (on a Wednesday). The format will be: (1) description of what we're doing (2) walk through of each step (3) application in the wild.
+
+## Query 1
+```cql
+correlate(
+
+ // First Search
+ name1: {
+ YOUR SEARCH HERE
+ } include: [Fields, To, Pass, To, Next, Search],
+
+ // Second Search
+ name2: {
+ YOUR SEARCH HERE
+ | correlationKey <=> name1.CorrelationKey
+ } include: [Fields, To, Pass, To, Next, Search],
+
+ // Search for systeminfo executions on Windows
+ search3: {
+ YOUR SEARCH HERE
+ | correlationKey <=> name2.CorrelationKey
+ } include: [Fields, To, Pass, To, Next, Search],
+ 
+// Parameters here
+sequence=false, within=5m)
+```
+
+## Query 2
+```cql
+correlate(
+
+ // Search for whoami executions on Windows
+ whoami: {
+ #event_simpleName=ProcessRollup2 event_platform=Win FileName="whoami.exe"
+ } include: [aid, ComputerName, FileName],
+
+ // Search for net executions on Windows
+ net: {
+ #event_simpleName=ProcessRollup2 event_platform=Win FileName=/^net1?.exe$/
+ // Correlation key between whoami search and net search
+ | aid <=> whoami.aid
+ } include: [aid, ComputerName, FileName],
+
+ // Search for systeminfo executions on Windows
+ systeminfo: {
+ #event_simpleName=ProcessRollup2 event_platform=Win FileName="systeminfo.exe"
+// Correlation key between net search and systeminfo search
+ | aid <=> net.aid
+ } include: [aid, ComputerName, FileName],
+
+ sequence=false, within=5m)
+```
+
+## Query 3
+```cql
+[...]
+| table([whoami.ComputerName, whoami.FileName, net.ComputerName, net.FileName, systeminfo.ComputerName, systeminfo.FileName])
+```
+
+## Query 4
+```cql
+correlate(
+    // Have any event from Zscaler
+    zscaler: {
+         #Vendor=zscaler 
+    } include: [@rawstring, user.email, client.ip],
+   // Event from Okta has email that matches email from Zscaler event
+    okta: {
+         #Vendor=okta
+        | user.name<=>zscaler.user.email
+          } include: [@rawstring, user.email, client.ip],
+  // Have Falcon event where external IP of endpoint matches Client IP of Zscaler event
+    falcon: {
+         #Vendor=crowdstrike
+        | aip<=>zscaler.client.ip
+          } include: [@rawstring, ComputerName, aip],
+sequence=false, within=60m)
+```

--- a/Queries-Only/Cool-Query-Friday/2026-03-11 - Cool Query Friday - correlate().md
+++ b/Queries-Only/Cool-Query-Friday/2026-03-11 - Cool Query Friday - correlate().md
@@ -89,3 +89,44 @@ correlate(
           } include: [@rawstring, ComputerName, aip],
 sequence=false, within=60m)
 ```
+
+## Community & Staff Additions
+*Harvested from this post's [r/CrowdStrike](https://www.reddit.com/r/crowdstrike/) comment thread — not part of the original CQF post. **[CS]** = CrowdStrike staff · **[Community]** = other r/CrowdStrike users. Upvote scores shown for context.*
+
+### Query variants
+
+```cql
+correlate(
+    // Search for grandparent process
+    grandparent: {
+         #event_simpleName=ProcessRollup2 event_platform=Win FileName!="explorer.exe" CommandLine=*
+    } include: [cid, aid, TargetProcessId, ParentProcessId, UserName, ComputerName, FileName, CommandLine],
+    // Search for parent process
+    parent: {
+         #event_simpleName=ProcessRollup2 event_platform=Win FileName="cmd.exe" CommandLine=*
+          | aid <=>grandparent.aid
+          | ParentProcessId<=>grandparent.TargetProcessId
+          } include: [cid, aid, TargetProcessId, ParentProcessId, UserName, ComputerName, FileName, CommandLine],
+    // Search for child process
+    child: {
+         #event_simpleName=ProcessRollup2 event_platform=Win FileName="powershell.exe" CommandLine=/\-(e(nc|ncodedcommand|ncoded)?)\s+(?<ecodedBlob>\S+)/iF
+            // Decoding base64
+            | base64Decode("child.ecodedBlob", as=decodedBlob, charset="UTF-16LE")
+          | aid<=>parent.aid
+          | ParentProcessId<=>parent.TargetProcessId
+          } include: [cid, aid, TargetProcessId, ParentProcessId, UserName,ComputerName, FileName, CommandLine, ecodedBlob, decodedBlob],
+sequence=true, within=10m)
+
+//  Create ProcessTree
+| ProcessLineage:=format(format="%s (%s)\n\t└ %s (%s)\n\t\t└ %s (%s)", field=[grandparent.FileName, grandparent.CommandLine, parent.FileName, parent.CommandLine, child.FileName, child.CommandLine])
+
+// Create Link to Process Explorer
+| format("[Graph Explorer](/graphs/process-explorer/tree?id=pid:%s:%s&investigate=true&_cid=%s)", field=["child.aid", "child.TargetProcessId", "child.cid"], as="Graph Explorer")
+```
+— [CS] Andrew-CS · comment score 3
+
+### Q&A
+
+**Q — [Community] yankeesfan01x:** Amazing stuff, as always Andrew and CQF crew. Out of curiosity, are there some chains that you guys have seen recently in the wild that a SOC would want to key in on more than others?
+
+**A — [CS] Andrew-CS:** I like this one that is only Falcon data, but does process chaining... correlate( // Search for grandparent process grandparent: { #event_simpleName=ProcessRollup2 event_platform=Win FileName!="explorer.exe" CommandLine=* } include: [cid, aid, TargetProcessId, ParentProcessId, UserName, ComputerName, FileName, CommandLine], // Search for parent process parent: { #event_simpleName=ProcessRollup2 event_platform=Win FileName="cmd.exe" CommandLine=* | aid <=>grandparent.aid | ParentProcessId<=>grand …

--- a/Queries-Only/Cool-Query-Friday/2026-03-20 - Cool Query Friday - explainasTable().md
+++ b/Queries-Only/Cool-Query-Friday/2026-03-20 - Cool Query Friday - explainasTable().md
@@ -18,3 +18,11 @@ Welcome to our [eighty-eighth](https://www.youtube.com/watch?v=HWoW-vX4HT8) inst
 | CommandLine=/\-(e(nc|ncodedcommand|ncoded)?)\s+/iF
 | groupBy([ComputerName, event_platform], function=([count(CommandLine, distinct=true, as=uniqueCmdLines), count(aid, as=totalExecutions)]), limit=max)
 ```
+
+## Community & Staff Additions
+*Harvested from this post's [r/CrowdStrike](https://www.reddit.com/r/crowdstrike/) comment thread — not part of the original CQF post. **[CS]** = CrowdStrike staff · **[Community]** = other r/CrowdStrike users. Upvote scores shown for context.*
+
+### Operational caveats
+
+> I would say if you're running a job nightly, I might break this into two jobs... (1) Historic: after you've looked for an IOC for 30-days, you only need to search new data for those same IOCs (in your case, the past 24-hours). (2) New: when you get a new IOC, you need to look back once thirty days and then only moving forward. Does that make sense? If the IOCs are atomic (SHA256, IP, Domain) I might leverage the IOC functionality in Falcon so you're alerted in real-time as opposed to searching. Things like Custom IOAs can also be helpful for file names, command line fragments, etc.
+— [CS] Andrew-CS · score 1

--- a/Queries-Only/Cool-Query-Friday/2026-03-20 - Cool Query Friday - explainasTable().md
+++ b/Queries-Only/Cool-Query-Friday/2026-03-20 - Cool Query Friday - explainasTable().md
@@ -1,0 +1,20 @@
+---
+title: "explain:asTable()"
+date: 2026-03-20
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/1ryw8kr/20260320_cool_query_friday_explainastable/"
+mitre: []
+series: Cool Query Friday
+---
+
+# explain:asTable()
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/1ryw8kr/20260320_cool_query_friday_explainastable/](https://www.reddit.com/r/crowdstrike/comments/1ryw8kr/20260320_cool_query_friday_explainastable/) — by Andrew-CS (CrowdStrike) — 2026-03-20
+
+Welcome to our [eighty-eighth](https://www.youtube.com/watch?v=HWoW-vX4HT8) installment of Cool Query Friday. The format will be: (1) description of what we're doing (2) walk through of each step (3) application in the wild.
+
+```cql
+#event_simpleName=ProcessRollup2 
+| CommandLine=/\-(e(nc|ncodedcommand|ncoded)?)\s+/iF
+| groupBy([ComputerName, event_platform], function=([count(CommandLine, distinct=true, as=uniqueCmdLines), count(aid, as=totalExecutions)]), limit=max)
+```

--- a/Queries-Only/Cool-Query-Friday/2026-04-24 - Cool Query Friday - Hunting AI Tools, Models, Services, Agents, and SDKs with Falcon for IT.md
+++ b/Queries-Only/Cool-Query-Friday/2026-04-24 - Cool Query Friday - Hunting AI Tools, Models, Services, Agents, and SDKs with Falcon for IT.md
@@ -1,0 +1,21 @@
+---
+title: "Hunting AI Tools, Models, Services, Agents, and SDKs with Falcon for IT"
+date: 2026-04-24
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/1suff2t/20260424_cool_query_friday_hunting_ai_tools/"
+mitre: []
+series: Cool Query Friday
+---
+
+# Hunting AI Tools, Models, Services, Agents, and SDKs with Falcon for IT
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/1suff2t/20260424_cool_query_friday_hunting_ai_tools/](https://www.reddit.com/r/crowdstrike/comments/1suff2t/20260424_cool_query_friday_hunting_ai_tools/) — by Andrew-CS (CrowdStrike) — 2026-04-24
+
+Welcome to our eighty-ninth installment of Cool Query Friday. The format will be: (1) description of what we're doing (2) walk through of each step (3) application in the wild.
+
+```cql
+| groupBy([aid, _tools_f, _models_f, _mcp_f, _sdks_f, _agents_f, _total], function=[], limit=max)
+| match(file="aid_master_main.csv", field=[aid], column=aid)
+| formatTime(format="%F %T %Z", as="FirstSeen", field=FirstSeen)
+| formatTime(format="%F %T %Z", as="LastSeen", field=LastSeen)
+```

--- a/Queries-Only/Cool-Query-Friday/2026-04-24 - Cool Query Friday - Hunting AI Tools, Models, Services, Agents, and SDKs with Falcon for IT.md
+++ b/Queries-Only/Cool-Query-Friday/2026-04-24 - Cool Query Friday - Hunting AI Tools, Models, Services, Agents, and SDKs with Falcon for IT.md
@@ -19,3 +19,32 @@ Welcome to our eighty-ninth installment of Cool Query Friday. The format will be
 | formatTime(format="%F %T %Z", as="FirstSeen", field=FirstSeen)
 | formatTime(format="%F %T %Z", as="LastSeen", field=LastSeen)
 ```
+
+## Community & Staff Additions
+*Harvested from this post's [r/CrowdStrike](https://www.reddit.com/r/crowdstrike/) comment thread — not part of the original CQF post. **[CS]** = CrowdStrike staff · **[Community]** = other r/CrowdStrike users. Upvote scores shown for context.*
+
+### Query variants
+
+```cql
+| groupBy([aid, _tools_f, _models_f, _mcp_f, _sdks_f, _agents_f, _total], function=[], limit=max)
+| match(file="aid_master_main.csv", field=[aid], column=aid)
+| match(file="aid_master_details.csv", field=[aid], column=[aid], include=[SensorGroupingTags, FalconGroupingTags])
+| formatTime(format="%F %T %Z", as="FirstSeen", field=FirstSeen)
+| formatTime(format="%F %T %Z", as="LastSeen", field=LastSeen)
+```
+— [CS] Andrew-CS · comment score 1
+
+### Operational caveats
+
+> Hi there. I mean, Falcon for IT is executing the scripts using RTR... but if you initiate the scripts on your own the script output wouldn't be sent anywhere. A lot of the magic is the redirection of STDOUT back to Falcon and then putting it in a curated format. So... yes, could definitely be done... but would require a lot more elbow grease.
+— [CS] Andrew-CS · score 1
+
+### Q&A
+
+**Q — [Community] OddFly6060:** | groupBy([aid, _tools_f, _models_f, _mcp_f, _sdks_f, _agents_f, _total], function=[], limit=max) | match(file="aid_master_main.csv", field=[aid], column=aid) | formatTime(format="%F %T %Z", as="FirstSeen", field=FirstSeen) | formatTime(format="%F %T %Z", as="LastSeen", field=LastSeen) How could I a …
+
+**A — [CS] Andrew-CS:** Hi there. You would need just one more line... | groupBy([aid, _tools_f, _models_f, _mcp_f, _sdks_f, _agents_f, _total], function=[], limit=max) | match(file="aid_master_main.csv", field=[aid], column=aid) | match(file="aid_master_details.csv", field=[aid], column=[aid], include=[SensorGroupingTags, FalconGroupingTags]) | formatTime(format="%F %T %Z", as="FirstSeen", field=FirstSeen) | formatTime(format="%F %T %Z", as="LastSeen", field=LastSeen)
+
+**Q — [Community] Gullible-PvM:** Is there a way to leverage these scripts through RTR/Fusion to do ad-hoc collections?
+
+**A — [CS] Andrew-CS:** Hi there. I mean, Falcon for IT is executing the scripts using RTR... but if you initiate the scripts on your own the script output wouldn't be sent anywhere. A lot of the magic is the redirection of STDOUT back to Falcon and then putting it in a curated format. So... yes, could definitely be done... but would require a lot more elbow grease.

--- a/Queries-Only/Cool-Query-Friday/2026-05-01 - Cool Query Friday - setTimeInterval().md
+++ b/Queries-Only/Cool-Query-Friday/2026-05-01 - Cool Query Friday - setTimeInterval().md
@@ -1,0 +1,45 @@
+---
+title: "setTimeInterval()"
+date: 2026-05-01
+author: "Andrew-CS"
+source_url: "https://www.reddit.com/r/crowdstrike/comments/1t0zcsz/20260501_cool_query_friday_settimeinterval/"
+mitre: []
+series: Cool Query Friday
+---
+
+# setTimeInterval()
+
+> Source: [https://www.reddit.com/r/crowdstrike/comments/1t0zcsz/20260501_cool_query_friday_settimeinterval/](https://www.reddit.com/r/crowdstrike/comments/1t0zcsz/20260501_cool_query_friday_settimeinterval/) — by Andrew-CS (CrowdStrike) — 2026-05-01
+
+Welcome to our ninetieth installment of Cool Query Friday. The format will be: (1) description of what we're doing (2) walk through of each step (3) application in the wild.
+
+## Query 1
+```cql
+setTimeInterval(start="7d")
+| my-search-here
+```
+
+## Query 2
+```cql
+setTimeInterval(start="7d@d", end="1d@d", timezone="EST")
+| my-search-here
+```
+
+## Query 3
+```cql
+setTimeInterval(start=1746054000000, end=1746780124517)
+| my-search-here
+```
+
+## Query 4
+```cql
+setTimeInterval(start="1h")
+| defineTable(
+  start=24h,
+  end=1h,
+  query={event_platform=Win #event_simpleName=DnsRequest ContextBaseFileName="powershell.exe"},
+  include=[DomainName, ContextBaseFileName],
+  name="ps_dns")
+| event_platform=Win #event_simpleName=DnsRequest ContextBaseFileName="powershell.exe"
+| !match(table="ps_dns", field=DomainName, strict=true)
+```

--- a/Queries-Only/Cool-Query-Friday/2026-05-01 - Cool Query Friday - setTimeInterval().md
+++ b/Queries-Only/Cool-Query-Friday/2026-05-01 - Cool Query Friday - setTimeInterval().md
@@ -43,3 +43,12 @@ setTimeInterval(start="1h")
 | event_platform=Win #event_simpleName=DnsRequest ContextBaseFileName="powershell.exe"
 | !match(table="ps_dns", field=DomainName, strict=true)
 ```
+
+## Community & Staff Additions
+*Harvested from this post's [r/CrowdStrike](https://www.reddit.com/r/crowdstrike/) comment thread — not part of the original CQF post. **[CS]** = CrowdStrike staff · **[Community]** = other r/CrowdStrike users. Upvote scores shown for context.*
+
+### Q&A
+
+**Q — [Community] dial647:** I have a question. I am trying to run a query for a 7 day period, and want the results when I have more than x number of events within a 10 mins time frame. Is it possible to achieve this using this statement?
+
+**A — [CS] Andrew-CS:** Hi there. You’d want to use slidingTimeWindow(). We have a writeup on that [here](https://www.reddit.com/r/crowdstrike/s/KcZ1lzf6L4).

--- a/Queries-Only/Cool-Query-Friday/Cool-Query-Friday-Index.md
+++ b/Queries-Only/Cool-Query-Friday/Cool-Query-Friday-Index.md
@@ -1,0 +1,100 @@
+# Cool Query Friday — Archive Index
+
+94 editions in this directory. Each links to its file (and original post when known).
+
+| Date | Title | Author |
+|------|-------|--------|
+| 2020-03-19 | [Historic MITRE ATT&CK Footprint Data](https://www.reddit.com/r/crowdstrike/comments/m8gpto/20200319_cool_query_friday_historic_mitre_attck/) | Andrew-CS |
+| 2020-04-30 | [System Resources](https://www.reddit.com/r/crowdstrike/comments/n1tbwn/20200430_cqf_system_resources/) | Andrew-CS |
+| 2021-03-05 | [Hunting For Renamed Command Line Programs](https://www.reddit.com/r/crowdstrike/comments/lyhga8/20210305_cool_query_friday_hunting_for_renamed/) | Andrew-CS |
+| 2021-03-12 | [Parsing and Hunting Failed User Logons in Windows](https://www.reddit.com/r/crowdstrike/comments/m3i45l/20210312_cool_query_friday_parsing_and_hunting/) | Andrew-CS |
+| 2021-03-26 | [Hunting Process Integrity Levels in Windows](https://www.reddit.com/r/crowdstrike/comments/mdo3dx/20210326_cool_query_friday_hunting_process/) | Andrew-CS |
+| 2021-04-02 | [Hunting macOS Kernel Extensions](https://www.reddit.com/r/crowdstrike/comments/mijvb0/20210402_cool_query_friday_hunting_macos_kernel/) | Andrew-CS |
+| 2021-04-08 | [Windows Dump Files](https://www.reddit.com/r/crowdstrike/comments/mngo2l/20210408_cool_query_friday_windows_dump_files/) | Andrew-CS |
+| 2021-04-16 | [Windows RDP User Login Events, Kilometers, and MACH 1](https://www.reddit.com/r/crowdstrike/comments/ms2mlz/20210416_cool_query_friday_windows_rdp_user_login/) | Andrew-CS |
+| 2021-04-23 | [Parsing the Call Stack](https://www.reddit.com/r/crowdstrike/comments/mwuz92/20210423_cool_query_friday_parsing_the_call_stack/) | Andrew-CS |
+| 2021-05-07 | [If You're Listening](https://www.reddit.com/r/crowdstrike/comments/n6xwv6/20210507_cool_query_friday_if_youre_listening/) | Andrew-CS |
+| 2021-05-14 | [Password Age and Reused Local Passwords](https://www.reddit.com/r/crowdstrike/comments/ncb5z7/20210514_cool_query_friday_password_age_and/) | Andrew-CS |
+| 2021-05-21 | [Internal Network Connections and Firewall Rules](https://www.reddit.com/r/crowdstrike/comments/nhs906/20210521_cool_query_friday_internal_network/) | Andrew-CS |
+| 2021-06-04 | [Stats](https://www.reddit.com/r/crowdstrike/comments/ns4k9q/20210604_cool_query_friday_stats/) | Andrew-CS |
+| 2021-06-11 | [Hunting Rogue DNS Servers](https://www.reddit.com/r/crowdstrike/comments/nxfcnu/20210611_cool_query_friday_hunting_rogue_dns/) | Andrew-CS |
+| 2021-06-18 | [User Added To Group](https://www.reddit.com/r/crowdstrike/comments/o2onsf/20210618_cool_query_friday_user_added_to_group/) | Andrew-CS |
+| 2021-06-25 | [Queries, Custom IOAs, and You: A Love Story](https://www.reddit.com/r/crowdstrike/comments/o7nvts/20210625_cool_query_friday_queries_custom_ioas/) | Andrew-CS |
+| 2021-07-01 | [PrintNightmare POC Hunting (CVE-2021-1675)](https://www.reddit.com/r/crowdstrike/comments/oblzcl/20210701_cool_query_friday_printnightmare_poc/) | Andrew-CS |
+| 2021-07-16 | [CLI Programs Running via Hidden Window](https://www.reddit.com/r/crowdstrike/comments/olhnwf/20210716_cool_query_friday_cli_programs_running/) | Andrew-CS |
+| 2021-07-21 | [Finding and Mitigating CVE-2021-36934 (HiveNightmare/SeriousSAM)](https://www.reddit.com/r/crowdstrike/comments/ooo6kk/20210721_cool_query_friday_finding_and_mitigating/) | Andrew-CS |
+| 2021-07-30 | [Command Line Scoring and Parsing](https://www.reddit.com/r/crowdstrike/comments/ouk533/20210730_cool_query_friday_command_line_scoring/) | Andrew-CS |
+| 2021-08-06 | [Scoping Discovery Via the net Command and Custom IOAs (T1087.001)](https://www.reddit.com/r/crowdstrike/comments/oz7uvn/20210806_cool_query_friday_scoping_discovery_via/) | Andrew-CS |
+| 2021-08-13 | [Matching Detections to Assigned Analysts in Event Search](https://www.reddit.com/r/crowdstrike/comments/p3mt5g/20210813_cool_query_friday_matching_detections_to/) | Andrew-CS |
+| 2021-08-20 | [Falcon Fusion Friday](https://www.reddit.com/r/crowdstrike/comments/p8d0rl/20210820_cool_query_friday_falcon_fusion_friday/) | Andrew-CS |
+| 2021-09-10 | [The Cheat Sheet](https://www.reddit.com/r/crowdstrike/comments/plkwqu/20210910_cool_query_friday_the_cheat_sheet/) | Andrew-CS |
+| 2021-09-17 | [Regular Expressions](https://www.reddit.com/r/crowdstrike/comments/ppzp59/20210917_cool_query_friday_regular_expressions/) | Andrew-CS |
+| 2021-09-24 | [Coalesce](https://www.reddit.com/r/crowdstrike/comments/puj8w6/20210924_cool_query_friday_coalesce/) | Andrew-CS |
+| 2021-10-01 | [FileVault Status in macOS](https://www.reddit.com/r/crowdstrike/comments/pz7i14/20211001_cool_query_friday_filevault_status_in/) | Andrew-CS |
+| 2021-10-05 | [Mining EndOfProcess and Profiling Programs](https://www.reddit.com/r/crowdstrike/comments/qna2ao/20211005_cool_query_friday_mining_endofprocess/) | Andrew-CS |
+| 2021-10-08 | [Parsing Linux Kernel Version](https://www.reddit.com/r/crowdstrike/comments/q3xscp/20211008_cool_query_friday_parsing_linux_kernel/) | Andrew-CS |
+| 2021-10-15 | [Mining Windows CommandHistory for Artifacts](https://www.reddit.com/r/crowdstrike/comments/q8qzmp/20211015_cool_query_friday_mining_windows/) | Andrew-CS |
+| 2021-10-22 | [Scheduled Searches, Failed User Logons, and Thresholds](https://www.reddit.com/r/crowdstrike/comments/qdebwx/20211022_cool_query_friday_scheduled_searches/) | Andrew-CS |
+| 2021-10-29 | [2021-10-29 - Cool Query Friday - CPU, RAM, Disk, Firmware, TPM 2.0, and Windows 11](https://www.reddit.com/r/crowdstrike/comments/qid1tj/20211029_cool_query_friday_cpu_ram_disk_firmware/) |  |
+| 2021-11-12 | [Tagging and Tracking Lost Endpoints](https://www.reddit.com/r/crowdstrike/comments/qsbtnp/20211112_cool_query_friday_tagging_and_tracking/) | Andrew-CS |
+| 2021-12-03 | [Auditing SSH Connections in Linux](https://www.reddit.com/r/crowdstrike/comments/r80usb/20211203_cool_query_friday_auditing_ssh/) | Andrew-CS |
+| 2021-12-10 | [Hunting Apache Log4j CVE-2021-44228 (Log4Shell)](https://www.reddit.com/r/crowdstrike/comments/rda0ls/20211210_cool_query_friday_hunting_apache_log4j/) | Andrew-CS |
+| 2021-12-22 | [(ish) - Continuing to Obsess Over Log4Shell](https://www.reddit.com/r/crowdstrike/comments/rmgjli/20211222_cool_query_fridayish_continuing_to/) | Andrew-CS |
+| 2022-01-07 | [Adding Process Explorer and RTR Links to Scheduled Queries](https://www.reddit.com/r/crowdstrike/comments/ry6ma0/20220107_cool_query_friday_adding_process/) | Andrew-CS |
+| 2022-01-26 | [Hunting pwnkit Local Privilege Escalation in Linux (CVE-2021-4034)](https://www.reddit.com/r/crowdstrike/comments/sdfeig/20220126_cool_query_friday_hunting_pwnkit_local/) | Andrew-CS |
+| 2022-02-11 | [Time To Assign, Time To Resolve, and Time To Close](https://www.reddit.com/r/crowdstrike/comments/spx5zu/20220211_cool_query_friday_time_to_assign_time_to/) | Andrew-CS |
+| 2022-02-18 | [New Office File Written Events](https://www.reddit.com/r/crowdstrike/comments/svf8y7/20220218_cool_query_friday_new_office_file/) | Andrew-CS |
+| 2022-02-25 | [Situational Awareness \\\\ DriveSlayer Wiper](https://www.reddit.com/r/crowdstrike/comments/t0vhe6/20220225_cool_query_friday_situational_awareness/) | Andrew-CS |
+| 2022-03-06 | [SITUATIONAL AWARENESS \\\\ Hunting for NVIDIA Certificates](https://www.reddit.com/r/crowdstrike/comments/t81heu/20220306_cool_query_friday_situational_awareness/) | Andrew-CS |
+| 2022-03-18 | [Revisiting User Added To Group Events](https://www.reddit.com/r/crowdstrike/comments/th06gy/20220318_cool_query_friday_revisiting_user_added/) | Andrew-CS |
+| 2022-04-08 | [Scoring User Logon Events in Windows](https://www.reddit.com/r/crowdstrike/comments/tz5obg/20220408_cool_query_friday_scoring_user_logon/) | Andrew-CS |
+| 2022-04-15 | [Hunting Tarrask and HAFNIUM](https://www.reddit.com/r/crowdstrike/comments/u49jxq/20220415_cool_query_friday_hunting_tarrask_and/) | Andrew-CS |
+| 2022-04-22 | [macOS, HostInfo, and System Preferences](https://www.reddit.com/r/crowdstrike/comments/u9f2z6/20220422_cool_query_friday_macos_hostinfo_and/) | Andrew-CS |
+| 2022-05-20 | [Hunting macOS Application Bundles](https://www.reddit.com/r/crowdstrike/comments/utycmg/20220520_cool_query_friday_hunting_macos/) | Andrew-CS |
+| 2022-07-15 | [Hunting ISO Mounts with New Telemetry](https://www.reddit.com/r/crowdstrike/comments/vzosj9/20220715_cool_query_friday_hunting_iso_mounts/) | Andrew-CS |
+| 2022-08-15 | [Hunting Cluster Events by Process Lineage](https://www.reddit.com/r/crowdstrike/comments/woz73a/20220815_cool_query_friday_hunting_cluster_events/) | Andrew-CS |
+| 2022-08-20 | [Linux UserLogon and FailedUserLogon Event Updates](https://www.reddit.com/r/crowdstrike/comments/wta83n/20220820_cool_query_friday_linux_userlogon_and/) | Andrew-CS |
+| 2022-09-07 | [Fields of Dreams Project](https://www.reddit.com/r/crowdstrike/comments/x85ufw/20220907_cool_query_friday_fields_of_dreams/) | Andrew-CS |
+| 2022-09-16 | [Microsoft Teams Credentials in the Clear](https://www.reddit.com/r/crowdstrike/comments/xfqtyb/20220916_cool_query_friday_microsoft_teams/) | Andrew-CS |
+| 2022-09-23 | [LogScale += Humio - Decoding PowerShell Base64 and Entropy](https://www.reddit.com/r/crowdstrike/comments/xm7lsn/20220923_cool_query_friday_logscale_humio/) | Andrew-CS |
+| 2022-10-14 | [Dealing with Security Articles](https://www.reddit.com/r/crowdstrike/comments/y3w8bt/20221014_cool_query_friday_dealing_with_security/) | Andrew-CS |
+| 2022-11-03 | [PSFalcon, Bulk RTR Queuing, and STDOUT Redirection to LogScale](https://www.reddit.com/r/crowdstrike/comments/yl8hv8/20221103_cool_query_friday_psfalcon_bulk_rtr/) | Andrew-CS |
+| 2022-12-09 | [Custom Weighting and Time-Bounding Events](https://www.reddit.com/r/crowdstrike/comments/zh7k5a/20221209_cool_query_friday_custom_weighting_and/) | Andrew-CS |
+| 2023-01-06 | [Hunting PE Language ID Prevalence in PeVersionInfo](https://www.reddit.com/r/crowdstrike/comments/104y1wr/20230106_cool_query_friday_hunting_pe_language_id/) | Andrew-CS |
+| 2023-03-23 | [LogScale: The Basics Part I](https://www.reddit.com/r/crowdstrike/comments/11zojds/20230323_cool_query_friday_logscale_the_basics/) | Andrew-CS |
+| 2023-04-07 | [Windows T1087.001 - When You're Bored, Go Overboard](https://www.reddit.com/r/crowdstrike/comments/12enf8y/20230407_cool_query_friday_windows_t1087001_when/) | Andrew-CS |
+| 2023-06-08 | [[T1562.009] Defense Evasion - Impair Defenses - Windows Safe Mode](https://www.reddit.com/r/crowdstrike/comments/144f19i/20230608_cool_query_friday_t1562009_defense/) | Andrew-CS |
+| 2023-06-14 | [2023-06-14 - Cool Query Friday - Watching the Watchers - Profiling Falcon Console Logins via Geohashing](https://www.reddit.com/r/crowdstrike/comments/149krol/20230614_cool_query_friday_watching_the_watchers/)) |  |
+| 2023-07-27 | [Adding Falcon Intelligence Data to LogScale and LTR Query Output](https://www.reddit.com/r/crowdstrike/comments/15b3nyu/20230727_cool_query_friday_adding_falcon/) | Andrew-CS |
+| 2023-08-04 | [Creating Your Own, Bespoke Hunting Repo with Falcon LTR](https://www.reddit.com/r/crowdstrike/comments/15i3i80/20230804_cool_query_friday_creating_your_own/) | Andrew-CS |
+| 2023-08-11 | [[T1036.005] Inventorying LOLBINs and Hunting for System Folder Binary Masquerading](https://www.reddit.com/r/crowdstrike/comments/15oa5io/20230811_cool_query_friday_t1036005_inventorying/) | Andrew-CS |
+| 2023-09-08 | 2023-09-08 - Cool Query Friday - Reflective .Net Module Loads and Program Database (PDB) File Paths |  |
+| 2023-09-20 | 2023-09-20 - Cool Query Friday - Up-leveling Teams With Text-box Driven Queries |  |
+| 2023-09-20 | [Live from Fal.Con - Up-leveling Teams With Multipurpose, Text-box Driven Queries](https://www.reddit.com/r/crowdstrike/comments/16soii4/20230920_cool_query_friday_live_from_falcon/) | Andrew-CS |
+| 2023-10-20 | [ATT&CK Edition: T1087.003](https://www.reddit.com/r/crowdstrike/comments/17c9nel/20231020_cool_query_friday_attck_edition_t1087003/) | Andrew-CS |
+| 2023-11-10 | [ATT&CK Edition: T1087.004](https://www.reddit.com/r/crowdstrike/comments/17s63ri/20231110_cool_query_friday_attck_edition_t1087004/) | Andrew-CS |
+| 2023-11-17 | [ATT&CK Edition: T1010](https://www.reddit.com/r/crowdstrike/comments/17xa6vm/20231117_cool_query_friday_attck_edition_t1010/) | Andrew-CS |
+| 2023-12-01 | [ATT&CK Edition: T1217](https://www.reddit.com/r/crowdstrike/comments/188e5ci/20231201_cool_query_friday_attck_edition_t1217/) | Andrew-CS |
+| 2023-12-08 | [ATT&CK Edition: T1580](https://www.reddit.com/r/crowdstrike/comments/18dnavb/20231208_cool_query_friday_attck_edition_t1580/) | Andrew-CS |
+| 2023-12-22 | [New Feature in Raptor: Falcon Helper](https://www.reddit.com/r/crowdstrike/comments/18off35/20231222_cool_query_friday_new_feature_in_raptor/) | Andrew-CS |
+| 2024-01-19 | [Raptor + AID Master](https://www.reddit.com/r/crowdstrike/comments/19akavg/20240119_cool_query_friday_raptor_aid_master/) | Andrew-CS |
+| 2024-02-02 | [Size and case Statements](https://www.reddit.com/r/crowdstrike/comments/1ah8sn1/20240202_cool_query_friday_size_and_case/) | Andrew-CS |
+| 2024-03-01 | 2024-03-01 CQF Live Supporting Queries |  |
+| 2024-05-30 | [Auto-Enriching Alerts with Bespoke Raptor Queries and Fusion SOAR Workflows](https://www.reddit.com/r/crowdstrike/comments/1d46szz/20240530_cool_query_friday_autoenriching_alerts/) | Andrew-CS |
+| 2024-06-03 | [(mini) - The Triumphant Return of aid_master as a File](https://www.reddit.com/r/crowdstrike/comments/1d76iro/20240603_cool_query_friday_mini_the_triumphant/) | Andrew-CS |
+| 2024-06-07 | [Custom Lookup Files in Raptor](https://www.reddit.com/r/crowdstrike/comments/1dal47a/20240607_cool_query_friday_custom_lookup_files_in/) | Andrew-CS |
+| 2024-06-21 | [Browser Extension Collection on Windows and macOS](https://www.reddit.com/r/crowdstrike/comments/1dl3bo5/20240621_cool_query_friday_browser_extension/) | Andrew-CS |
+| 2024-08-23 | [Hunting CommandHistory in Windows](https://www.reddit.com/r/crowdstrike/comments/1ezcbjx/20240823_cool_query_friday_hunting_commandhistory/) | Andrew-CS |
+| 2024-09-27 | [Hunting Newly Seen DNS Resolutions in PowerShell](https://www.reddit.com/r/crowdstrike/comments/1fqokic/20240927_cool_query_friday_hunting_newly_seen_dns/) | Andrew-CS |
+| 2024-10-11 | [New Regex Engine Edition](https://www.reddit.com/r/crowdstrike/comments/1g1hw21/20241011_cool_query_friday_new_regex_engine/) | Andrew-CS |
+| 2024-10-18 | [Hunting Windows RMM Tools](https://www.reddit.com/r/crowdstrike/comments/1g6iupi/20241018_cool_query_friday_hunting_windows_rmm/) | Andrew-CS |
+| 2024-10-24 | [Part II: Hunting Windows RMM Tools, Custom IOAs, and SOAR Response](https://www.reddit.com/r/crowdstrike/comments/1gb30r9/20241024_cool_query_friday_part_ii_hunting/) | Andrew-CS |
+| 2025-02-21 | [Impossible Time To Travel and the Speed of Sound](https://www.reddit.com/r/crowdstrike/comments/1iuwne9/20250221_cool_query_friday_impossible_time_to/) | Andrew-CS |
+| 2025-02-28 | [Electric Slide… ‘ing Time Windows](https://www.reddit.com/r/crowdstrike/comments/1izst3r/20250228_cool_query_friday_electric_slide_ing/) | Andrew-CS |
+| 2025-04-14 | [Hunting Fake CAPTCHA Artifacts in Windows](https://www.reddit.com/r/crowdstrike/comments/1jz02j3/20250414_cool_query_friday_hunting_fake_captcha/) | Andrew-CS |
+| 2025-04-18 | [Agentic Charlotte Workflows, Baby Queries, and Prompt Engineering](https://www.reddit.com/r/crowdstrike/comments/1k26eov/20250418_cool_query_friday_agentic_charlotte/) | Andrew-CS |
+| 2026-03-02 | [Hunting for Typosquatted Domains](https://www.reddit.com/r/crowdstrike/comments/1rixd9d/20260302_cool_query_friday_hunting_for/) | Dylan-CS |
+| 2026-03-11 | [correlate()](https://www.reddit.com/r/crowdstrike/comments/1rquf4q/20260311_cool_query_friday_correlate/) | Andrew-CS |
+| 2026-03-20 | [explain:asTable()](https://www.reddit.com/r/crowdstrike/comments/1ryw8kr/20260320_cool_query_friday_explainastable/) | Andrew-CS |
+| 2026-04-24 | [Hunting AI Tools, Models, Services, Agents, and SDKs with Falcon for IT](https://www.reddit.com/r/crowdstrike/comments/1suff2t/20260424_cool_query_friday_hunting_ai_tools/) | Andrew-CS |
+| 2026-05-01 | [setTimeInterval()](https://www.reddit.com/r/crowdstrike/comments/1t0zcsz/20260501_cool_query_friday_settimeinterval/) | Andrew-CS |


### PR DESCRIPTION
The `Queries-Only/Cool-Query-Friday/` directory currently holds a handful of the series' editions. This PR backfills it with **89 additional Cool Query Friday editions** authored by CrowdStrike staff on r/CrowdStrike (Andrew-CS, Dylan-CS), spanning **2021-03 to 2026-05** — close to the full run of the series (recent editions reference the ~90th installment).

Each edition is a markdown file following the existing `YYYY-MM-DD - Cool Query Friday - <Title>.md` naming, with:
- a link back to the original Reddit post,
- author attribution + date (YAML frontmatter),
- the narrative intro, and
- the CQL in fenced code blocks (the author's inline comments preserved).

Also adds `Cool-Query-Friday-Index.md` — a table of the editions with post links.

**Scope / safety:**
- Existing files were left untouched (matched by original post URL or filename; 3 skipped).
- Content is public r/CrowdStrike Cool Query Friday material by CrowdStrike staff, attributed per file.
- Editions older than ~2021-03 are not included — Reddit's search/feed horizon does not surface them via the API.

**Notes for maintainers:**
- CQF posts build queries incrementally, so some files contain multiple staged query blocks (Query 1, 2, …) mirroring the walkthrough.
- Happy to adjust format, split, slugify filenames, or trim per your conventions.
